### PR TITLE
meta-dream: dreambox-boot-progress: set proper S value

### DIFF
--- a/meta-dream/recipes-bsp/drivers/dreambox-boot-progress.bb
+++ b/meta-dream/recipes-bsp/drivers/dreambox-boot-progress.bb
@@ -8,6 +8,7 @@ PR = "r0"
 require conf/license/openpli-gplv2.inc
 
 SRC_URI = "file://progress"
+S = "${WORKDIR}"
 
 do_install () {
 #


### PR DESCRIPTION
Fixes bitbake warning: ('S') don't exist, you must set 'S' to a proper value