### PR TITLE
Disable certificate verification by default in python 2.7.9

### DIFF
--- a/meta-openpli/recipes-devtools/python/python/disable-certificate-verification.patch
+++ b/meta-openpli/recipes-devtools/python/python/disable-certificate-verification.patch
@@ -1,0 +1,11 @@
+--- a/Lib/httplib.py	2014-12-10 17:59:36.000000000 +0200
++++ b/Lib/httplib.py	2015-05-04 16:58:48.259621676 +0300
+@@ -1193,7 +1193,7 @@
+             self.key_file = key_file
+             self.cert_file = cert_file
+             if context is None:
+-                context = ssl._create_default_https_context()
++                context = ssl._create_unverified_context()
+             if key_file or cert_file:
+                 context.load_cert_chain(cert_file, key_file)
+             self._context = context

--- a/meta-openpli/recipes-devtools/python/python_2.7.9.bbappend
+++ b/meta-openpli/recipes-devtools/python/python_2.7.9.bbappend
@@ -7,6 +7,7 @@ SRC_URI += " \
 			file://ctypes-error-handling-fix.patch \
 			file://setuptweaks-2.patch \
 			file://pgettext.patch \
+			file://disable-certificate-verification.patch \
 "
 
 EXTRA_OECONF += " \


### PR DESCRIPTION
Sertificate verification by default enbled in python 2.7.9 in PEP 0476, but it breaks many things where used urllib2. Therefore disable it. But this still allows the use of certificate verification using the context if necessary.