### PR TITLE
Remove dreamcrc library hack in plugin xmltvimport

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-xmltvimport.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-xmltvimport.bb
@@ -35,7 +35,6 @@ DISTUTILS_INSTALL_ARGS = "\
     "
 
 do_install_append() {
-	mv ${D}${libdir}/enigma2/python/Plugins/Extensions/*.so ${D}/usr/lib/enigma2/python/Plugins/Extensions/${PLUGIN}
 	rm ${D}${libdir}/enigma2/python/Plugins/Extensions/*.egg-info
 	# Remove files we don't want to deploy
 	rm -r ${D}${libdir}/${PYTHON_DIR}


### PR DESCRIPTION
It must be fixed in https://github.com/OpenPLi/enigma2-plugin-extensions-xmltvimport/pull/7
After add this, please do not forget update the plugin version sha to actual.

The next my step will be to simplify bitbake file using distutils-openplugins and remove all hacks. But I will wait what do you say about this commit.