### PR TITLE
Remove tabs in openwebif.bbappend to disable warning on building

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-openwebif.bbappend
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-openwebif.bbappend
@@ -25,11 +25,11 @@ python do_package_prepend () {
         ('vuultimo', 'ultimo.jpg', 'vu_ultimo.png'),
         ('vuuno', 'uno.jpg', 'vu_normal.png'),
         ('vuzero', 'zero.jpg', 'vu_normal.png'),
-	('hd1100', 'hd1100.jpg', 'hd1x00.png'),
-	('hd1200', 'hd1200.jpg', 'hd1x00.png'),
-	('hd2400', 'hd2400.jpg', 'hd2400.png'),
-	('fusionhd', 'fusionhd.jpg', 'fusionhd.png'),
-	('fusionhdse', 'fusionhdse.jpg', 'fusionhdse.png'),
+        ('hd1100', 'hd1100.jpg', 'hd1x00.png'),
+        ('hd1200', 'hd1200.jpg', 'hd1x00.png'),
+        ('hd2400', 'hd2400.jpg', 'hd2400.png'),
+        ('fusionhd', 'fusionhd.jpg', 'fusionhd.png'),
+        ('fusionhdse', 'fusionhdse.jpg', 'fusionhdse.png'),
     ]
     import os
     top = '${D}${PLUGINPATH}/public/images/'


### PR DESCRIPTION
With tabs I have warning:
WARNING: Variable do_package contains tabs, please remove these (/meta-openpli/recipes-openpli/e2openplugins/enigma2-plugin-extensions-openwebif.bb)