### PR TITLE
Remove timezone.xml from tuxbox-common

### DIFF
--- a/meta-openpli/recipes-multimedia/tuxbox/tuxbox-common.bb
+++ b/meta-openpli/recipes-multimedia/tuxbox/tuxbox-common.bb
@@ -22,9 +22,6 @@ do_compile() {
 do_install() {
 	install -d ${D}${sysconfdir}/tuxbox/
 	install -m 0644 ${S}/share/tuxbox/scart.conf ${D}${sysconfdir}/tuxbox/scart.conf
-	install -m 0644 ${S}/etc/timezone.xml ${D}${sysconfdir}/tuxbox/timezone.xml
-
-	ln -sf tuxbox/timezone.xml ${D}${sysconfdir}/timezone.xml
 
 	for i in ${TRANSPONDER_LISTS}; do
 		install -m 0644 ${S}/share/tuxbox/$i ${D}${sysconfdir}/tuxbox/$i


### PR DESCRIPTION
Enigma use own timezone.xml in /usr/share/enigma2.
Why there a need for different in /etc?
It only leads unnecessary confusion.