### PR TITLE
Remove sh from busybox.links.nosuid

### DIFF
--- a/meta-openpli/recipes-core/busybox/busybox_1.24.%.bbappend
+++ b/meta-openpli/recipes-core/busybox/busybox_1.24.%.bbappend
@@ -45,6 +45,7 @@ do_install_append() {
 	fi
 	install -d ${D}${sysconfdir}/mdev
 	install -m 0755 ${WORKDIR}/mdev-mount.sh ${D}${sysconfdir}/mdev
+	sed -i "/[/][s][h]*$/d" ${D}${sysconfdir}/busybox.links.nosuid
 }
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"


### PR DESCRIPTION
This fix busybox package update.
It looks like the trick with sh copying in tmp does not work.
update-alternatives is bash script that link to /bin/sh, and after update-alternatives remove /bin/sh, it stops working.
Link to /bin/sh already exists in the package, there is no need to create it, if remove it from the busybox.links.nosuid, it is not used in update-alternatives and not removed when run update-alternatives --remove.