### PR TITLE
samba4: on install add directory /run/samba to fix building

### DIFF
--- a/meta-openpli/recipes-connectivity/samba/samba_4.%.bbappend
+++ b/meta-openpli/recipes-connectivity/samba/samba_4.%.bbappend
@@ -33,6 +33,10 @@ SRC_URI += " \
 
 FILES_${PN} += "${sysconfdir}/init.d/samba.sh"
 
+do_install_prepend() {
+	install -d ${D}/run/samba
+}
+
 do_install_append() {
 	rm -fR ${D}/var
 	rm -fR ${D}/run


### PR DESCRIPTION
To fix startup I move sockets-dir from /run/samba to /run.
Perhaps therefore do_install now wants to remove the directory /run/samba which no longer exists.
I added an empty directory to avoid error.
Perhaps reason is a another changes on openembedded, but in any case this fix samba building.