### PR TITLE
enigma2-plugins: remove gstreamer support

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugins.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugins.bb
@@ -36,7 +36,6 @@ EXTRA_OECONF = " \
 	STAGING_INCDIR=${STAGING_INCDIR} \
 	STAGING_LIBDIR=${STAGING_LIBDIR} \
 	--without-debug \
-	${@base_contains("GST_VERSION", "1.0", "--with-gstversion=1.0", "", d)} \
 "
 
 CONFFILES_${PN} += "${sysconfdir}/enigma2/movietags"


### PR DESCRIPTION
I can not find any plugin which currently have used anything from gstreamer.
Therefore, remove this.
This pull request should be used together with this: https://github.com/OpenPLi/enigma2-plugins/pull/47