### PR TITLE
enigma2-plugins: change only python plugins arch to all

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugins.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugins.bb
@@ -45,9 +45,9 @@ FILES_${PN}-meta = "${datadir}/meta"
 PACKAGES += "${PN}-meta"
 PACKAGE_ARCH = "all"
 
-PACKAGE_ARCH_enigma2-plugin-extensions-moviecut = "${MACHINE_ARCH}"
-PACKAGE_ARCH_enigma2-plugin-systemplugins-networkbrowser = "${MACHINE_ARCH}"
-PACKAGE_ARCH_enigma2-plugin-systemplugins-vps = "${MACHINE_ARCH}"
+PACKAGE_ARCH_enigma2-plugin-extensions-moviecut = "${TUNE_PKGARCH}"
+PACKAGE_ARCH_enigma2-plugin-systemplugins-networkbrowser = "${TUNE_PKGARCH}"
+PACKAGE_ARCH_enigma2-plugin-systemplugins-vps = "${TUNE_PKGARCH}"
 
 inherit autotools-brokensep
 

--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugins.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugins.bb
@@ -25,6 +25,7 @@ inherit gitpkgv pythonnative pkgconfig
 
 PV = "experimental-git${SRCPV}"
 PKGV = "experimental-git${GITPKGV}"
+PR = "r1"
 
 SRCREV = "${AUTOREV}"
 GITHUB_URI ?= "git://github.com"

--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugins.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugins.bb
@@ -42,7 +42,11 @@ CONFFILES_${PN} += "${sysconfdir}/enigma2/movietags"
 FILES_${PN} += " /usr/share/enigma2 /usr/share/fonts "
 FILES_${PN}-meta = "${datadir}/meta"
 PACKAGES += "${PN}-meta"
-PACKAGE_ARCH = "${MACHINE_ARCH}"
+PACKAGE_ARCH = "all"
+
+PACKAGE_ARCH_enigma2-plugin-extensions-moviecut = "${MACHINE_ARCH}"
+PACKAGE_ARCH_enigma2-plugin-systemplugins-networkbrowser = "${MACHINE_ARCH}"
+PACKAGE_ARCH_enigma2-plugin-systemplugins-vps = "${MACHINE_ARCH}"
 
 inherit autotools-brokensep
 


### PR DESCRIPTION
If in the plugin is only python code, why it architecture depends of the machine?
So change only python plugins architecture to all.