### PR TITLE
Meta-dream: change image_fstype.

### DIFF
--- a/meta-dream/conf/machine/include/dreambox-jffs2.inc
+++ b/meta-dream/conf/machine/include/dreambox-jffs2.inc
@@ -1,3 +1,3 @@
 inherit image_types_nfi
 
-IMAGE_FSTYPES ?= "jffs2.nfi"
+IMAGE_FSTYPES ?= "jffs2nfi"

--- a/meta-dream/conf/machine/include/dreambox-ubi.inc
+++ b/meta-dream/conf/machine/include/dreambox-ubi.inc
@@ -1,6 +1,6 @@
 inherit image_types_nfi
 
-IMAGE_FSTYPES ?= "ubi.nfi"
+IMAGE_FSTYPES ?= "ubinfi"
 UBI_VOLNAME = "rootfs"
 UBINIZE_VOLSIZE ?= "0"
 UBINIZE_DATAVOL ?= "0"

--- a/meta-dream/recipes-bsp/linux/linux-dreambox.inc
+++ b/meta-dream/recipes-bsp/linux/linux-dreambox.inc
@@ -112,7 +112,7 @@ pkg_postrm_kernel () {
 
 CMDLINE_JFFS2 = "root=/dev/mtdblock3 rootfstype=jffs2 rw ${CMDLINE_CONSOLE}"
 CMDLINE_UBI = "ubi.mtd=root root=ubi0:rootfs rootfstype=ubifs rw ${CMDLINE_CONSOLE}"
-CMDLINE = "${@base_contains('IMAGE_FSTYPES', 'ubi.nfi', '${CMDLINE_UBI}', '${CMDLINE_JFFS2}', d)}"
+CMDLINE = "${@base_contains('IMAGE_FSTYPES', 'ubinfi', '${CMDLINE_UBI}', '${CMDLINE_JFFS2}', d)}"
 USB_CMDLINE = "root=${USB_ROOT} rootdelay=10 rw ${CMDLINE_CONSOLE}"
 
 LOCALVERSION = "-${MACHINE}"

--- a/meta-openpli/classes/image_types_nfi.bbclass
+++ b/meta-openpli/classes/image_types_nfi.bbclass
@@ -1,6 +1,6 @@
 inherit image_types
 
-IMAGE_CMD_jffs2.nfi = " \
+IMAGE_CMD_jffs2nfi = " \
 	mkfs.jffs2 \
 		--root=${IMAGE_ROOTFS}/boot \
 		--compression-mode=none \
@@ -20,35 +20,7 @@ IMAGE_CMD_jffs2.nfi = " \
 		> ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.nfi; \
 "
 
-IMAGE_CMD_sum.jffs2.nfi = " \
-	mkfs.jffs2 \
-		--root=${IMAGE_ROOTFS}/boot \
-		--compression-mode=none \
-		--output=${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.boot.jffs2 \
-		${EXTRA_IMAGECMD}; \
-	sumtool \
-		-i ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.boot.jffs2 \
-		-o ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.boot.sum.jffs2 \
-		${EXTRA_IMAGECMD}; \
-	rm -rf ${IMAGE_ROOTFS}/boot/*; \
-	mkfs.jffs2 \
-		--root=${IMAGE_ROOTFS} \
-		--enable-compressor=lzo \
-		--compression-mode=priority \
-		--output=${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.rootfs.jffs2 \
-		${EXTRA_IMAGECMD}; \
-	sumtool \
-		-i ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.rootfs.jffs2 \
-		-o ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.rootfs.sum.jffs2 \
-		${EXTRA_IMAGECMD}; \
-	${DREAMBOX_BUILDIMAGE} \
-		--boot-partition ${DREAMBOX_PART0_SIZE}:${DEPLOY_DIR_IMAGE}/secondstage-${MACHINE}.bin \
-		--data-partition ${DREAMBOX_PART1_SIZE}:${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.boot.sum.jffs2 \
-		--data-partition ${DREAMBOX_PART2_SIZE}:${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.rootfs.sum.jffs2 \
-		> ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.nfi; \
-"
-
-IMAGE_CMD_ubi.nfi = " \
+IMAGE_CMD_ubinfi = " \
 	mkfs.jffs2 \
 		--root=${IMAGE_ROOTFS}/boot \
 		--compression-mode=none \
@@ -89,12 +61,10 @@ IMAGE_CMD_ubi.nfi = " \
 		> ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.nfi; \
 "
 
-EXTRA_IMAGECMD_jffs2.nfi ?= "-e ${DREAMBOX_ERASE_BLOCK_SIZE} -n -l"
-EXTRA_IMAGECMD_sum.jffs2.nfi ?= "-e ${DREAMBOX_ERASE_BLOCK_SIZE} -n -l"
-EXTRA_IMAGECMD_ubi.nfi ?= "-e ${DREAMBOX_ERASE_BLOCK_SIZE} -n -l"
+EXTRA_IMAGECMD_jffs2nfi ?= "-e ${DREAMBOX_ERASE_BLOCK_SIZE} -n -l"
+EXTRA_IMAGECMD_ubinfi ?= "-e ${DREAMBOX_ERASE_BLOCK_SIZE} -n -l"
 
-IMAGE_DEPENDS_jffs2.nfi = "${IMAGE_DEPENDS_jffs2} dreambox-buildimage-native"
-IMAGE_DEPENDS_sum.jffs2.nfi = "${IMAGE_DEPENDS_sum.jffs2} dreambox-buildimage-native"
-IMAGE_DEPENDS_ubi.nfi = "${IMAGE_DEPENDS_ubi} ${IMAGE_DEPENDS_ubifs} dreambox-buildimage-native"
+IMAGE_DEPENDS_jffs2nfi = "${IMAGE_DEPENDS_jffs2} dreambox-buildimage-native"
+IMAGE_DEPENDS_ubinfi = "${IMAGE_DEPENDS_ubi} ${IMAGE_DEPENDS_ubifs} dreambox-buildimage-native"
 
-IMAGE_TYPES += "jffs2.nfi sum.jffs2.nfi ubi.nfi"
+IMAGE_TYPES += "jffs2nfi ubinfi"


### PR DESCRIPTION
-Build images dreamboxes fail due to changes of rootfs/image process in OE-core,IMAGE_FSTYPE need to be adapt to work with it.
-Remove unused code.

Thanks to Alexvrs.
