### PR TITLE
Plugin blurayplayer: change to branch openpli

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-blurayplayer.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-blurayplayer.bb
@@ -4,14 +4,16 @@ HOMEPAGE = "https://github.com/Taapat/enigma2-plugin-blurayplayer"
 SECTION = "multimedia"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING.GPLv2;md5=b234ee4d69f5fce4486a80fdaf4a4263"
-SRC_URI = "git://github.com/Taapat/enigma2-plugin-blurayplayer.git"
-
-S = "${WORKDIR}/git"
 
 inherit gitpkgv
 SRCREV = "${AUTOREV}"
 PV = "1+git${SRCPV}"
 PKGV = "1+git${GITPKGV}"
+BRANCH = "openpli"
+
+SRC_URI = "git://github.com/Taapat/enigma2-plugin-blurayplayer.git;branch=${BRANCH}"
+
+S = "${WORKDIR}/git"
 
 inherit distutils-openplugins
 


### PR DESCRIPTION
This is necessary to use a separate plugin version after its integration in enigma MovieSelection.
This plugin version does not have unnecessary screen BlurayPlayerDirBrowser.

Please use together with this pull request in enigma: https://github.com/OpenPLi/enigma2/pull/223