### PR TITLE
python-lxml: fix pkg-config for libxml2 and libxslt

### DIFF
--- a/meta-openpli/recipes-devtools/python/python-lxml_3.2.5.bbappend
+++ b/meta-openpli/recipes-devtools/python/python-lxml_3.2.5.bbappend
@@ -1,0 +1,13 @@
+DISTUTILS_BUILD_ARGS = " \
+                     --with-xslt-config='pkg-config libxslt' \
+                     --with-xml2-config='pkg-config libxml-2.0' \
+"
+
+DISTUTILS_INSTALL_ARGS = " \
+                     --with-xslt-config='pkg-config libxslt' \
+                     --with-xml2-config='pkg-config libxml-2.0' \
+"
+
+do_configure_prepend() {
+    sed -i -e 's/--version/--modversion/' ${B}/setupinfo.py
+}


### PR DESCRIPTION
Fix based on a later commit on meta-openembedded: https://github.com/openembedded/meta-openembedded/commit/a6423360a175a5e8515c0c6f97d711850dc96c53