### PR TITLE
add atsc-usb-hauppauge meta package

### DIFF
--- a/meta-openpli/recipes-linux/linux-firmwares/firmware-xc5000.bb
+++ b/meta-openpli/recipes-linux/linux-firmwares/firmware-xc5000.bb
@@ -1,0 +1,10 @@
+require linux-firmware.inc
+
+DESCRIPTION = "Firmware for xc5000"
+
+SRCREV = "f640c0ec14a7075eed9901808e313db1623fdcc0"
+
+do_install() {
+	install -d ${D}${base_libdir}/firmware
+	install -m 0644 dvb-fe-xc5000-1.6.114.fw ${D}${base_libdir}/firmware
+}

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/dvb-usb-drivers-meta.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/dvb-usb-drivers-meta.bb
@@ -3,6 +3,7 @@ DESCRIPTION = "meta file for USB DVB drivers"
 require conf/license/openpli-gplv2.inc
 
 DEPENDS = "\
+	enigma2-plugin-drivers-atsc-usb-hauppauge \
 	enigma2-plugin-drivers-dvb-usb-dib0700 \
 	enigma2-plugin-drivers-dvb-usb-af9015 \
 	enigma2-plugin-drivers-dvb-usb-af9035 \
@@ -17,4 +18,4 @@ DEPENDS = "\
 	enigma2-plugin-drivers-dvb-usb-tbs \
 	"
 
-PR = "r1"
+PR = "r2"

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-atsc-usb-hauppauge.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-atsc-usb-hauppauge.bb
@@ -1,0 +1,23 @@
+DESCRIPTION = "USB ATSC driver for Hauppauge WinTV-HVR Tuners"
+
+require conf/license/openpli-gplv2.inc
+
+inherit allarch
+
+RRECOMMENDS_${PN} = " \
+	kernel-module-au0828 \
+	kernel-module-au8522 \
+	kernel-module-au8522-common \
+	kernel-module-au8522-decoder \
+	kernel-module-au8522-dig \
+	kernel-module-cx231xx \
+	kernel-module-em28xx \
+	kernel-module-tda18271 \
+	kernel-module-tveeprom \
+	kernel-module-xc5000 \
+	firmware-xc5000 \
+	"
+
+PV = "1.0"
+
+ALLOW_EMPTY_${PN} = "1"


### PR DESCRIPTION
This commit adds support for Hauppauge WinTV-HVR Tuners.
The required xc5000 firmware was added also.