### PR TITLE
meta-dream: fixes for master-next

### DIFF
--- a/meta-dream/conf/machine/dm500hd.conf
+++ b/meta-dream/conf/machine/dm500hd.conf
@@ -14,3 +14,6 @@ require conf/machine/include/dreambox-mips32el.inc
 DVBMEDIASINK_CONFIG = "--with-pcm --with-wma --with-wmv --with-dtsdownmix --with-eac3"
 
 CHIPSET = "bcm7405"
+
+# Do not install samba due to small flash size
+IMAGE_INSTALL_remove = "samba-base"

--- a/meta-dream/conf/machine/dm800se.conf
+++ b/meta-dream/conf/machine/dm800se.conf
@@ -20,3 +20,5 @@ CHIPSET = "bcm7405"
 # and 6604470 didn't.
 KERNEL_IMAGE_MAXSIZE = "6500000"
 
+# Do not install samba due to small flash size
+IMAGE_INSTALL_remove = "samba-base"

--- a/meta-dream/conf/machine/include/dreambox.inc
+++ b/meta-dream/conf/machine/include/dreambox.inc
@@ -35,7 +35,7 @@ PREFERRED_VERSION_linux-dreambox = "3.2"
 KERNEL_IMAGETYPE = "vmlinux"
 KERNEL_OUTPUT = "${KERNEL_IMAGETYPE}"
 KERNEL_OUTPUT_DIR = "."
-KERNEL_CONSOLE = "${@base_contains('OPENPLI_FEATURES', 'usbconsole', 'ttyS0,115200', 'null', d)}"
+KERNEL_CONSOLE = "${@bb.utils.contains('OPENPLI_FEATURES', 'usbconsole', 'ttyS0,115200', 'null', d)}"
 
 DREAMBOX_BUILDIMAGE = "buildimage --arch ${MACHINE} ${EXTRA_BUILDCMD} \
 	--erase-block-size ${DREAMBOX_ERASE_BLOCK_SIZE} \

--- a/meta-dream/recipes-bsp/linux/linux-dreambox.inc
+++ b/meta-dream/recipes-bsp/linux/linux-dreambox.inc
@@ -112,7 +112,7 @@ pkg_postrm_kernel () {
 
 CMDLINE_JFFS2 = "root=/dev/mtdblock3 rootfstype=jffs2 rw ${CMDLINE_CONSOLE}"
 CMDLINE_UBI = "ubi.mtd=root root=ubi0:rootfs rootfstype=ubifs rw ${CMDLINE_CONSOLE}"
-CMDLINE = "${@base_contains('IMAGE_FSTYPES', 'ubinfi', '${CMDLINE_UBI}', '${CMDLINE_JFFS2}', d)}"
+CMDLINE = "${@bb.utils.contains('IMAGE_FSTYPES', 'ubinfi', '${CMDLINE_UBI}', '${CMDLINE_JFFS2}', d)}"
 USB_CMDLINE = "root=${USB_ROOT} rootdelay=10 rw ${CMDLINE_CONSOLE}"
 
 LOCALVERSION = "-${MACHINE}"


### PR DESCRIPTION
meta-dream: do not install samba on machines with small flash

The dm800se/dm500hd machines flash is too small to fit samba4.
Do not install it by default on the image.

base_contains is deprecated, please use bb.utils.contains instead

sed -i 's/base_contains/bb.utils.contains/g' `grep -r -l base_contains meta-dream/`