### PR TITLE
Binutils: add 1001-do-not-set-the-ABIVERSION-to-5-for-MIPS.patch

### DIFF
--- a/meta-openpli/recipes-devtools/binutils/binutils-cross_2.27.bbappend
+++ b/meta-openpli/recipes-devtools/binutils/binutils-cross_2.27.bbappend
@@ -1,0 +1,5 @@
+SRC_URI += " \
+	file://1001-do-not-set-the-ABIVERSION-to-5-for-MIPS.patch \
+	"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"

--- a/meta-openpli/recipes-devtools/binutils/binutils_2.27.bbappend
+++ b/meta-openpli/recipes-devtools/binutils/binutils_2.27.bbappend
@@ -1,0 +1,5 @@
+SRC_URI += " \
+	file://1001-do-not-set-the-ABIVERSION-to-5-for-MIPS.patch \
+	"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"

--- a/meta-openpli/recipes-devtools/binutils/files/1001-do-not-set-the-ABIVERSION-to-5-for-MIPS.patch
+++ b/meta-openpli/recipes-devtools/binutils/files/1001-do-not-set-the-ABIVERSION-to-5-for-MIPS.patch
@@ -1,0 +1,22 @@
+Aurelien Jarno                          GPG: 4096R/1DDD8C9B
+aurelien@aurel32.net                 http://www.aurel32.net
+
+# DP: do not set the ABIVERSION to 5 for MIPS objects with non-executable stack
+
+This is basically a revert of upstream commit 17733f5be9. The GNU libc
+side is not yet ready for that.
+
+https://lists.debian.org/debian-mips/2016/08/msg00011.html
+
+--- a/bfd/elfxx-mips.c
++++ b/bfd/elfxx-mips.c
+@@ -16187,9 +16187,6 @@
+   if (mips_elf_tdata (abfd)->abiflags.fp_abi == Val_GNU_MIPS_ABI_FP_64
+       || mips_elf_tdata (abfd)->abiflags.fp_abi == Val_GNU_MIPS_ABI_FP_64A)
+     i_ehdrp->e_ident[EI_ABIVERSION] = 3;
+-
+-  if (elf_stack_flags (abfd) && !(elf_stack_flags (abfd) & PF_X))
+-    i_ehdrp->e_ident[EI_ABIVERSION] = 5;
+ }
+ 
+ int


### PR DESCRIPTION
https://lists.debian.org/debian-mips/2016/08/msg00011.html

This fix for example error in ffmpeg
error while loading shared libraries: /usr/lib/libavformat.so.57: ELF file ABI version invalid