### PR TITLE
gstreamer: add few missing plugins

### DIFF
--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.8.2.bbappend
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.8.2.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG += "faac faad libmms rtmp"

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.8.2.bbappend
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.8.2.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG += "amrnb amrwb cdio dvdread mad"


### PR DESCRIPTION
Since we switched to new OE the gstreamer was missing few bad and ugly plugins.

Enable missing plugins using bbappend.