### PR TITLE
gst-plugins-bad: rename plugin from fragmented to hls

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2/enigma2.bb
+++ b/meta-openpli/recipes-openpli/enigma2/enigma2.bb
@@ -98,7 +98,7 @@ GST_BAD_RDEPS = "\
 	gstreamer1.0-plugins-bad-rtmp \
 	gstreamer1.0-plugins-bad-smoothstreaming \
 	gstreamer1.0-plugins-bad-faad \
-	gstreamer1.0-plugins-bad-fragmented \
+	gstreamer1.0-plugins-bad-hls \
 	gstreamer1.0-plugins-bad-videoparsersbad \
 	"
 


### PR DESCRIPTION
In 1.6.2, the "--enable-hls" configure option generated an installable package
called "gstreamer1.0-plugins-bad-fragmented". In 1.7.1 that HLS plugin package
has become "gstreamer1.0-plugins-bad-hls". See:
http://cgit.freedesktop.org/gstreamer/gst-plugins-bad/commit/?id=efe62292a3d045126654d93239fdf4cc8e48ae08