### PR TITLE
gstreamer: use _append instead of += in PACKAGECONFIG

### DIFF
--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.8.2.bbappend
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.8.2.bbappend
@@ -1,1 +1,1 @@
-PACKAGECONFIG += "faac faad libmms rtmp"
+PACKAGECONFIG_append = " faac faad libmms rtmp"

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.8.2.bbappend
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.8.2.bbappend
@@ -1,1 +1,1 @@
-PACKAGECONFIG += "amrnb amrwb cdio dvdread mad"
+PACKAGECONFIG_append = " amrnb amrwb cdio dvdread mad"


### PR DESCRIPTION
It seems += in PACKAGECIONFIG clears the default weak assignment ??=.

So use _append that does not clear the default weak assignment.