### PR TITLE
meta-openpli: fix python-mutagen md5 checksum failure on download

### DIFF
--- a/meta-openpli/recipes-devtools/python/python-mutagen_1.18.bb
+++ b/meta-openpli/recipes-devtools/python/python-mutagen_1.18.bb
@@ -8,13 +8,11 @@ PR = "r1"
 DEPENDS = "python"
 RDEPENDS_${PN} = "python-shell"
 
-MD5SUM = "0c2cd954e4bacd79fadd45afc4acce4c"
-
-SRC_URI = "http://pkgs.fedoraproject.org/repo/pkgs/${PN}/${SRCNAME}.tar.gz/${MD5SUM}/${SRCNAME}.tar.gz \
+SRC_URI = "http://pkgs.fedoraproject.org/repo/pkgs/${PN}/${SRCNAME}.tar.gz/0c2cd954e4bacd79fadd45afc4acce4c/${SRCNAME}.tar.gz \
 	file://patch.diff \
 "
 
-SRC_URI[md5sum] = "${MD5SUM}"
+SRC_URI[md5sum] = "0c2cd954e4bacd79fadd45afc4acce4c"
 SRC_URI[sha256sum] = "30b6147baf59ab3609939acf49a1a1c73b15d8b1c637a01bfee89da7feea0d6c"
 
 S = "${WORKDIR}/${SRCNAME}"


### PR DESCRIPTION
The python-mutagen recipe set SRC_URI[md5sum] using a variable which doesn't
seem to be correctly evaluated, resulting in this kind of error message
during source fetching:

ERROR: Fetcher failure for URL: <blah...>
Checksum mismatch!
File: '/home/foobar/openpli-oe-core/sources/mutagen-1.18.tar.gz' has md5
checksum 0c2cd954e4bacd79fadd45afc4acce4c when ${MD5SUM} was expected

This breaks the vuduo2 build for me.  Fix by expressing the md5sum as a
string literal where it is used.