### PR TITLE
Update libbluray

### DIFF
--- a/meta-openpli/recipes-support/libbluray/libbluray/expose_clip_id_in_BLURAY_CLIP_INFO.patch
+++ b/meta-openpli/recipes-support/libbluray/libbluray/expose_clip_id_in_BLURAY_CLIP_INFO.patch
@@ -1,0 +1,37 @@
+From 1a113167733091fe325152a5ece4d57ee1b89dc0 Mon Sep 17 00:00:00 2001
+From: John Stebbins <stebbins@jetheaddev.com>
+Date: Wed, 18 May 2016 15:40:17 -0600
+Subject: [PATCH] expose clip_id in BLURAY_CLIP_INFO
+
+---
+ src/libbluray/bluray.c | 1 +
+ src/libbluray/bluray.h | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/src/libbluray/bluray.c b/src/libbluray/bluray.c
+index b7598b9..3478ade 100644
+--- a/src/libbluray/bluray.c
++++ b/src/libbluray/bluray.c
+@@ -2602,6 +2602,7 @@ static BLURAY_TITLE_INFO* _fill_title_info(NAV_TITLE* title, uint32_t title_idx,
+             BLURAY_CLIP_INFO *ci = &title_info->clips[ii];
+             NAV_CLIP *nc = &title->clip_list.clip[ii];
+ 
++            memcpy(ci->clip_id, pi->clip[0].clip_id, sizeof(ci->clip_id));
+             ci->pkt_count = nc->end_pkt - nc->start_pkt;
+             ci->start_time = (uint64_t)nc->title_time * 2;
+             ci->in_time = (uint64_t)pi->in_time * 2;
+diff --git a/src/libbluray/bluray.h b/src/libbluray/bluray.h
+index 3cd7118..177b3d4 100644
+--- a/src/libbluray/bluray.h
++++ b/src/libbluray/bluray.h
+@@ -225,6 +225,7 @@ typedef struct bd_stream_info {
+ } BLURAY_STREAM_INFO;
+ 
+ typedef struct bd_clip {
++    char               clip_id[6];
+     uint32_t           pkt_count;
+     uint8_t            still_mode;
+     uint16_t           still_time;  /* seconds */
+-- 
+2.5.5
+

--- a/meta-openpli/recipes-support/libbluray/libbluray_git.bb
+++ b/meta-openpli/recipes-support/libbluray/libbluray_git.bb
@@ -6,8 +6,10 @@ LIC_FILES_CHKSUM="file://COPYING;md5=435ed639f84d4585d93824e7da3d85da"
 
 DEPENDS = "libxml2"
 
-SRC_URI = "git://git.videolan.org/libbluray.git;branch=master;protocol=git"
-SRCREV="eefd7c6a192b5243ec9b25676944fcb87cfa3c2e"
+SRC_URI = "gitsm://git.videolan.org/libbluray.git \
+    file://expose_clip_id_in_BLURAY_CLIP_INFO.patch \
+"
+SRCREV="efcde25b3bd58eee9cb96f151b79a585a52a09ff"
 
 inherit gitpkgv autotools-brokensep pkgconfig
 
@@ -21,7 +23,6 @@ EXTRA_OECONF = " \
     --disable-bdjava-jar \
     --disable-doxygen-doc \
     --disable-doxygen-dot \
-    --disable-udf \
     --without-freetype \
     --without-fontconfig \
 "


### PR DESCRIPTION
Update on latest git revision.
Enable udf (as submodule) to read iso discs.
Add patch to expose clip_id in BLURAY_CLIP_INFO. This allow get m2ts track name from BLURAY_CLIP_INFO in BlurayPlayer plugin.