### PR TITLE
libbluray: fix package version

### DIFF
--- a/meta-openpli/recipes-support/libbluray/libbluray_git.bb
+++ b/meta-openpli/recipes-support/libbluray/libbluray_git.bb
@@ -13,8 +13,12 @@ SRCREV="efcde25b3bd58eee9cb96f151b79a585a52a09ff"
 
 inherit gitpkgv autotools-brokensep pkgconfig
 
-PV = "v0.9.3+git${SRCPV}"
-PKGV = "v0.9.3+git${GITPKGV}"
+# Set PV and PKGV manualy on OE before https://github.com/openembedded/meta-openembedded/commit/22004e5281a913818a94bcd160ad3135a9ecd314
+# Remove this after meta-openembedded update
+#PV = "v0.9.3+git${SRCPV}"
+#PKGV = "v0.9.3+git${GITPKGV}"
+PV = "v0.9.3+git2490+efcde25"
+PKGV = "v0.9.3+git2490+efcde25"
 
 S="${WORKDIR}/git"
 


### PR DESCRIPTION
On meta-openembedded gitpkgv does not work using "gitsm://" before this commit
https://github.com/openembedded/meta-openembedded/commit/22004e5281a913818a94bcd160ad3135a9ecd314

This set package version manualy.
Remove this after meta-openembedded update.