### PR TITLE
[OpenWebif] Split out package openwebif-vxg

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-openwebif.bbappend
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-openwebif.bbappend
@@ -72,3 +72,8 @@ python do_package_prepend () {
             if target_remote != name and name != 'ow_remote.png' and (exception + '.png' != name):
                 os.remove(os.path.join(root, name))
 }
+
+PACKAGES =+ "${PN}-vxg"
+DESCRIPTION_${PN}-vxg = "Adds Google Chrome support to OpenWebif's WebTV"
+FILES_${PN}-vxg = "/usr/lib/enigma2/python/Plugins/Extensions/OpenWebif/public/js/media_player.pexe"
+RDEPENDS_${PN}-vxg =+ "${PN}"


### PR DESCRIPTION
The purpose of enigma2-plugin-extensions-openwebif-vxg is to provide WebTV support in Chrome.

However, it's 1.4 MB in size, too much for boxes with small flash, so WebTV was coded with VXG as **optional** feature.
If -vxg is missing, there is no WebTV support for Chrome, but no other consequences.

NOTE: Try ASAP after merging, I have no OpenPLi build-env.