### PR TITLE
image_types_nfi: remove inherit image_types

### DIFF
--- a/meta-openpli/classes/image_types_nfi.bbclass
+++ b/meta-openpli/classes/image_types_nfi.bbclass
@@ -1,4 +1,3 @@
-inherit image_types
 
 IMAGE_CMD_jffs2nfi = " \
 	mkfs.jffs2 \


### PR DESCRIPTION
It breaks the build for dreamboxes due to 'Unable to determine endianness for architecture 'none''
for uninative-tarball and uninative-tarball.