### PR TITLE
Create /media/net directory on every boot

### DIFF
--- a/meta-openpli/recipes-daemons/autofs/autofs/99_autofs
+++ b/meta-openpli/recipes-daemons/autofs/autofs/99_autofs
@@ -1,0 +1,3 @@
+# <type> <owner> <group> <mode> <path> <linksource>
+d root root 0700 /var/run/autofs none
+d root root 0755 /media/net none

--- a/meta-openpli/recipes-daemons/autofs/autofs_5.1.%.bbappend
+++ b/meta-openpli/recipes-daemons/autofs/autofs_5.1.%.bbappend
@@ -1,4 +1,8 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
 EXTRA_OECONF += "--with-confdir=/etc/default"
+
+SRC_URI += " file://99_autofs"
 
 # Remove and change configuration files
 do_install_append() {
@@ -7,4 +11,14 @@ do_install_append() {
 	chmod 0644 ${D}/etc/auto.net
 	rm -f ${D}/etc/auto.smb ${D}/etc/auto.misc ${D}/etc/autofs_ldap_auth.conf
 	sed -i 's/^TIMEOUT=300/TIMEOUT=30/' ${D}/etc/default/autofs
+	install -d ${D}${sysconfdir}/default/volatiles
+	install -m 644 ${WORKDIR}/99_autofs ${D}${sysconfdir}/default/volatiles/99_autofs
+}
+
+pkg_postinst_${PN} () {
+        if [ -z "$D" ]; then
+                if [ -e ${sysconfdir}/init.d/populate-volatile.sh ]; then
+                        ${sysconfdir}/init.d/populate-volatile.sh update
+                fi
+        fi
 }


### PR DESCRIPTION
autofs don't work without the directory and it cannot create
the directory by itself.