### PR TITLE
astra-sm: update to version with t2mi everywhere

### DIFF
--- a/meta-openpli/recipes-multimedia/astra-sm/astra-sm/astra-sm
+++ b/meta-openpli/recipes-multimedia/astra-sm/astra-sm/astra-sm
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+if [ -z "$1" ] ; then
+    echo "Usage: $0 [start|stop|restart]"
+    exit 0
+fi
+
+if [ "$1" = "start" ] ; then
+    ulimit -n 65536
+    /usr/bin/astra --pid /var/run/astra.pid /etc/astra/astra.conf &
+elif [ "$1" = "stop" ] ; then
+    kill `cat /var/run/astra.pid`
+elif [ "$1" = "restart" ] ; then
+    $0 stop
+    sleep 1
+    $0 start
+fi

--- a/meta-openpli/recipes-multimedia/astra-sm/astra-sm/astra.conf
+++ b/meta-openpli/recipes-multimedia/astra-sm/astra-sm/astra.conf
@@ -1,0 +1,4 @@
+-- Astra Slonik Mod
+
+log.set({ stdout = false, debug = false, syslog = "astra", })
+

--- a/meta-openpli/recipes-multimedia/astra-sm/astra-sm_0.2.bb
+++ b/meta-openpli/recipes-multimedia/astra-sm/astra-sm_0.2.bb
@@ -4,12 +4,14 @@ DESCRIPTION = "Astra (Advanced Streamer) is a professional software to organize 
 SECTION = "multimedia"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
-SRCREV = "0ec5137d33ca23b0d53e85daec38cb809be378e0"
+SRCREV = "1c45755761e10f96318f2fffb29bb5466e00bcfc"
 DEPENDS = "libaio"
 
 SRC_URI = "git://gitlab.com/berdyansk/astra-sm.git;protocol=http \
 	file://version.patch \
 	file://undef_dvb_net.patch \
+	file://astra-sm \
+	file://astra.conf \
 	"
 
 S = "${WORKDIR}/git"
@@ -18,6 +20,15 @@ inherit autotools-brokensep pkgconfig gettext
 
 do_install_append() {
 	install -m 0755 ${S}/tests/t2mi_decap ${D}${bindir}/t2mi_decap
+	install -d ${D}/etc/init.d
+	install -m 0755 ${WORKDIR}/astra-sm ${D}/etc/init.d/
+	install -m 0644 ${WORKDIR}/astra.conf ${D}/etc/astra/
 }
 
+FILES_${PN} += "/etc/init.d/"
 FILES_${PN}-dev += "${datadir}"
+
+INITSCRIPT_NAME = "astra-sm"
+INITSCRIPT_PARAMS = "defaults"
+
+inherit update-rc.d


### PR DESCRIPTION
Also start astra-sm as a service with an empty config file.

Eg. astra-sm can be used as udpxy alternative.