### PR TITLE
Update to ofgwrite 3.8.0

### DIFF
--- a/meta-openpli/recipes-extended/ofgwrite/ofgwrite.bb
+++ b/meta-openpli/recipes-extended/ofgwrite/ofgwrite.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=0636e73ff0215e8d672dc4c32c317bb3 \
 
 inherit gitpkgv
 
-SRCREV = "638302c06807b8e4f21e52e885ef6465b7e6aea9"
+SRCREV = "6f77e99efc1ac292c3f473ff86848fe79d0aee79"
 PKGV = "3.x+git${GITPKGV}"
 
 SRC_URI = "git://github.com/oe-alliance/ofgwrite.git"


### PR DESCRIPTION
This version is needed to flash backups on hd51 via backup suite