### PR TITLE
Update for 7 segment displays

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2/enigma2.bb
+++ b/meta-openpli/recipes-openpli/enigma2/enigma2.bb
@@ -184,6 +184,7 @@ EXTRA_OECONF = "\
 	ac_cv_prog_c_openmp=-fopenmp \
 	${@base_contains("MACHINE_FEATURES", "textlcd", "--with-textlcd" , "", d)} \
 	${@base_contains("MACHINE_FEATURES", "7segment", "--with-7segment" , "", d)} \
+	${@base_contains("MACHINE_FEATURES", "7seg", "--with-7segment" , "", d)} \
 	BUILD_SYS=${BUILD_SYS} \
 	HOST_SYS=${HOST_SYS} \
 	STAGING_INCDIR=${STAGING_INCDIR} \

--- a/meta-openpli/recipes-openpli/images/openpli-enigma2-image.bb
+++ b/meta-openpli/recipes-openpli/images/openpli-enigma2-image.bb
@@ -67,7 +67,6 @@ ENIGMA2_PLUGINS = " \
 	${@base_contains('OPENPLI_FEATURES', 'ci', 'enigma2-plugin-systemplugins-commoninterfaceassignment', '', d)} \
 	${@base_contains('OPENPLI_FEATURES', 'dvd', 'enigma2-plugin-extensions-cdinfo enigma2-plugin-extensions-dvdplayer', '', d)} \
 	${@base_contains('OPENPLI_FEATURES', 'fan', 'enigma2-plugin-systemplugins-tempfancontrol', '', d)} \
-	${@base_contains('OPENPLI_FEATURES', '7seg', 'enigma2-plugin-systemplugins-vfdcontrol', '', d)} \
 	"
 
 DEPENDS += " \


### PR DESCRIPTION
enigma2: use --with-7segment also for receivers with 7seg in MACHINE_FEATURES
This allow use skin_text_7segment.xml aslo for edision, spycat and formuler if they do not use their skin_text.xml.
Tested only on formuler f3 but should work on all receivers with 7 segment display.

Remove plugin vfdcontrol from image
Remove enigma2-plugin-systemplugins-vfdcontrol if 7seg in OPENPLI_FEATURES.
In manufacturers bsp is not used 7seg in OPENPLI_FEATURES.
7seg is used in the MACHINE_FEATURES and for it now is used skin_text_7segment.xml.
Therefore, remove this option which is not used anywhere.