### PR TITLE
Fix license warnings reported in future OE versions

### DIFF
--- a/meta-openpli/recipes-devtools/python/python-wifi_0.5.0.bb
+++ b/meta-openpli/recipes-devtools/python/python-wifi_0.5.0.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Provides access to Linux Wireless Extensions"
 HOMEPAGE = "http://pythonwifi.wikispot.org/"
 SECTION = "devel/python"
-LICENSE = "LGPLv2+"
+LICENSE = "LGPLv2+ & GPLv2+"
 LICENSE_${PN}-examples = "GPLv2+"
 LIC_FILES_CHKSUM = "file://README;beginline=56;endline=57;md5=31ebd3ff22b6f3c0160a143e0c4a98a3 \
                     file://examples/iwconfig.py;beginline=1;endline=20;md5=60fd41501905b3e20e9065995edfc0cf \

--- a/meta-openpli/recipes-multimedia/cdparanoia/cdparanoia_svn.bb
+++ b/meta-openpli/recipes-multimedia/cdparanoia/cdparanoia_svn.bb
@@ -1,7 +1,7 @@
 # Copyright (C) 2005, Advanced Micro Devices, Inc.  All Rights Reserved
 SUMMARY = "audio extraction tool for sampling CDs"
 HOMEPAGE = "http://xiph.org/paranoia/"
-LICENSE = "GPLv2"
+LICENSE = "GPLv2 & LGPLv2.1"
 LIC_FILES_CHKSUM = "file://COPYING-GPL;md5=1ed9d357695b2e3ef099df37fed63d96 \
                     file://COPYING-LGPL;md5=d370feaa1c9edcdbd29ca27ea3d2304d"
 SECTION = "multimedia"


### PR DESCRIPTION
This patch solves the following warnings reported by futuner OE versions:
WARNING: LICENSE_python-wifi-examples includes licenses (GPLv2+) that are not listed in LICENSE
WARNING: LICENSE_libcdparanoia includes licenses (LGPLv2.1) that are not listed in LICENSE