### PR TITLE
tuxtxt-enigma2: fix warning about not shipped pyc files

### DIFF
--- a/meta-openpli/recipes-multimedia/tuxtxt/tuxtxt-enigma2.bb
+++ b/meta-openpli/recipes-multimedia/tuxtxt/tuxtxt-enigma2.bb
@@ -28,4 +28,9 @@ EXTRA_OECONF = "--with-boxtype=generic --with-configdir=/etc \
 	DVB_API_VERSION=5\
 	"
 
+do_install_append() {
+	# remove unused .pyc files
+	find ${D}/usr/lib/enigma2/python/ -name '*.pyc' -exec rm {} \;
+}
+
 PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
Delete pyc leftovers in order to silence the following warning.

WARNING: tuxtxt-enigma2-2.0+gitAUTOINC+a1b42559e8-r3 do_package: QA Issue: tuxtxt-enigma2: Files/directories were installed but not shipped in any package:
  /usr/lib/enigma2/python/Plugins/Extensions/Tuxtxt/__init__.pyc
  /usr/lib/enigma2/python/Plugins/Extensions/Tuxtxt/plugin.pyc