### PR TITLE
[smb.conf] Not the right place to put advertisements ...

### DIFF
--- a/meta-openpli/recipes-connectivity/samba/samba/smb.conf
+++ b/meta-openpli/recipes-connectivity/samba/samba/smb.conf
@@ -5,7 +5,7 @@
    log level = 1
    security = share
    server string = OpenPLi %h network services
-   workgroup = OpenPLi
+   workgroup = WORKGROUP
    netbios name = %h
    case sensitive=yes
    preserve case=yes


### PR DESCRIPTION
... any Windows defaults to work group WORKGROUP and will by default only see other machines in the same workgroup.

Putting anything but the workgroup the other machines are in breaks browsing!

Back in WfW 3.11 or so they accidently translated it, e.g. to ARBEITSGRUPPE in German, but Microsoft reverted that.
It's now **always** WORKGROUP by default and any decent Linux distro lets Samba default to WORKGROUP too.

Note: You already got it right in master-next ...