### PR TITLE
dmm: Fix non bootable box.

### DIFF
--- a/meta-dream/recipes-bsp/linux/linux-dreambox.inc
+++ b/meta-dream/recipes-bsp/linux/linux-dreambox.inc
@@ -59,9 +59,8 @@ do_install_append() {
         echo "/boot/${KERNEL_IMAGETYPE}-${KERNEL_VERSION}.gz ${USB_CMDLINE}" >> ${D}/${KERNEL_IMAGEDEST}/autoexec_${MACHINE}.bat
 }
 
-# The vmlinux package gets priority over the kernel-image, so make it empty so that
-# kernel-image gets those files.
-FILES_kernel-vmlinux = ""
+# Set FILES for vmlinux package, so that kernel-image gets those files.
+FILES_kernel-vmlinux = "boot/vmlinux-3.2-${MACHINE}.gz"
 ALLOW_EMPTY_kernel-vmlinux = "1"
 FILES_kernel-image += "\
 	/${KERNEL_IMAGEDEST}/autoexec*.bat \


### PR DESCRIPTION
Since commit:
http://git.openembedded.org/openembedded-core/commit/meta/classes/kernel.bbclass?h=morty&id=a248ef51ae680e81cf78f07fe242ac6e01a5fcb4
vmlinux is not incluced in image.
Which result in a non bootable box after a flash.
Set files to vmlinux to restore it.