### PR TITLE
enigma2: move get_crashaddr to all EXTRA_OECONF otions set up

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2/enigma2.bb
+++ b/meta-openpli/recipes-openpli/enigma2/enigma2.bb
@@ -182,10 +182,17 @@ PKGV_enigma2-fonts = "${PV_enigma2-fonts}"
 PKGR_enigma2-fonts = "${PR_enigma2-fonts}"
 FILES_enigma2-fonts = "${datadir}/fonts"
 
+def get_crashaddr(d):
+    if d.getVar('CRASHADDR', True):
+        return '--with-crashlogemail="${CRASHADDR}"'
+    else:
+        return ''
+
 EXTRA_OECONF = "\
 	--with-libsdl=no --with-boxtype=${MACHINE} \
 	--enable-dependency-tracking \
 	ac_cv_prog_c_openmp=-fopenmp \
+	${@get_crashaddr(d)} \
 	${@bb.utils.contains("MACHINE_FEATURES", "textlcd", "--with-textlcd" , "", d)} \
 	${@bb.utils.contains("MACHINE_FEATURES", "7segment", "--with-7segment" , "", d)} \
 	${@bb.utils.contains("MACHINE_FEATURES", "7seg", "--with-7segment" , "", d)} \
@@ -229,14 +236,6 @@ do_openpli_branding() {
 }
 
 addtask openpli_branding after do_unpack before do_configure
-
-def get_crashaddr(d):
-    if d.getVar('CRASHADDR', True):
-        return '--with-crashlogemail="${CRASHADDR}"'
-    else:
-        return ''
-
-EXTRA_OECONF += "${@get_crashaddr(d)}"
 
 do_install_append() {
 	install -d ${D}/usr/share/keymaps


### PR DESCRIPTION
Why add extra EXTRA_OECONF += in the end of the file?
Set all options in one place.