### PR TITLE
busybox mdev-mount: fix errors on mmc mount

### DIFF
--- a/meta-openpli/recipes-core/busybox/busybox/mdev-mount.sh
+++ b/meta-openpli/recipes-core/busybox/busybox/mdev-mount.sh
@@ -20,6 +20,10 @@ case "$ACTION" in
 			exit 0
 		fi
 		DEVBASE=`expr substr $MDEV 1 3`
+		# for mmcblk[0-9]p[0-9] change to mmcblk[0-9]
+		if [ "${DEVBASE}" == "mmc" ] ; then
+			DEVBASE=`expr substr $MDEV 1 7`
+		fi
 		# check for "please don't mount it" file
 		if [ -f "/dev/nomount.${DEVBASE}" ] ; then
 			# blocked
@@ -55,6 +59,7 @@ case "$ACTION" in
 		fi
 		# first allow fstab to determine the mountpoint
 		if ! mount /dev/$MDEV > /dev/null 2>&1 ; then
+			DEVICETYPE="usb"
 			# no fstab entry, use automatic mountpoint
 			if [ -z "${LABEL}" ] ; then
 				REMOVABLE=`cat /sys/block/$DEVBASE/removable`
@@ -63,6 +68,10 @@ case "$ACTION" in
 				if [ "${REMOVABLE}" -eq "0" -a $EXTERNAL -eq 0 ] ; then
 					# mount the first non-removable internal device on /media/hdd
 					DEVICETYPE="hdd"
+				elif [ ! -e /sys/block/$DEVBASE/device/model ]; then
+					if [ ${#DEVBASE} == 7 ]; then
+						DEVICETYPE="mmc1"
+					fi
 				else
 					MODEL=`cat /sys/block/$DEVBASE/device/model`
 					if [ "$MODEL" == "USB CF Reader   " ]; then
@@ -85,8 +94,6 @@ case "$ACTION" in
 						DEVICETYPE="mmc1"
 					elif [ "$MDEV" == "mmcblk0p1" ]; then
 						DEVICETYPE="mmc1"
-					else
-						DEVICETYPE="usb"
 					fi
 				fi
 			else


### PR DESCRIPTION
On zgemma when mount internal SD-card occurs errors:
cat: cant open  /sys/block/mmc/removable : No such file or directory
cat: cant open  /sys/block/mmc/device/model : No such file or directory

The reason is that for the mmc is used wrong DEVBASE and not exist ../device/model
To fix change for mms DEVBASE from the first three characters to seven (mmcblk[0-9])
Checks if exist ../device/model before try get model.