### PR TITLE
glib-networking: use glib-openssl for TLS backend

### DIFF
--- a/meta-openpli/recipes-core/glib-networking/glib-networking_2.%.bbappend
+++ b/meta-openpli/recipes-core/glib-networking/glib-networking_2.%.bbappend
@@ -1,0 +1,3 @@
+PACKAGECONFIG = "ca-certificates"
+RDEPENDS_${PN} += "glib-openssl"
+ALLOW_EMPTY_${PN} = "1"

--- a/meta-openpli/recipes-core/glib-networking/glib-openssl_2.50.1.bb
+++ b/meta-openpli/recipes-core/glib-networking/glib-openssl_2.50.1.bb
@@ -1,0 +1,19 @@
+SUMMARY = "GLib networking for tls using openssl"
+DESCRIPTION = "This is a fork of glib-networking providing only tls support using openssl. As a side point it fully supports Windows."
+HOMEPAGE = "http://git.gnome.org/browse/glib-openssl/"
+BUGTRACKER = "http://bugzilla.gnome.org"
+
+LICENSE = "LGPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=5f30f0716dfdd0d91eb439ebec522ec2"
+
+SECTION = "libs"
+DEPENDS = "glib-2.0 intltool-native openssl"
+
+SRC_URI[archive.md5sum] = "de9f89e0e7d9aa973e6edffe78b82ce8"
+SRC_URI[archive.sha256sum] = "23203c8f83e9442c51aeff75959470531135eb3872b638791de6a6f7fee65a9b"
+
+inherit gnomebase gettext upstream-version-is-even gio-module-cache
+
+FILES_${PN} += "${libdir}/gio/modules/libgio*.so ${datadir}/dbus-1/services/"
+FILES_${PN}-dev += "${libdir}/gio/modules/libgio*.la"
+FILES_${PN}-staticdev += "${libdir}/gio/modules/libgio*.a"


### PR DESCRIPTION
The gnutls is much, much slower than OpenSSL, switch to new glib-openssl TLS backend.

More info: https://forums.openpli.org/topic/37567-full-ci-support/page-7#entry688949