### PR TITLE
Use OpenSSL for curl and openldap

### DIFF
--- a/meta-openpli/conf/distro/openpli.conf
+++ b/meta-openpli/conf/distro/openpli.conf
@@ -87,3 +87,7 @@ DISTRO_FEED_ARCHS = "all ${TUNE_PKGARCH} ${MACHINE_ARCH}"
 
 # temporary workaround for vuplus-dvbmediasink needing non-HEAD commit
 SRCREV_pn-gst-plugin-vuplus-dvbmediasink = "a02fcc119ee7c4c37d7ffd989a898411ac8fc48a"
+
+# Use OpenSSL only
+PACKAGECONFIG_pn-curl = "${@bb.utils.contains("DISTRO_FEATURES", "ipv6", "ipv6", "", d)} ssl proxy zlib"
+PACKAGECONFIG_pn-openldap = "openssl modules mdb ldap meta monitor null passwd shell proxycache dnssrv ${@bb.utils.contains('DISTRO_FEATURES', 'ipv6', 'ipv6', '', d)}"


### PR DESCRIPTION
Change PACKAGECONFIG for curl and openldap to make use of OpenSSL instead of GnuTLS.

It reduces the image size (almost 2MB) and most probably the compile time, since GnuTLS might not build anymore, at least on base instalation.