### PR TITLE
dvb-usb: update for newer kernels

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-af9015.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-af9015.bb
@@ -2,15 +2,25 @@ DESCRIPTION = "USB DVB driver for Afatech 9015 chipset"
 
 require conf/license/openpli-gplv2.inc
 
-DVBPROVIDER ?= "kernel"
+inherit allarch
 
-RDEPENDS_${PN} = " \
-	${DVBPROVIDER}-module-dvb-usb-af9015 \
-	firmware-dvb-usb-af9015 \
+RRECOMMENDS_${PN} = " \
 	firmware-dvb-fe-af9013 \
+	firmware-dvb-usb-af9015 \
+	kernel-module-af9013 \
+	kernel-module-dvb-pll \
+	kernel-module-dvb-usb \
+	kernel-module-dvb-usb-af9015 \
+	kernel-module-mc44s803 \
+	kernel-module-mt2060 \
+	kernel-module-mxl5005s \
+	kernel-module-mxl5007t \
+	kernel-module-qt1010 \
+	kernel-module-stv0299 \
+	kernel-module-tda18218 \
+	kernel-module-tda18271 \
 	"
 
-PV = "1.0"
-PR = "r3"
+PV = "1.1"
 
 ALLOW_EMPTY_${PN} = "1"

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-af9035.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-af9035.bb
@@ -2,20 +2,20 @@ DESCRIPTION = "USB DVB driver for af9035 devices"
 
 require conf/license/openpli-gplv2.inc
 
-DVBPROVIDER ?= "kernel"
+inherit allarch
 
 RRECOMMENDS_${PN} = " \
-	${DVBPROVIDER}-module-dvb-usb-af9035 \
-	${DVBPROVIDER}-module-af9033 \
-	${DVBPROVIDER}-module-tua9001 \
-	${DVBPROVIDER}-module-mxl5007t \
-	${DVBPROVIDER}-module-tda18218 \
-	${DVBPROVIDER}-module-it913x \
 	firmware-dvb-usb-af9035-01 \
 	firmware-dvb-usb-af9035-02 \
 	firmware-dvb-usb-it913x \
+	kernel-module-af9033 \
+	kernel-module-dvb-usb-af9035 \
+	kernel-module-it913x \
+	kernel-module-mxl5007t \
+	kernel-module-tda18218 \
+	kernel-module-tua9001 \
 	"
 
-PV = "1.2"
+PV = "1.3"
 
 ALLOW_EMPTY_${PN} = "1"

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-dib0700.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-dib0700.bb
@@ -2,21 +2,33 @@ DESCRIPTION = "USB DVB driver for dib0700 chipset"
 
 require conf/license/openpli-gplv2.inc
 
-DVBPROVIDER ?= "kernel"
+inherit allarch
 
-RDEPENDS_${PN} = " \
-	${DVBPROVIDER}-module-dvb-usb-dib0700 \
-	${DVBPROVIDER}-module-dvb-usb-dibusb-common \
-	${DVBPROVIDER}-module-dvb-usb-dibusb-mc \
+RRECOMMENDS_${PN} = " \
 	firmware-dvb-usb-dib0700-1.20 \
 	firmware-dvb-usb-dibusb-5.0.0.11 \
 	firmware-dvb-usb-dibusb-6.0.0.8 \
 	firmware-dvb-usb-dibusb-an2235-01 \
 	firmware-xc3028-v27 \
 	firmware-xc3028l-v36 \
+	kernel-module-dib0070 \
+	kernel-module-dib0090 \
+	kernel-module-dib3000mb \
+	kernel-module-dib3000mc \
+	kernel-module-dib7000m \
+	kernel-module-dib7000p \
+	kernel-module-dib8000 \
+	kernel-module-dibx000-common \
+	kernel-module-dvb-usb \
+	kernel-module-dvb-usb-dib0700 \
+	kernel-module-dvb-usb-dibusb-common \
+	kernel-module-dvb-usb-dibusb-mc \
+	kernel-module-fc0013 \
+	kernel-module-mt2060 \
+	kernel-module-mt2266 \
+	kernel-module-tuner-xc2028 \
 	"
 
-PV = "1.0"
-PR = "r3"
+PV = "1.1"
 
 ALLOW_EMPTY_${PN} = "1"

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-it913x.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-it913x.bb
@@ -2,14 +2,19 @@ DESCRIPTION = "USB DVB driver for it913x chipsets"
 
 require conf/license/openpli-gplv2.inc
 
-DVBPROVIDER ?= "kernel"
+inherit allarch
 
-RDEPENDS_${PN} = " \
-	${DVBPROVIDER}-module-dvb-usb-it913x \
-	firmware-dvb-usb-it913x \
+RRECOMMENDS_${PN} = " \
+        firmware-dvb-usb-af9035-01 \
+        firmware-dvb-usb-af9035-02 \
+        firmware-dvb-usb-it913x \
+        kernel-module-af9033 \
+        kernel-module-dvb-usb-af9035 \
+        kernel-module-dvb-usb-it913x \
+        kernel-module-it913x \
+        kernel-module-module-it913x-fe \
 	"
 
-PV = "1.0"
-PR = "r0"
+PV = "1.1"
 
 ALLOW_EMPTY_${PN} = "1"


### PR DESCRIPTION
Update several dvb-usb drivers for newer kernels. 

Switch provider to kernel (we do not build v4l drivers since OpenPLi 3). 
Inherit allarch to create packages once.
