### PR TITLE
dvb-usb: update for newer kernels 

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/dvb-usb-drivers-meta.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/dvb-usb-drivers-meta.bb
@@ -2,10 +2,13 @@ DESCRIPTION = "meta file for USB DVB drivers"
 
 require conf/license/openpli-gplv2.inc
 
+inherit allarch
+
 DEPENDS = "\
 	enigma2-plugin-drivers-atsc-usb-hauppauge \
 	enigma2-plugin-drivers-atsc-usb-hauppauge-950q \
 	enigma2-plugin-drivers-atsc-usb-hauppauge-955q \
+	enigma2-plugin-drivers-ct2-dvb-usb-pctv292e \
 	enigma2-plugin-drivers-ct2-usb-dvbsky-t330 \
 	enigma2-plugin-drivers-ct2-usb-geniatech-t230 \
 	enigma2-plugin-drivers-s2-usb-dvbsky-s960 \
@@ -23,4 +26,4 @@ DEPENDS = "\
 	enigma2-plugin-drivers-dvb-usb-tbs \
 	"
 
-PR = "r2"
+PV = "1.1"

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-ct2-dvb-usb-pctv292e.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-ct2-dvb-usb-pctv292e.bb
@@ -1,0 +1,18 @@
+DESCRIPTION = "USB DVB driver for pctv292e chipsets"
+
+require conf/license/license-gplv2.inc
+
+inherit allarch
+
+RRECOMMENDS_${PN} = " \
+	firmware-dvb-demod-si2168-b40 \
+	kernel-module-em28xx \
+	kernel-module-em28xx-dvb \
+	kernel-module-em28xx-rc \
+	kernel-module-si2157 \
+	kernel-module-si2168 \
+	"
+
+PV = "1.0"
+
+ALLOW_EMPTY_${PN} = "1"

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-as102.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-as102.bb
@@ -2,15 +2,15 @@ DESCRIPTION = "USB DVB driver for AS102 chipset"
 
 require conf/license/openpli-gplv2.inc
 
-DVBPROVIDER ?= "kernel"
+inherit allarch
 
-RDEPENDS_${PN} = " \
-	${DVBPROVIDER}-module-dvb-as102 \
+RRECOMMENDS_${PN} = " \
 	firmware-as102-data1-st \
 	firmware-as102-data2-st \
+	kernel-module-as102-fe \
+	kernel-module-dvb-as102 \
 	"
 
-PV = "1.0"
-PR = "r0"
+PV = "1.1"
 
 ALLOW_EMPTY_${PN} = "1"

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-dtt200u.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-dtt200u.bb
@@ -2,18 +2,17 @@ DESCRIPTION = "USB DVB driver for dtt200u chipsets"
 
 require conf/license/openpli-gplv2.inc
 
-DVBPROVIDER ?= "kernel"
+inherit allarch
 
-RDEPENDS_${PN} = " \
-	${DVBPROVIDER}-module-dvb-usb-dtt200u \
+RRECOMMENDS_${PN} = " \
 	firmware-dvb-usb-dtt200u-01 \
 	firmware-dvb-usb-wt220u-02 \
 	firmware-dvb-usb-wt220u-fc03 \
 	firmware-dvb-usb-wt220u-miglia-01 \
 	firmware-dvb-usb-wt220u-zl0353-01 \
+	kernel-module-dvb-usb-dtt200u \
 	"
 
-PV = "1.0"
-PR = "r0"
+PV = "1.1"
 
 ALLOW_EMPTY_${PN} = "1"

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-em28xx.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-em28xx.bb
@@ -2,14 +2,15 @@ DESCRIPTION = "USB DVB driver for EM28xx chipset"
 
 require conf/license/openpli-gplv2.inc
 
-DVBPROVIDER ?= "kernel"
+inherit allarch
 
-RDEPENDS_${PN} = " \
-	${DVBPROVIDER}-module-em28xx-dvb \
+RRECOMMENDS_${PN} = " \
+	kernel-module-cxd2820r \
+	kernel-module-em28xx-dvb \
+	kernel-module-tda10071 \
 	firmware-dvb-fe-tda10071 \
 	"
 
-PV = "1.0"
-PR = "r0"
+PV = "1.1"
 
 ALLOW_EMPTY_${PN} = "1"

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-pctv452e.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-pctv452e.bb
@@ -2,13 +2,12 @@ DESCRIPTION = "USB DVB driver for pctv452e chipsets"
 
 require conf/license/openpli-gplv2.inc
 
-DVBPROVIDER ?= "kernel"
+inherit allarch
 
-RDEPENDS_${PN} = " \
-	${DVBPROVIDER}-module-dvb-usb-pctv452e \
+RRECOMMENDS_${PN} = " \
+	kernel-module-dvb-usb-pctv452e \
 	"
 
-PV = "1.0"
-PR = "r0"
+PV = "1.1"
 
 ALLOW_EMPTY_${PN} = "1"

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-rtl2832.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-rtl2832.bb
@@ -1,24 +1,23 @@
 SUMMARY = "USB DVB driver for Realtek RTL2832 chipset"
-PACKAGE_ARCH = "all"
 
 require conf/license/openpli-gplv2.inc
 
-DVBPROVIDER ?= "kernel"
+inherit allarch
 
 RRECOMMENDS_${PN} = " \
-    ${DVBPROVIDER}-module-dvb-usb-rtl2832 \
-    ${DVBPROVIDER}-module-dvb-usb-rtl28xxu \
-    ${DVBPROVIDER}-module-rtl2832 \
-    ${DVBPROVIDER}-module-e4000 \
-    ${DVBPROVIDER}-module-r820t \
-    ${DVBPROVIDER}-module-mt2266 \
-    ${DVBPROVIDER}-module-fc0013 \
-    firmware-dvb-usb-af9035-01 \
-    firmware-dvb-usb-af9035-02 \
-    firmware-dvb-usb-af9015 \
-    "
+	kernel-module-dvb-usb-rtl2832 \
+	kernel-module-dvb-usb-rtl28xxu \
+	kernel-module-e4000 \
+	kernel-module-fc0012 \
+	kernel-module-fc0013 \
+	kernel-module-mt2266 \
+	kernel-module-r820t \
+	kernel-module-rtl2832 \
+	firmware-dvb-usb-af9015 \
+	firmware-dvb-usb-af9035-01 \
+	firmware-dvb-usb-af9035-02 \
+	"
 
-PV = "1.0"
-PR = "r0"
+PV = "1.1"
 
 ALLOW_EMPTY_${PN} = "1"

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-siano.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-siano.bb
@@ -2,17 +2,17 @@ DESCRIPTION = "USB DVB driver for Siano chipset"
 
 require conf/license/openpli-gplv2.inc
 
-DVBPROVIDER ?= "kernel"
+inherit allarch
 
-RDEPENDS_${PN} = " \
-	${DVBPROVIDER}-module-smsusb \
-	${DVBPROVIDER}-module-smsdvb \
-	firmware-dvb-siano \
+RRECOMMENDS_${PN} = " \
 	firmware-dvb-nova-12mhz-b0 \
+	firmware-dvb-siano \
 	firmware-isdbt-nova-12mhz-b0 \
+	kernel-module-smsdvb \
+	kernel-module-smsmdtv \
+	kernel-module-smsusb \
 	"
 
-PV = "1.0"
-PR = "r5"
+PV = "1.1"
 
 ALLOW_EMPTY_${PN} = "1"


### PR DESCRIPTION
Update several dvb-usb drivers for newer kernels.

Switch provider to kernel (we do not build v4l drivers since OpenPLi 3).
Inherit allarch to create packages once.

Also provide recipe for pctv292e.