### PR TITLE
modifyplifullhd: allarch do not depend on enigma2

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-modifyplifullhd.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-modifyplifullhd.bb
@@ -3,15 +3,9 @@ MAINTAINER = "ims"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=534862957bf314f95d85e0c07632f84d"
 
-OLDPKG = "${@bb.data.getVar('PN',d,1).replace('-extensions-','-pli-')}"
-RREPLACES_${PN} = "${OLDPKG}"
-RCONFLICTS_${PN} = "${OLDPKG}"
-
 inherit gitpkgv
 PV = "2.0+git${SRCPV}"
 PKGV = "2.0+git${GITPKGV}"
-
-DEPENDS += "enigma2"
 
 SRC_URI = "git://github.com/ims21/ModifyPliFullHD.git;protocol=git"
 

--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-refreshbouquet.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-refreshbouquet.bb
@@ -3,15 +3,9 @@ MAINTAINER = "ims(ims21)"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=9432c1f3d564948269193fd19a0ad0fd"
 
-OLDPKG = "${@bb.data.getVar('PN',d,1).replace('-extensions-','-pli-')}"
-RREPLACES_${PN} = "${OLDPKG}"
-RCONFLICTS_${PN} = "${OLDPKG}"
-
 inherit gitpkgv
 PV = "2.0+git${SRCPV}"
 PKGV = "2.0+git${GITPKGV}"
-
-DEPENDS += "enigma2"
 
 SRC_URI = "git://github.com/ims21/RefreshBouquet.git;protocol=git"
 


### PR DESCRIPTION
We don't need to depend on enigma2 becase every time the enigma2 rebuilds
it will cause modifyplifullhd to rebuild.

Also stop replacing/conficting with old plugin name. It's long gone.