### PR TITLE
lcd4linux: change DEPENDS into RDEPENDS

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-lcd4linux.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-lcd4linux.bb
@@ -11,27 +11,21 @@ PKGV = "${PKGVERSION}-${GITPKGV}"
 
 SRC_URI = "git://github.com/eriksl/enigma2-plugin-extensions-lcd4linux-ihad-source-copy.git"
 
-DEPENDS += "\
-	libusb \
-	python-simplejson \
-	png-util \
-	python-pyusb \
-"
-
 RDEPENDS_${PN} += "\
-	python-codecs \
-	python-datetime \
-	python-imaging \
-	python-textutils \
-	python-shell \
-	python-ctypes \
-	python-mutagen \
-	python-zlib \
-	python-email \
-	python-subprocess \
-	python-simplejson \
-	python-pyusb \
+	libusb \
 	png-util \
+	python-codecs \
+	python-ctypes \
+	python-datetime \
+	python-email \
+	python-imaging \
+	python-mutagen \
+	python-pyusb \
+	python-shell \
+	python-simplejson \
+	python-subprocess \
+	python-textutils \
+	python-zlib \
 "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
When using allrch it seems that depending on packages that chang between arch causes
rebuilds on plugins. Change depends into rdepends to solve issue.