### PR TITLE
lcd4linux: nothing provides libusb in runtime remove it

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-lcd4linux.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-lcd4linux.bb
@@ -12,7 +12,6 @@ PKGV = "${PKGVERSION}-${GITPKGV}"
 SRC_URI = "git://github.com/eriksl/enigma2-plugin-extensions-lcd4linux-ihad-source-copy.git"
 
 RDEPENDS_${PN} += "\
-	libusb \
 	png-util \
 	python-codecs \
 	python-ctypes \


### PR DESCRIPTION
Although we can depend on libusb, in runtime nothing provides libusb.
Remove it to allow building and restore the required runtime dependency if any.