### PR TITLE
firewall: remove depends to iptables and virtual/kernel

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-security-firewall.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-security-firewall.bb
@@ -2,7 +2,6 @@ DESCRIPTION = "Firewall"
 
 require conf/license/openpli-gplv2.inc
 
-DEPENDS = "iptables virtual/kernel"
 RDEPENDS_${PN} = "iptables kernel-module-ip-tables kernel-module-ip-conntrack kernel-module-ipt-reject kernel-module-ipt-state kernel-module-iptable-filter"
 
 SRC_URI = "file://firewall.sh file://firewall.users"


### PR DESCRIPTION
We don't really depend on those packages to build an allarch package.
The runtime depends will add required iptables and kernel modules.