### PR TITLE
dreambox: get rid of warning dvb-modules

### DIFF
--- a/meta-dream/recipes-bsp/drivers/dreambox-dvb-modules.inc
+++ b/meta-dream/recipes-bsp/drivers/dreambox-dvb-modules.inc
@@ -37,3 +37,4 @@ DRIVERDATE = "${@'${PV}'.split('-')[-1]}"
 FILESEXTRAPATHS_prepend := "${THISDIR}/dreambox-dvb-modules:"
 
 FILES_${PN} += "${sysconfdir}/modules-load.d/${PN}.conf"
+FILES_${PN} += "/lib/modules/${DM_LOCALVERSION}/extra/LICENSE"


### PR DESCRIPTION
WARNING: dreambox-dvb-modules-dm8000-3.2-20140604a-r7.0 do_package: QA Issue: dreambox-dvb-modules-dm8000:
Files/directories were installed but not shipped in any package:
/lib/modules/3.2-dm8000/extra/LICENSE
Please set FILES such that these items are packaged. Alternatively if they are unneeded, avoid installing them or delete them within do_install.
dreambox-dvb-modules-dm8000: 1 installed and not shipped files. [installed-vs-shipped]