### PR TITLE
dmm: get rid of warning dvb-modules

### DIFF
--- a/meta-dream/recipes-bsp/drivers/dreambox-dvb-modules.inc
+++ b/meta-dream/recipes-bsp/drivers/dreambox-dvb-modules.inc
@@ -21,7 +21,6 @@ do_install() {
 	install -d ${D}${sysconfdir}/modules-load.d
 	install -m 0644 ${WORKDIR}/modules ${D}${sysconfdir}/modules-load.d/${PN}.conf
 	install -d ${D}/lib/modules/${DM_LOCALVERSION}/extra
-	install -m 0644 ${WORKDIR}/LICENSE ${D}/lib/modules/${DM_LOCALVERSION}/extra
 	install -m 0644 ${WORKDIR}/*.ko ${D}/lib/modules/${DM_LOCALVERSION}/extra
 }
 


### PR DESCRIPTION
No need to install license file.
This prevent warning:
WARNING: dreambox-dvb-modules-dm8000-3.2-20140604a-r7.0 do_package: QA Issue: dreambox-dvb-modules-dm8000:
Files/directories were installed but not shipped in any package:
/lib/modules/3.2-dm8000/extra/LICENSE
Please set FILES such that these items are packaged. Alternatively if they are unneeded, avoid installing them or delete them within do_install.
dreambox-dvb-modules-dm8000: 1 installed and not shipped files. [installed-vs-shipped]