### PR TITLE
dvb-usb-meta: move common parts in a single include file

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/dvb-usb-drivers-meta.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/dvb-usb-drivers-meta.bb
@@ -1,8 +1,6 @@
 DESCRIPTION = "meta file for USB DVB drivers"
 
-require conf/license/openpli-gplv2.inc
-
-inherit allarch
+require dvb-usb-drivers-meta.inc
 
 DEPENDS = "\
 	enigma2-plugin-drivers-atsc-usb-hauppauge \

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/dvb-usb-drivers-meta.inc
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/dvb-usb-drivers-meta.inc
@@ -1,0 +1,15 @@
+require conf/license/openpli-gplv2.inc
+
+inherit allarch
+
+PACKAGES = "${PN}"
+ALLOW_EMPTY_${PN} = "1"
+
+# We only need the packaging tasks - disable the rest
+do_fetch[noexec] = "1"
+do_unpack[noexec] = "1"
+do_patch[noexec] = "1"
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+do_install[noexec] = "1"
+do_populate_sysroot[noexec] = "1"

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-atsc-usb-hauppauge-950q.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-atsc-usb-hauppauge-950q.bb
@@ -1,8 +1,6 @@
 DESCRIPTION = "USB ATSC driver for Hauppauge 950Q WinTV-HVR Tuners"
 
-require conf/license/openpli-gplv2.inc
-
-inherit allarch
+require dvb-usb-drivers-meta.inc
 
 RRECOMMENDS_${PN} = " \
 	kernel-module-au0828 \
@@ -15,5 +13,3 @@ RRECOMMENDS_${PN} = " \
 	"
 
 PV = "1.0"
-
-ALLOW_EMPTY_${PN} = "1"

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-atsc-usb-hauppauge-955q.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-atsc-usb-hauppauge-955q.bb
@@ -1,8 +1,6 @@
 DESCRIPTION = "USB ATSC driver for Hauppauge 955Q WinTV-HVR Tuners"
 
-require conf/license/openpli-gplv2.inc
-
-inherit allarch
+require dvb-usb-drivers-meta.inc
 
 RRECOMMENDS_${PN} = " \
 	kernel-module-cx231xx \
@@ -15,5 +13,3 @@ RRECOMMENDS_${PN} = " \
 	"
 
 PV = "1.0"
-
-ALLOW_EMPTY_${PN} = "1"

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-atsc-usb-hauppauge.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-atsc-usb-hauppauge.bb
@@ -1,8 +1,6 @@
 DESCRIPTION = "USB ATSC driver for Hauppauge WinTV-HVR Tuners"
 
-require conf/license/openpli-gplv2.inc
-
-inherit allarch
+require dvb-usb-drivers-meta.inc
 
 RRECOMMENDS_${PN} = " \
 	kernel-module-au0828 \
@@ -19,5 +17,3 @@ RRECOMMENDS_${PN} = " \
 	"
 
 PV = "1.0"
-
-ALLOW_EMPTY_${PN} = "1"

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-ct2-dvb-usb-pctv292e.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-ct2-dvb-usb-pctv292e.bb
@@ -1,8 +1,6 @@
 DESCRIPTION = "USB DVB driver for pctv292e chipsets"
 
-require conf/license/license-gplv2.inc
-
-inherit allarch
+require dvb-usb-drivers-meta.inc
 
 RRECOMMENDS_${PN} = " \
 	firmware-dvb-demod-si2168-b40 \
@@ -14,5 +12,3 @@ RRECOMMENDS_${PN} = " \
 	"
 
 PV = "1.0"
-
-ALLOW_EMPTY_${PN} = "1"

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-ct2-usb-dvbsky-t330.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-ct2-usb-dvbsky-t330.bb
@@ -1,8 +1,6 @@
 DESCRIPTION = "USB dvbsky driver for T330"
 
-require conf/license/openpli-gplv2.inc
-
-inherit allarch
+require dvb-usb-drivers-meta.inc
 
 RRECOMMENDS_${PN} = " \
 	kernel-module-dvb-usb-dvbsky \
@@ -12,5 +10,3 @@ RRECOMMENDS_${PN} = " \
 	"
 
 PV = "1.0"
-
-ALLOW_EMPTY_${PN} = "1"

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-ct2-usb-geniatech-t230.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-ct2-usb-geniatech-t230.bb
@@ -1,8 +1,6 @@
 DESCRIPTION = "USB geniatech driver for T230"
 
-require conf/license/openpli-gplv2.inc
-
-inherit allarch
+require dvb-usb-drivers-meta.inc
 
 RRECOMMENDS_${PN} = " \
 	kernel-module-dvb-usb-cxusb \
@@ -12,5 +10,3 @@ RRECOMMENDS_${PN} = " \
 	"
 
 PV = "1.0"
-
-ALLOW_EMPTY_${PN} = "1"

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-af9015.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-af9015.bb
@@ -1,8 +1,6 @@
 DESCRIPTION = "USB DVB driver for Afatech 9015 chipset"
 
-require conf/license/openpli-gplv2.inc
-
-inherit allarch
+require dvb-usb-drivers-meta.inc
 
 RRECOMMENDS_${PN} = " \
 	firmware-dvb-fe-af9013 \
@@ -22,5 +20,3 @@ RRECOMMENDS_${PN} = " \
 	"
 
 PV = "1.1"
-
-ALLOW_EMPTY_${PN} = "1"

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-af9035.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-af9035.bb
@@ -1,8 +1,6 @@
 DESCRIPTION = "USB DVB driver for af9035 devices"
 
-require conf/license/openpli-gplv2.inc
-
-inherit allarch
+require dvb-usb-drivers-meta.inc
 
 RRECOMMENDS_${PN} = " \
 	firmware-dvb-usb-af9035-01 \
@@ -17,5 +15,3 @@ RRECOMMENDS_${PN} = " \
 	"
 
 PV = "1.3"
-
-ALLOW_EMPTY_${PN} = "1"

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-as102.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-as102.bb
@@ -1,8 +1,6 @@
 DESCRIPTION = "USB DVB driver for AS102 chipset"
 
-require conf/license/openpli-gplv2.inc
-
-inherit allarch
+require dvb-usb-drivers-meta.inc
 
 RRECOMMENDS_${PN} = " \
 	firmware-as102-data1-st \
@@ -12,5 +10,3 @@ RRECOMMENDS_${PN} = " \
 	"
 
 PV = "1.1"
-
-ALLOW_EMPTY_${PN} = "1"

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-dib0700.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-dib0700.bb
@@ -1,8 +1,6 @@
 DESCRIPTION = "USB DVB driver for dib0700 chipset"
 
-require conf/license/openpli-gplv2.inc
-
-inherit allarch
+require dvb-usb-drivers-meta.inc
 
 RRECOMMENDS_${PN} = " \
 	firmware-dvb-usb-dib0700-1.20 \
@@ -30,5 +28,3 @@ RRECOMMENDS_${PN} = " \
 	"
 
 PV = "1.1"
-
-ALLOW_EMPTY_${PN} = "1"

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-dtt200u.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-dtt200u.bb
@@ -1,8 +1,6 @@
 DESCRIPTION = "USB DVB driver for dtt200u chipsets"
 
-require conf/license/openpli-gplv2.inc
-
-inherit allarch
+require dvb-usb-drivers-meta.inc
 
 RRECOMMENDS_${PN} = " \
 	firmware-dvb-usb-dtt200u-01 \
@@ -14,5 +12,3 @@ RRECOMMENDS_${PN} = " \
 	"
 
 PV = "1.1"
-
-ALLOW_EMPTY_${PN} = "1"

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-dw2102.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-dw2102.bb
@@ -1,8 +1,6 @@
 DESCRIPTION = "USB DVB driver for DW210x/DW310x chipset"
 
-require conf/license/openpli-gplv2.inc
-
-inherit allarch
+require dvb-usb-drivers-meta.inc
 
 RRECOMMENDS_${PN} = " \
 	kernel-module-dvb-usb-dw2102 \
@@ -13,5 +11,3 @@ RRECOMMENDS_${PN} = " \
 	"
 
 PV = "1.1"
-
-ALLOW_EMPTY_${PN} = "1"

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-em28xx.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-em28xx.bb
@@ -1,8 +1,6 @@
 DESCRIPTION = "USB DVB driver for EM28xx chipset"
 
-require conf/license/openpli-gplv2.inc
-
-inherit allarch
+require dvb-usb-drivers-meta.inc
 
 RRECOMMENDS_${PN} = " \
 	kernel-module-cxd2820r \
@@ -12,5 +10,3 @@ RRECOMMENDS_${PN} = " \
 	"
 
 PV = "1.1"
-
-ALLOW_EMPTY_${PN} = "1"

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-it913x.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-it913x.bb
@@ -1,8 +1,6 @@
 DESCRIPTION = "USB DVB driver for it913x chipsets"
 
-require conf/license/openpli-gplv2.inc
-
-inherit allarch
+require dvb-usb-drivers-meta.inc
 
 RRECOMMENDS_${PN} = " \
         firmware-dvb-usb-af9035-01 \
@@ -16,5 +14,3 @@ RRECOMMENDS_${PN} = " \
 	"
 
 PV = "1.1"
-
-ALLOW_EMPTY_${PN} = "1"

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-pctv452e.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-pctv452e.bb
@@ -1,13 +1,9 @@
 DESCRIPTION = "USB DVB driver for pctv452e chipsets"
 
-require conf/license/openpli-gplv2.inc
-
-inherit allarch
+require dvb-usb-drivers-meta.inc
 
 RRECOMMENDS_${PN} = " \
 	kernel-module-dvb-usb-pctv452e \
 	"
 
 PV = "1.1"
-
-ALLOW_EMPTY_${PN} = "1"

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-rtl2832.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-rtl2832.bb
@@ -1,8 +1,6 @@
 SUMMARY = "USB DVB driver for Realtek RTL2832 chipset"
 
-require conf/license/openpli-gplv2.inc
-
-inherit allarch
+require dvb-usb-drivers-meta.inc
 
 RRECOMMENDS_${PN} = " \
 	kernel-module-dvb-usb-rtl2832 \
@@ -19,5 +17,3 @@ RRECOMMENDS_${PN} = " \
 	"
 
 PV = "1.1"
-
-ALLOW_EMPTY_${PN} = "1"

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-siano.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-siano.bb
@@ -1,8 +1,6 @@
 DESCRIPTION = "USB DVB driver for Siano chipset"
 
-require conf/license/openpli-gplv2.inc
-
-inherit allarch
+require dvb-usb-drivers-meta.inc
 
 RRECOMMENDS_${PN} = " \
 	firmware-dvb-nova-12mhz-b0 \
@@ -14,5 +12,3 @@ RRECOMMENDS_${PN} = " \
 	"
 
 PV = "1.1"
-
-ALLOW_EMPTY_${PN} = "1"

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-tbs.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-tbs.bb
@@ -1,8 +1,6 @@
 DESCRIPTION = "USB DVB driver for TBS Tuners"
 
-require conf/license/openpli-gplv2.inc
-
-inherit allarch
+require dvb-usb-drivers-meta.inc
 
 RRECOMMENDS_${PN} = " \
 	kernel-module-dvb-usb-tbsusb \
@@ -18,5 +16,3 @@ RRECOMMENDS_${PN} = " \
 	"
 
 PV = "1.1"
-
-ALLOW_EMPTY_${PN} = "1"

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-technisat-skystar.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-technisat-skystar.bb
@@ -1,8 +1,6 @@
 DESCRIPTION = "USB DVB driver for Technisat Skystar HD"
 
-require conf/license/openpli-gplv2.inc
-
-inherit allarch
+require dvb-usb-drivers-meta.inc
 
 RRECOMMENDS_${PN} = " \
 	blindscan-s2 \
@@ -13,5 +11,3 @@ RRECOMMENDS_${PN} = " \
 	"
 
 PV = "1.0"
-
-ALLOW_EMPTY_${PN} = "1"

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-s2-usb-dvbsky-s960.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-s2-usb-dvbsky-s960.bb
@@ -1,8 +1,6 @@
 DESCRIPTION = "USB dvbsky driver for S960"
 
-require conf/license/openpli-gplv2.inc
-
-inherit allarch
+require dvb-usb-drivers-meta.inc
 
 RRECOMMENDS_${PN} = " \
 	kernel-module-dvb-usb-dvbsky \
@@ -11,5 +9,3 @@ RRECOMMENDS_${PN} = " \
 	"
 
 PV = "1.0"
-
-ALLOW_EMPTY_${PN} = "1"


### PR DESCRIPTION
Create dvb-usb-drivers-meta.inc and move common parts.
Also don't create dev/dbg packages.
Finally disable tasks not required to create those packages.