### PR TITLE
gstplayer: add LDFLAGS when building

### DIFF
--- a/meta-openpli/recipes-multimedia/gstplayer/gstplayer_0.1.bb
+++ b/meta-openpli/recipes-multimedia/gstplayer/gstplayer_0.1.bb
@@ -15,7 +15,7 @@ S = "${WORKDIR}/git/"
 
 do_compile() {
     cd ${S}/gstplayer/gst-1.0
-    ${CC} *.c ../common/*.c -I../common/ `pkg-config --cflags --libs gstreamer-1.0 gstreamer-pbutils-1.0` -o gstplayer_gst-1.0
+    ${CC} *.c ../common/*.c -I../common/ `pkg-config --cflags --libs gstreamer-1.0 gstreamer-pbutils-1.0` -o gstplayer_gst-1.0 ${LDFLAGS}
 }
 
 do_install() {


### PR DESCRIPTION
It fixes the following warning:
WARNING: gstplayer-0.1-r0 do_package_qa: QA Issue: No GNU_HASH in the elf binary: '/.../armv7ahf-neon-oe-linux-gnueabi/gstplayer/0.1-r0/packages-split/gstplayer/usr/bin/gstplayer' [ldflags]