### PR TITLE
readymedia: add missing depends

### DIFF
--- a/meta-openpli/recipes-multimedia/readymedia/readymedia.bb
+++ b/meta-openpli/recipes-multimedia/readymedia/readymedia.bb
@@ -11,7 +11,7 @@ inherit gitpkgv
 PV = "1.1.0+git${SRCPV}"
 PKGV = "1.1.0+git${GITPKGV}"
 PR = "r0"
-DEPENDS = "libexif libav"
+DEPENDS = "libexif libav libjpeg-turbo libvorbis flac libid3tag sqlite3"
 
 SRC_URI = "git://git.code.sf.net/p/minidlna/git;protocol=git \
 			file://readymedia.sh \


### PR DESCRIPTION
Fixes the following warnings:
readymedia-1.1.0+gitAUTOINC+5450ac486e: readymedia rdepends on libjpeg-turbo, but it isn't a build dependency, missing libjpeg-turbo in DEPENDS or PACKAGECONFIG? [build-deps]
readymedia-1.1.0+gitAUTOINC+5450ac486e: readymedia rdepends on libvorbis, but it isn't a build dependency, missing libvorbis in DEPENDS or PACKAGECONFIG? [build-deps]
readymedia-1.1.0+gitAUTOINC+5450ac486e: readymedia rdepends on libflac, but it isn't a build dependency, missing flac in DEPENDS or PACKAGECONFIG? [build-deps]
readymedia-1.1.0+gitAUTOINC+5450ac486e: readymedia rdepends on libid3tag, but it isn't a build dependency, missing libid3tag in DEPENDS or PACKAGECONFIG? [build-deps]
readymedia-1.1.0+gitAUTOINC+5450ac486e: readymedia rdepends on libsqlite3, but it isn't a build dependency, missing sqlite3 in DEPENDS or PACKAGECONFIG? [build-deps]