### PR TITLE
Fix some URLs

### DIFF
--- a/meta-openpli/recipes-connectivity/pyload/pyload.bb
+++ b/meta-openpli/recipes-connectivity/pyload/pyload.bb
@@ -25,7 +25,7 @@ PR = "r1"
 
 inherit update-rc.d
 
-SRC_URI = "https://github.com/pyload/pyload/releases/download/v${PV}/pyload-src-v${PV}.zip \
+SRC_URI = "http://sources.openelec.tv/mirror/pyload/pyload-src-v${PV}.zip \
   file://pyload.init \
   file://pyload.tar.gz.defaults"
 SRC_URI[md5sum] = "28876150af22999b6f539c8579d3b415"

--- a/meta-openpli/recipes-multimedia/dvbtools/wscan_20170107.bb
+++ b/meta-openpli/recipes-multimedia/dvbtools/wscan_20170107.bb
@@ -7,8 +7,8 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=892f569a555ba9c07a568a7c0c4fa63a"
 
 SRC_URI = "http://wirbel.htpc-forum.de/w_scan/w_scan-${PV}.tar.bz2"
 
-SRC_URI[md5sum] = "57aa860b4c9e6aa480ca6eb0504bd4f5"
-SRC_URI[sha256sum] = "2077af7f8b42b7af038e83abf0565f96f59461bbc5e14c4516b68f50b5c00d79"
+SRC_URI[md5sum] = "c7f9adf92d46b8da5391be80be6fbd72"
+SRC_URI[sha256sum] = "38e0f38a7bf06cff6d6ea01652ad4ee60da2cb0e937360468f936da785b46ffe"
 
 S = "${WORKDIR}/w_scan-${PV}"
 

--- a/meta-openpli/recipes-support/libev/libev_4.24.bb
+++ b/meta-openpli/recipes-support/libev/libev_4.24.bb
@@ -6,9 +6,8 @@ SRC_URI = "http://dist.schmorp.de/libev/libev-${PV}.tar.gz"
 
 inherit autotools
 
-SRC_URI[md5sum] = "f1dbf786ead8307e0d4f5f68f2f8526c"
-SRC_URI[sha256sum] = "c7fe743e0c3b50dd34bf222ebdba4e8acac031d41ce174f17890f8f84eeddd7a"
-
+SRC_URI[md5sum] = "94459a5a22db041dec6f98424d6efe54"
+SRC_URI[sha256sum] = "973593d3479abdf657674a55afe5f78624b0e440614e2b8cb3a07f16d4d7f821"
 
 do_compile_prepend() {
 	sed -i 's#include_HEADERS = ev.h ev++.h event.h#include_HEADERS = ev.h ev++.h#' ${S}/Makefile.*


### PR DESCRIPTION
This will make the develop branch of openpli-oe-core build openpli-enigma2-feed again from scratch.
- Update libev to 4.24 (4.23 doesn't exist anymore on the server)
- Update w_scan to 20170107 (20161022 doesn't exist anymore on the server)
- Update the URL for pyload-src-v0.4.9.zip. (github doesn't host it anymore for some reason so let's use the openelec.tv mirror)