### PR TITLE
lcd4linux: build pydpflib from sources and update to 4.8-r2

### DIFF
--- a/meta-openpli/recipes-extended/pydpflib/pydpflib.bb
+++ b/meta-openpli/recipes-extended/pydpflib/pydpflib.bb
@@ -1,0 +1,21 @@
+DESCRIPTION = "DPF access extension module"
+MAINTAINER = "https://sourceforge.net/projects/pydpf/"
+LICENSE = "LGPLv2"
+LIC_FILES_CHKSUM = "file://PKG-INFO;md5=6a256fd20875b5cf06888bbcbe1a21aa"
+
+SRC_URI = "git://github.com/athoik/pydpflib.git;protocol=http"
+SRCREV = "${AUTOREV}"
+
+DEPENDS = "libusb"
+
+S = "${WORKDIR}/git"
+
+inherit gitpkgv setuptools
+
+PV = "0.14+git${SRCPV}"
+PKGV = "0.14+git${GITPKGV}"
+PR = "r0"
+
+do_compile_prepend() {
+    $MAKE -C ./dpf-ax/dpflib all
+}

--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-lcd4linux.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-lcd4linux.bb
@@ -5,7 +5,7 @@ MAINTAINER = "PLi team"
 LICENSE = "NPOSL-3.0"
 LIC_FILES_CHKSUM = "file://usr/lib/enigma2/python/Plugins/Extensions/LCD4linux/LICENSE;md5=a06300d1389bd32f84faeb97b6f6771f"
 
-PKGVERSION = "4.7-r6"
+PKGVERSION = "4.8-r2"
 PV = "${PKGVERSION}-${SRCPV}"
 PKGV = "${PKGVERSION}-${GITPKGV}"
 
@@ -13,6 +13,7 @@ SRC_URI = "git://github.com/eriksl/enigma2-plugin-extensions-lcd4linux-ihad-sour
 
 RDEPENDS_${PN} += "\
 	png-util \
+	pydpflib \
 	python-codecs \
 	python-ctypes \
 	python-datetime \


### PR DESCRIPTION
Requires also https://github.com/eriksl/enigma2-plugin-extensions-lcd4linux-ihad-source-copy/pull/2