### PR TITLE
gstplayer: add simlink to gstplayer_gst-1.0

### DIFF
--- a/meta-openpli/recipes-multimedia/gstplayer/gstplayer_0.1.bb
+++ b/meta-openpli/recipes-multimedia/gstplayer/gstplayer_0.1.bb
@@ -22,3 +22,7 @@ do_install() {
     install -d ${D}${bindir}
     install -m 0755 ${S}/gstplayer/gst-1.0/gstplayer_gst-1.0 ${D}${bindir}/gstplayer
 }
+
+pkg_postinst_${PN}() {
+    ln -s gstplayer $D${bindir}/gstplayer_gst-1.0
+}


### PR DESCRIPTION
It seems that after https://github.com/OpenPLi/openpli-oe-core/commit/c59385c4609b2e431692465a6c6bfce3fff18cd2 the serviceapp fails to locate gstplayer.

So with gstplayer IPTVPlayer works, with gstplayer_gst-1.0 serviceapp works.
With simlink hopefully both will work.