### PR TITLE
libbluray: remove unrecognised configure option

### DIFF
--- a/meta-openpli/recipes-support/libbluray/libbluray_git.bb
+++ b/meta-openpli/recipes-support/libbluray/libbluray_git.bb
@@ -20,7 +20,6 @@ PKGV = "v0.9.3+git2490+efcde25"
 S="${WORKDIR}/git"
 
 EXTRA_OECONF = " \
-    --disable-bdjava \
     --disable-bdjava-jar \
     --disable-doxygen-doc \
     --disable-doxygen-dot \


### PR DESCRIPTION
This prevents warning:
WARNING: libbluray-v1.0.0+gitAUTOINC+da27917598-r0 do_configure: QA Issue:
libbluray: configure was passed unrecognised options: --disable-bdjava [unknown-configure-option]

http://git.videolan.org/?p=libbluray.git;a=commit;h=415da3663a1ff2a935d4a36417f4f46bf2b947d2