### PR TITLE
serviceapp: change PACKAGE_ARCH to MACHINE_ARCH

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-systemplugins-serviceapp.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-systemplugins-serviceapp.bb
@@ -3,7 +3,7 @@ AUTHOR = "Maroš Ondrášek <mx3ldev@gmail.com>"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-#PACKAGE_ARCH = "${MACHINE_ARCH}"
+PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 DEPENDS = "enigma2 uchardet openssl"
 RDEPENDS_${PN} = "enigma2 uchardet openssl"


### PR DESCRIPTION
Any package that depends on arch that has MACHINE_ARCH (like enigma2)
will force rebuild every time MACHINE changes.

Change serviceapp to MACHINE_ARCH to build once for every MACHINE
without getting version going backwards on every build.