### PR TITLE
libbluray: bump to version 1.0.0

### DIFF
--- a/meta-openpli/recipes-support/libbluray/libbluray_git.bb
+++ b/meta-openpli/recipes-support/libbluray/libbluray_git.bb
@@ -10,12 +10,8 @@ SRC_URI = "gitsm://git.videolan.org/libbluray.git"
 
 inherit gitpkgv autotools-brokensep pkgconfig
 
-# Set PV and PKGV manualy on OE before https://github.com/openembedded/meta-openembedded/commit/22004e5281a913818a94bcd160ad3135a9ecd314
-# Remove this after meta-openembedded update
-#PV = "v0.9.3+git${SRCPV}"
-#PKGV = "v0.9.3+git${GITPKGV}"
-PV = "v0.9.3+git2490+efcde25"
-PKGV = "v0.9.3+git2490+efcde25"
+PV = "v1.0.0+git${SRCPV}"
+PKGV = "v1.0.0+git${GITPKGV}"
 
 S="${WORKDIR}/git"
 


### PR DESCRIPTION
We are beyond that commit in meta-openembedded and git head is version 1.0.0 now.