### PR TITLE
dvb-usb: add mn88473 firmware

### DIFF
--- a/meta-openpli/conf/distro/reporefs.conf
+++ b/meta-openpli/conf/distro/reporefs.conf
@@ -143,6 +143,7 @@ SRCREV_pn-firmware-dvb-usb-dib0700-03-pre1 = "${AUTOREV}"
 SRCREV_pn-firmware-sms1xxx-nova-a-dvbt-01 = "${AUTOREV}"
 SRCREV_pn-firmware-xc5000c = "${AUTOREV}"
 SRCREV_pn-firmware-dvb-usb-technisat-skystar = "${AUTOREV}"
+SRCREV_pn-firmware-dvb-demod-mn88473-01 = "${AUTOREV}"
 
 SRCREV_pn-ofgwrite = "${AUTOREV}"
 

--- a/meta-openpli/recipes-linux/linux-firmwares/firmware-dvb-demod-mn88473-01.bb
+++ b/meta-openpli/recipes-linux/linux-firmwares/firmware-dvb-demod-mn88473-01.bb
@@ -1,0 +1,8 @@
+require linux-firmware.inc
+
+DESCRIPTION = "Firmware for demod mn88473"
+
+do_install() {
+	install -d ${D}${base_libdir}/firmware
+	install -m 0644 dvb-demod-mn88473-01.fw ${D}${base_libdir}/firmware
+}

--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-rtl2832.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-dvb-usb-rtl2832.bb
@@ -11,6 +11,7 @@ RRECOMMENDS_${PN} = " \
 	kernel-module-mt2266 \
 	kernel-module-r820t \
 	kernel-module-rtl2832 \
+	firmware-dvb-demod-mn88473-01 \
 	firmware-dvb-usb-af9015 \
 	firmware-dvb-usb-af9035-01 \
 	firmware-dvb-usb-af9035-02 \


### PR DESCRIPTION
Required for Astrometa T2 devices.
More info: https://forums.openpli.org/topic/35710-astrometa-dvb-tt2c-mn88472mn88473/page-5