### PR TITLE
mpg123: silence mpg123 rdepends on libltdl warning

### DIFF
--- a/meta-openpli/recipes-multimedia/mpg123/mpg123_1.23.%.bbappend
+++ b/meta-openpli/recipes-multimedia/mpg123/mpg123_1.23.%.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS_${PN} = " libltdl "


### PR DESCRIPTION
To prevent warning:
mpg123-1.23.6-r0 do_package_qa: QA Issue: mpg123 rdepends on libltdl, but it isn't a build dependency,
missing libtool in DEPENDS or PACKAGECONFIG? [build-deps]