### PR TITLE
dreambox-blindscan-utils: silence already stripped warning

### DIFF
--- a/meta-dream/recipes-bsp/drivers/dreambox-blindscan-utils_1.9.bb
+++ b/meta-dream/recipes-bsp/drivers/dreambox-blindscan-utils_1.9.bb
@@ -5,6 +5,7 @@ PROVIDES += "virtual/blindscan-dvbs virtual/blindscan-dvbc"
 RPROVIDES_${PN} += "virtual/blindscan-dvbs virtual/blindscan-dvbc"
 
 DEPENDS = "ncurses"
+INSANE_SKIP_${PN} += "already-stripped"
 
 SRC_URI += "http://dreamboxupdate.com/download/opendreambox/2.0.0/blindscan-utils/blindscan-utils_${PV}_${TUNE_PKGARCH}.tar.bz2;name=${TUNE_PKGARCH}"
 


### PR DESCRIPTION
To prevent warning:
WARNING: dreambox-blindscan-utils-1.9-r0 do_package: QA Issue: File '/usr/bin/blindscan' from dreambox-blindscan-utils
was already stripped, this will prevent future debugging! [already-stripped]