### PR TITLE
libdvdnav: bump to version 5.0.4

### DIFF
--- a/meta-openpli/recipes-multimedia/libdvdnav/libdvdnav.bb
+++ b/meta-openpli/recipes-multimedia/libdvdnav/libdvdnav.bb
@@ -3,7 +3,7 @@ SECTION = "libs/multimedia"
 LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
 DEPENDS = "libdvdread"
-PV = "5.0.2"
+PV = "5.0.4"
 
 inherit autotools pkgconfig git-project
 


### PR DESCRIPTION
git head is version 5.0.4, not 5.0.2.
https://github.com/mirror/libdvdnav/commit/c9651ff16663d039b2fdf4a5989c5eea35919c2e