### PR TITLE
Upgrade gstreamer to version 1.12.0

### DIFF
--- a/meta-openpli/recipes-multimedia/gstreamer/files/0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch
+++ b/meta-openpli/recipes-multimedia/gstreamer/files/0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch
@@ -1,0 +1,42 @@
+From 90916f96262fa7b27a0a99788c69f9fd6df11000 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Tue, 24 Nov 2015 16:46:27 +0200
+Subject: [PATCH] introspection.m4: prefix pkgconfig paths with
+ PKG_CONFIG_SYSROOT_DIR
+
+We can't use our tweaked introspection.m4 from gobject-introspection tarball
+because gstreamer also defines INTROSPECTION_INIT in its introspection.m4, which
+is later supplied to g-ir-scanner.
+
+Upstream-Status: Pending [review on oe-core list]
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+---
+ common/m4/introspection.m4 | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/common/m4/introspection.m4 b/common/m4/introspection.m4
+index 162be57..217a6ae 100644
+--- a/common/m4/introspection.m4
++++ b/common/m4/introspection.m4
+@@ -54,14 +54,14 @@ m4_define([_GOBJECT_INTROSPECTION_CHECK_INTERNAL],
+     INTROSPECTION_GIRDIR=
+     INTROSPECTION_TYPELIBDIR=
+     if test "x$found_introspection" = "xyes"; then
+-       INTROSPECTION_SCANNER=`$PKG_CONFIG --variable=g_ir_scanner gobject-introspection-1.0`
+-       INTROSPECTION_COMPILER=`$PKG_CONFIG --variable=g_ir_compiler gobject-introspection-1.0`
+-       INTROSPECTION_GENERATE=`$PKG_CONFIG --variable=g_ir_generate gobject-introspection-1.0`
++       INTROSPECTION_SCANNER=$PKG_CONFIG_SYSROOT_DIR`$PKG_CONFIG --variable=g_ir_scanner gobject-introspection-1.0`
++       INTROSPECTION_COMPILER=$PKG_CONFIG_SYSROOT_DIR`$PKG_CONFIG --variable=g_ir_compiler gobject-introspection-1.0`
++       INTROSPECTION_GENERATE=$PKG_CONFIG_SYSROOT_DIR`$PKG_CONFIG --variable=g_ir_generate gobject-introspection-1.0`
+        INTROSPECTION_GIRDIR=`$PKG_CONFIG --variable=girdir gobject-introspection-1.0`
+        INTROSPECTION_TYPELIBDIR="$($PKG_CONFIG --variable=typelibdir gobject-introspection-1.0)"
+        INTROSPECTION_CFLAGS=`$PKG_CONFIG --cflags gobject-introspection-1.0`
+        INTROSPECTION_LIBS=`$PKG_CONFIG --libs gobject-introspection-1.0`
+-       INTROSPECTION_MAKEFILE=`$PKG_CONFIG --variable=datadir gobject-introspection-1.0`/gobject-introspection-1.0/Makefile.introspection
++       INTROSPECTION_MAKEFILE=$PKG_CONFIG_SYSROOT_DIR`$PKG_CONFIG --variable=datadir gobject-introspection-1.0`/gobject-introspection-1.0/Makefile.introspection
+        INTROSPECTION_INIT="extern void gst_init(gint*,gchar**); gst_init(NULL,NULL);"
+     fi
+     AC_SUBST(INTROSPECTION_SCANNER)
+-- 
+2.6.2
+

--- a/meta-openpli/recipes-multimedia/gstreamer/gst-plugins-package.inc
+++ b/meta-openpli/recipes-multimedia/gstreamer/gst-plugins-package.inc
@@ -1,0 +1,57 @@
+PACKAGESPLITFUNCS_prepend = " split_gstreamer10_packages "
+PACKAGESPLITFUNCS_append = " set_metapkg_rdepends "
+
+python split_gstreamer10_packages () {
+    gst_libdir = d.expand('${libdir}/gstreamer-${LIBV}')
+    postinst = d.getVar('plugin_postinst', True)
+    glibdir = d.getVar('libdir', True)
+
+    do_split_packages(d, glibdir, '^lib(.*)\.so\.*', 'lib%s', 'gstreamer %s library', extra_depends='', allow_links=True)
+    do_split_packages(d, gst_libdir, 'libgst(.*)\.so$', d.expand('${PN}-%s'), 'GStreamer plugin for %s', postinst=postinst, extra_depends='')
+    do_split_packages(d, glibdir+'/girepository-1.0', 'Gst(.*)-1.0\.typelib$', d.expand('${PN}-%s-typelib'), 'GStreamer typelib file for %s', postinst=postinst, extra_depends='')
+    do_split_packages(d, gst_libdir, 'libgst(.*)\.la$', d.expand('${PN}-%s-dev'), 'GStreamer plugin for %s (development files)', extra_depends=d.expand('${PN}-dev'))
+    do_split_packages(d, gst_libdir, 'libgst(.*)\.a$', d.expand('${PN}-%s-staticdev'), 'GStreamer plugin for %s (static development files)', extra_depends=d.expand('${PN}-staticdev'))
+}
+
+python set_metapkg_rdepends () {
+    import os
+
+    pn = d.getVar('PN', True)
+    metapkg =  pn + '-meta'
+    d.setVar('ALLOW_EMPTY_' + metapkg, "1")
+    d.setVar('FILES_' + metapkg, "")
+    blacklist = [ pn, pn + '-locale', pn + '-dev', pn + '-dbg', pn + '-doc', pn + '-meta' ]
+    metapkg_rdepends = []
+    packages = d.getVar('PACKAGES', True).split()
+    pkgdest = d.getVar('PKGDEST', True)
+    for pkg in packages[1:]:
+        if not pkg in blacklist and not pkg in metapkg_rdepends and not pkg.endswith('-dev') and not pkg.endswith('-dbg') and not pkg.count('locale') and not pkg.count('-staticdev'):
+            # See if the package is empty by looking at the contents of its PKGDEST subdirectory. 
+            # If this subdirectory is empty, then the package is.
+            # Empty packages do not get added to the meta package's RDEPENDS
+            pkgdir = os.path.join(pkgdest, pkg)
+            if os.path.exists(pkgdir):
+                dir_contents = os.listdir(pkgdir) or []
+            else:
+                dir_contents = []
+            is_empty = len(dir_contents) == 0
+            if not is_empty:
+                metapkg_rdepends.append(pkg)
+    d.setVar('RDEPENDS_' + metapkg, ' '.join(metapkg_rdepends))
+    d.setVar('DESCRIPTION_' + metapkg, pn + ' meta package')
+}
+
+# each plugin-dev depends on PN-dev, plugin-staticdev on PN-staticdev
+# so we need them even when empty (like in gst-plugins-good case)
+ALLOW_EMPTY_${PN} = "1"
+ALLOW_EMPTY_${PN}-dev = "1"
+ALLOW_EMPTY_${PN}-staticdev = "1"
+
+PACKAGES += "${PN}-apps ${PN}-meta ${PN}-glib"
+
+FILES_${PN} = ""
+FILES_${PN}-dbg += "${libdir}/gstreamer-${LIBV}/.debug"
+FILES_${PN}-apps = "${bindir}"
+FILES_${PN}-glib = "${datadir}/glib-2.0"
+
+# RRECOMMENDS_${PN} += "${PN}-meta"

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-libav.inc
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-libav.inc
@@ -1,0 +1,40 @@
+SUMMARY = "Libav-based GStreamer 1.x plugin"
+HOMEPAGE = "http://gstreamer.freedesktop.org/"
+SECTION = "multimedia"
+LICENSE = "GPLv2+ & LGPLv2+ & ( (GPLv2+ & LGPLv2.1+) | (GPLv3+ & LGPLv3+) )"
+LICENSE_FLAGS = "commercial"
+
+DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base zlib bzip2 xz"
+
+inherit autotools pkgconfig upstream-version-is-even
+
+# CAUTION: Using the system libav is not recommended. Since the libav API is changing all the time,
+# compilation errors (and other, more subtle bugs) can happen. It is usually better to rely on the
+# libav copy included in the gst-libav package.
+PACKAGECONFIG ??= "orc"
+ 
+PACKAGECONFIG[gpl] = "--enable-gpl,--disable-gpl,"
+PACKAGECONFIG[libav] = "--with-system-libav,,libav"
+PACKAGECONFIG[orc] = "--enable-orc,--disable-orc,orc"
+PACKAGECONFIG[yasm] = "--enable-yasm,--disable-yasm,yasm-native"
+
+
+GSTREAMER_1_0_DEBUG ?= "--disable-debug"
+
+LIBAV_EXTRA_CONFIGURE = "--with-libav-extra-configure"
+LIBAV_EXTRA_CONFIGURE_COMMON = \
+'${LIBAV_EXTRA_CONFIGURE}="${LIBAV_EXTRA_CONFIGURE_COMMON_ARG}"'
+
+EXTRA_OECONF = "${LIBAV_EXTRA_CONFIGURE_COMMON}"
+
+FILES_${PN} += "${libdir}/gstreamer-1.0/*.so"
+FILES_${PN}-dbg += "${libdir}/gstreamer-1.0/.debug"
+FILES_${PN}-dev += "${libdir}/gstreamer-1.0/*.la"
+FILES_${PN}-staticdev += "${libdir}/gstreamer-1.0/*.a"
+
+# http://errors.yoctoproject.org/Errors/Details/20493/
+ARM_INSTRUCTION_SET_armv4 = "arm"
+ARM_INSTRUCTION_SET_armv5 = "arm"
+
+# ffmpeg/libav disables PIC on some platforms (e.g. x86-32)
+INSANE_SKIP_${PN} = "textrel"

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-libav/0001-Disable-yasm-for-libav-when-disable-yasm.patch
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-libav/0001-Disable-yasm-for-libav-when-disable-yasm.patch
@@ -1,0 +1,33 @@
+From 54bba228ea52d01fd84941d97be23c03f9862b64 Mon Sep 17 00:00:00 2001
+From: Carlos Rafael Giani <dv@pseudoterminal.org>
+Date: Sat, 6 Apr 2013 01:22:22 +0200
+Subject: [PATCH] Disable yasm for libav when --disable-yasm
+
+Upstream-Status: Inappropriate [configuration]
+
+Signed-off-by: Shane Wang <shane.wang@intel.com>
+Signed-off-by: Carlos Rafael Giani <dv@pseudoterminal.org>
+---
+ configure.ac | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/configure.ac b/configure.ac
+index 22ede88..ef3c050 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -305,6 +305,12 @@ else
+     emblibav_configure_args="$emblibav_configure_args --enable-gpl"
+   fi
+
++  AC_ARG_ENABLE(yasm,
++              [AC_HELP_STRING([--disable-yasm], [disable use of yasm assembler])])
++  if test "x$enable_yasm" = "xno"; then
++    emblibav_configure_args="$emblibav_configure_args --disable-yasm"
++  fi
++
+   # if we are cross-compiling, tell libav so
+   case $host in
+       *android*)
+-- 
+1.8.2
+

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-libav_git.bb
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-libav_git.bb
@@ -1,0 +1,52 @@
+include gstreamer1.0-libav.inc
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+                    file://COPYING.LIB;md5=6762ed442b3822387a51c92d928ead0d \
+                    file://ext/libav/gstav.h;beginline=1;endline=18;md5=a752c35267d8276fd9ca3db6994fca9c \
+"
+
+
+# To build using the system libav/ffmpeg, append "libav" to PACKAGECONFIG
+# and remove the ffmpeg sources from SRC_URI below. However, first note the
+# warnings in gstreamer1.0-libav.inc
+SRC_URI = " \
+	git://anongit.freedesktop.org/gstreamer/gst-libav;name=base \
+	git://anongit.freedesktop.org/gstreamer/common;destsuffix=git/common;name=common \
+	file://0001-Disable-yasm-for-libav-when-disable-yasm.patch \
+"
+
+
+S = "${WORKDIR}/git"
+
+DEPENDS =+ "ffmpeg"
+PACKAGECONFIG = "orc libav"
+CFLAGS_append = " -Wno-deprecated-declarations "
+
+UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>(\d+(\.\d+)+))"
+
+SRCREV = "011dc043c8253c3c56caf2f34542e76bcb1f7dba"
+SRCREV_common = "29046b89d80bbca22eb222c18820fb40a4ac5bde"
+SRCREV_FORMAT = "base"
+
+inherit gitpkgv
+PV = "1.12.00+git${SRCPV}"
+PKGV = "1.12.00+git${GITPKGV}"
+
+MIPSFPU = "${@bb.utils.contains('TARGET_FPU', 'soft', ' --disable-mipsfpu', ' --enable-mipsfpu', d)}"
+
+LIBAV_EXTRA_CONFIGURE_COMMON_ARG = "--target-os=linux \
+  --cc='${CC}' --as='${CC}' --ld='${CC}' --nm='${NM}' --ar='${AR}' \
+  --ranlib='${RANLIB}' \
+  ${@bb.utils.contains("TARGET_ARCH", "arm", "", " \
+  --disable-mipsdsp \
+  --disable-mipsdspr0 \
+  ${MIPSFPU}", d)} \
+  ${GSTREAMER_1_0_DEBUG} \
+  --cross-prefix='${HOST_PREFIX}'"
+
+do_configure_prepend() {
+	cd ${S}
+	./autogen.sh --noconfigure
+	cd ${B}
+}
+

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad.inc
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad.inc
@@ -1,0 +1,126 @@
+require gstreamer1.0-plugins.inc
+
+LICENSE = "GPLv2+ & LGPLv2+ & LGPLv2.1+ "
+
+DEPENDS += "gstreamer1.0-plugins-base bzip2 libpng jpeg libdca"
+
+S = "${WORKDIR}/gst-plugins-bad-${PV}"
+
+inherit gettext bluetooth
+
+# opengl packageconfig factored out to make it easy for distros
+# and BSP layers to pick either (desktop) opengl, gles2, or no GL
+PACKAGECONFIG_GL ?= "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'gles2', '', d)}"
+
+PACKAGECONFIG ??= " \
+    ${PACKAGECONFIG_GL} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'wayland egl', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'bluez', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'directfb', 'directfb', '', d)} \
+    orc curl neon sndfile \
+    hls sbc dash bz2 smoothstreaming \
+    faac faad libmms dash dtls rsvg uvch264 webp rtmp opus \
+    "
+
+# dash = Dynamic Adaptive Streaming over HTTP
+PACKAGECONFIG[assrender]       = "--enable-assrender,--disable-assrender,libass"
+PACKAGECONFIG[curl]            = "--enable-curl,--disable-curl,curl"
+PACKAGECONFIG[gles2]           = "--enable-gles2 --enable-egl,--disable-gles2 --disable-egl,virtual/libgles2 virtual/egl"
+PACKAGECONFIG[opengl]          = "--enable-opengl,--disable-opengl,virtual/libgl libglu"
+PACKAGECONFIG[dc1394]          = "--enable-dc1394,--disable-dc1394,libdc1394"
+PACKAGECONFIG[faac]            = "--enable-faac,--disable-faac,faac"
+PACKAGECONFIG[faad]            = "--enable-faad,--disable-faad,faad2"
+PACKAGECONFIG[libmms]          = "--enable-libmms,--disable-libmms,libmms"
+PACKAGECONFIG[modplug]         = "--enable-modplug,--disable-modplug,libmodplug"
+PACKAGECONFIG[opus]            = "--enable-opus,--disable-opus,libopus"
+PACKAGECONFIG[flite]           = "--enable-flite,--disable-flite,flite-alsa"
+PACKAGECONFIG[opencv]          = "--enable-opencv,--disable-opencv,opencv"
+PACKAGECONFIG[wayland]         = "--enable-wayland,--disable-wayland,wayland-native wayland"
+PACKAGECONFIG[uvch264]         = "--enable-uvch264,--disable-uvch264,libusb1 udev"
+PACKAGECONFIG[directfb]        = "--enable-directfb,--disable-directfb,directfb"
+PACKAGECONFIG[neon]            = "--enable-neon,--disable-neon,neon"
+PACKAGECONFIG[openal]          = "--enable-openal,--disable-openal,openal-soft"
+PACKAGECONFIG[hls]             = "--enable-hls,--disable-hls,gnutls"
+PACKAGECONFIG[sbc]             = "--enable-sbc,--disable-sbc,sbc"
+PACKAGECONFIG[dash]            = "--enable-dash,--disable-dash,libxml2"
+PACKAGECONFIG[bz2]             = "--enable-bz2,--disable-bz2,bzip2"
+PACKAGECONFIG[fluidsynth]      = "--enable-fluidsynth,--disable-fluidsynth,fluidsynth"
+PACKAGECONFIG[schroedinger]    = "--enable-schro,--disable-schro,schroedinger"
+PACKAGECONFIG[smoothstreaming] = "--enable-smoothstreaming,--disable-smoothstreaming,libxml2"
+PACKAGECONFIG[bluez]           = "--enable-bluez,--disable-bluez,${BLUEZ}"
+PACKAGECONFIG[rsvg]            = "--enable-rsvg,--disable-rsvg,librsvg"
+PACKAGECONFIG[sndfile]         = "--enable-sndfile,--disable-sndfile,libsndfile1"
+PACKAGECONFIG[webp]            = "--enable-webp,--disable-webp,libwebp"
+PACKAGECONFIG[rtmp]            = "--enable-rtmp,--disable-rtmp,rtmpdump"
+PACKAGECONFIG[dtls]            = "--enable-dtls,--disable-dtls,openssl"
+PACKAGECONFIG[egl]             = "--enable-egl,--disable-egl,virtual/egl"
+PACKAGECONFIG[gtk]             = "--enable-gtk3,--disable-gtk3,gtk+3"
+PACKAGECONFIG[srtp]            = "--enable-srtp,--disable-srtp,libsrtp"
+PACKAGECONFIG[voaacenc]        = "--enable-voaacenc,--disable-voaacenc,vo-aacenc"
+PACKAGECONFIG[voamrwbenc]      = "--enable-voamrwbenc,--disable-voamrwbenc,vo-amrwbenc"
+PACKAGECONFIG[resindvd]        = "--enable-resindvd,--disable-resindvd,libdvdread libdvdnav"
+PACKAGECONFIG[openjpeg]        = "--enable-openjpeg,--disable-openjpeg,openjpeg"
+
+# these plugins have not been ported to 1.0 (yet):
+#   apexsink dc1394 lv2 linsys musepack nas timidity teletextdec sdl xvid wininet
+#   acm gsettings sndio cdxaparse dccp faceoverlay hdvparse tta mve nuvdemux
+#   patchdetect real sdi videomeasure gsettings
+
+# these plugins have no corresponding library in OE-core or meta-openembedded:
+#   openni2 winks direct3d directsound winscreencap
+#   apple_media android_media avc bs2b chromaprint daala dts gme gsm kate ladspa
+#   libde265 mimic mpeg2enc mplex ofa openh264 opensles pvr soundtouch spandsp
+#   spc vdpau wasapi x265 zbar
+
+EXTRA_OECONF += " \
+    --enable-dvb \
+    --enable-shm \
+    --enable-fbdev \
+    --enable-decklink \
+    --enable-vcd \
+    --enable-dts \
+    --enable-mpegdemux \
+    --disable-acm \
+    --disable-android_media \
+    --disable-apple_media \
+    --disable-avc \
+    --disable-bs2b \
+    --disable-chromaprint \
+    --disable-cocoa \
+    --disable-daala \
+    --disable-direct3d \
+    --disable-directsound \
+    --disable-gme \
+    --disable-gsm \
+    --disable-kate \
+    --disable-ladspa \
+    --disable-lv2 \
+    --disable-mpeg2enc \
+    --disable-mplex \
+    --disable-musepack \
+    --disable-ofa \
+    --disable-openexr \
+    --disable-openni2 \
+    --disable-opensles \
+    --disable-qt \
+    --disable-soundtouch \
+    --disable-spandsp \
+    --disable-spc \
+    --disable-teletextdec \
+    --disable-vdpau \
+    --disable-wasapi \
+    --disable-wildmidi \
+    --disable-winscreencap \
+    --disable-x265 \
+    --disable-zbar \
+    "
+
+OPENCV_PREFIX="${STAGING_DIR_TARGET}${prefix}"
+export OPENCV_PREFIX
+
+ARM_INSTRUCTION_SET = "arm"
+
+FILES_${PN}-opencv += "${datadir}/gst-plugins-bad/${LIBV}/opencv*"
+FILES_${PN}-freeverb += "${datadir}/gstreamer-${LIBV}/presets/GstFreeverb.prs"
+FILES_${PN}-voamrwbenc += "${datadir}/gstreamer-${LIBV}/presets/GstVoAmrwbEnc.prs"
+FILES_${PN}-dev += "${libdir}/gstreamer-${LIBV}/include/gst/gl/gstglconfig.h"

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0001-Makefile.am-don-t-hardcode-libtool-name-when-running-pbad.patch
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0001-Makefile.am-don-t-hardcode-libtool-name-when-running-pbad.patch
@@ -1,0 +1,71 @@
+From ae7f7f6f53a264cabe324a3810599a66b357d3f2 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Sat, 19 Nov 2016 11:07:55 +0100
+Subject: [PATCH] [PATCH] Makefile.am: don't hardcode libtool name when running
+  introspection tools
+
+Upstream-Status: Pending [review on oe-core list]
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+
+	modified:   gst-libs/gst/gl/Makefile.am
+	modified:   gst-libs/gst/insertbin/Makefile.am
+	modified:   gst-libs/gst/mpegts/Makefile.am
+---
+ gst-libs/gst/gl/Makefile.am        | 2 +-
+ gst-libs/gst/insertbin/Makefile.am | 2 +-
+ gst-libs/gst/mpegts/Makefile.am    | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/gst-libs/gst/gl/Makefile.am b/gst-libs/gst/gl/Makefile.am
+index 68cc619..1ff5511 100644
+--- a/gst-libs/gst/gl/Makefile.am
++++ b/gst-libs/gst/gl/Makefile.am
+@@ -172,7 +172,7 @@ GstGL-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstgl-@GST_API_VERSION@
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+ 		--include=GstVideo-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg gstreamer-base-@GST_API_VERSION@ \
+ 		--pkg gstreamer-video-@GST_API_VERSION@ \
+diff --git a/gst-libs/gst/insertbin/Makefile.am b/gst-libs/gst/insertbin/Makefile.am
+index 1f8ea30..4b98ef6 100644
+--- a/gst-libs/gst/insertbin/Makefile.am
++++ b/gst-libs/gst/insertbin/Makefile.am
+@@ -45,7 +45,7 @@ GstInsertBin-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstinsertbin-@GS
+ 		--library=libgstinsertbin-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg gstreamer-base-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-insertbin-@GST_API_VERSION@ \
+diff --git a/gst-libs/gst/mpegts/Makefile.am b/gst-libs/gst/mpegts/Makefile.am
+index aeea32e..929d9cc 100644
+--- a/gst-libs/gst/mpegts/Makefile.am
++++ b/gst-libs/gst/mpegts/Makefile.am
+@@ -79,7 +79,7 @@ GstMpegts-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstmpegts-@GST_API_
+ 		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-video-@GST_API_VERSION@` \
+ 		--library=libgstmpegts-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg gstreamer-video-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-mpegts-@GST_API_VERSION@ \
+-- 
+2.7.4
+
+--- a/gst-libs/gst/allocators/Makefile.am	2017-06-06 13:34:13.206127663 +0200
++++ b/gst-libs/gst/allocators/Makefile.am	2017-06-06 13:34:44.395382923 +0200
+@@ -37,7 +37,7 @@
+ 		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		--library=libgstbadallocators-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-badallocators-@GST_API_VERSION@ \
+ 		--output $@ \

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0001-rtmp-fix-seeking-and-potential-segfault.patch
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0001-rtmp-fix-seeking-and-potential-segfault.patch
@@ -1,0 +1,63 @@
+From bb9478be40b450629f165d5d3566f4e4a3ee1b66 Mon Sep 17 00:00:00 2001
+From: Athanasios Oikonomou <athoik@gmail.com>
+Date: Tue, 28 Oct 2014 08:48:20 +0200
+Subject: [PATCH] rtmp: fix seeking and potential segfault
+
+Segfault info: https://bugzilla.gnome.org/show_bug.cgi?id=739263
+Seeking info: http://forums.openpli.org/topic/32910-mediaplayer-seek-doesnt-work-with-rtmp-streams/
+
+diff --git a/ext/rtmp/gstrtmpsrc.c b/ext/rtmp/gstrtmpsrc.c
+index b9ecfcf..8b4bf22 100644
+--- a/ext/rtmp/gstrtmpsrc.c
++++ b/ext/rtmp/gstrtmpsrc.c
+@@ -86,7 +86,6 @@ static void gst_rtmp_src_get_property (GObject * object, guint prop_id,
+     GValue * value, GParamSpec * pspec);
+ static void gst_rtmp_src_finalize (GObject * object);
+ 
+-static gboolean gst_rtmp_src_unlock (GstBaseSrc * src);
+ static gboolean gst_rtmp_src_stop (GstBaseSrc * src);
+ static gboolean gst_rtmp_src_start (GstBaseSrc * src);
+ static gboolean gst_rtmp_src_is_seekable (GstBaseSrc * src);
+@@ -137,7 +136,6 @@ gst_rtmp_src_class_init (GstRTMPSrcClass * klass)
+ 
+   gstbasesrc_class->start = GST_DEBUG_FUNCPTR (gst_rtmp_src_start);
+   gstbasesrc_class->stop = GST_DEBUG_FUNCPTR (gst_rtmp_src_stop);
+-  gstbasesrc_class->unlock = GST_DEBUG_FUNCPTR (gst_rtmp_src_unlock);
+   gstbasesrc_class->is_seekable = GST_DEBUG_FUNCPTR (gst_rtmp_src_is_seekable);
+   gstbasesrc_class->prepare_seek_segment =
+       GST_DEBUG_FUNCPTR (gst_rtmp_src_prepare_seek_segment);
+@@ -603,23 +601,6 @@ gst_rtmp_src_start (GstBaseSrc * basesrc)
+ #undef STR2AVAL
+ 
+ static gboolean
+-gst_rtmp_src_unlock (GstBaseSrc * basesrc)
+-{
+-  GstRTMPSrc *rtmpsrc = GST_RTMP_SRC (basesrc);
+-
+-  GST_DEBUG_OBJECT (rtmpsrc, "unlock");
+-
+-  /* This closes the socket, which means that any pending socket calls
+-   * error out. */
+-  if (rtmpsrc->rtmp) {
+-    RTMP_Close (rtmpsrc->rtmp);
+-  }
+-
+-  return TRUE;
+-}
+-
+-
+-static gboolean
+ gst_rtmp_src_stop (GstBaseSrc * basesrc)
+ {
+   GstRTMPSrc *src;
+@@ -627,6 +608,7 @@ gst_rtmp_src_stop (GstBaseSrc * basesrc)
+   src = GST_RTMP_SRC (basesrc);
+ 
+   if (src->rtmp) {
++    RTMP_Close (src->rtmp);
+     RTMP_Free (src->rtmp);
+     src->rtmp = NULL;
+   }
+-- 
+1.7.10.4
+

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0004-rtmp-hls-tsdemux-fix.patch
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0004-rtmp-hls-tsdemux-fix.patch
@@ -1,0 +1,12 @@
+diff --git a/gst/mpegtsdemux/tsdemux.c b/gst/mpegtsdemux/tsdemux.cindex bd196c3..1f29ef0 100644
+--- a/gst/mpegtsdemux/tsdemux.c
++++ b/gst/mpegtsdemux/tsdemux.c
+@@ -1634,7 +1634,7 @@ gst_ts_demux_stream_added (MpegTSBase * base, MpegTSBaseStream * bstream,
+     stream->first_pts = GST_CLOCK_TIME_NONE;
+     stream->raw_pts = -1;
+     stream->raw_dts = -1;
+-    stream->pending_ts = TRUE;
++    stream->pending_ts = program->pcr_pid < 0x1fff;
+     stream->nb_out_buffers = 0;
+     stream->gap_ref_buffers = 0;
+     stream->gap_ref_pts = GST_CLOCK_TIME_NONE;

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/configure-allow-to-disable-libssh2.patch
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/configure-allow-to-disable-libssh2.patch
@@ -1,0 +1,64 @@
+From f59c5269f92d59a5296cbfeeb682d42095cd88ad Mon Sep 17 00:00:00 2001
+From: Wenzong Fan <wenzong.fan@windriver.com>
+Date: Thu, 18 Sep 2014 02:24:07 -0400
+Subject: [PATCH] gstreamer1.0-plugins-bad: allow to disable libssh2
+
+libssh2 is automatically linked to if present, this undetermined
+dependency may cause build errors like:
+
+  .../x86_64-poky-linux/4.9.0/ld: cannot find -lssh2
+
+libssh2 isn't an oe-core recipe, so allow to disable it from
+configure.
+
+Upstream-Status: Pending
+
+Signed-off-by: Wenzong Fan <wenzong.fan@windriver.com>
+---
+ configure.ac |   23 +++++++++++++++++------
+ 1 file changed, 17 insertions(+), 6 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 0e95c5c..12153b4 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1901,6 +1901,15 @@ AG_GST_CHECK_FEATURE(CHROMAPRINT, [chromaprint], chromaprint, [
+ ])
+ 
+ dnl *** Curl ***
++AC_ARG_ENABLE([libssh2],
++     [  --enable-libssh2		enable LIBSSH2 support @<:@default=auto@:>@],
++     [case "${enableval}" in
++       yes)  NEED_SSH2=yes ;;
++       no)   NEED_SSH2=no ;;
++       auto) NEED_SSH2=auto ;;
++       *) AC_MSG_ERROR([bad value ${enableval} for --enable-libssh2]) ;;
++     esac],[NEED_SSH2=auto])
++
+ translit(dnm, m, l) AM_CONDITIONAL(USE_CURL, true)
+ AG_GST_CHECK_FEATURE(CURL, [Curl plugin], curl, [
+   PKG_CHECK_MODULES(CURL, libcurl >= 7.21.0, [
+@@ -1915,12 +1924,14 @@ AG_GST_CHECK_FEATURE(CURL, [Curl plugin], curl, [
+   ])
+   AC_SUBST(CURL_CFLAGS)
+   AC_SUBST(CURL_LIBS)
+-  PKG_CHECK_MODULES(SSH2, libssh2 >= 1.4.3, [
+-    HAVE_SSH2="yes"
+-    AC_DEFINE(HAVE_SSH2, 1, [Define if libssh2 is available])
+-  ], [
+-    HAVE_SSH2="no"
+-  ])
++  if test "x$NEED_SSH2" != "xno"; then
++    PKG_CHECK_MODULES(SSH2, libssh2 >= 1.4.3, [
++      HAVE_SSH2="yes"
++      AC_DEFINE(HAVE_SSH2, 1, [Define if libssh2 is available])
++    ], [
++      HAVE_SSH2="no"
++    ])
++  fi
+   AM_CONDITIONAL(USE_SSH2, test "x$HAVE_SSH2" = "xyes")
+   AC_SUBST(SSH2_CFLAGS)
+   AC_SUBST(SSH2_LIBS)
+-- 
+1.7.9.5
+

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/dvbapi5-fix-old-kernel.patch
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/dvbapi5-fix-old-kernel.patch
@@ -1,0 +1,12 @@
+--- a/sys/dvb/gstdvbsrc.c	2016-12-16 21:52:42.691458624 +0100
++++ b/sys/dvb/gstdvbsrc.c	2016-12-16 21:54:05.192216253 +0100
+@@ -306,7 +306,9 @@
+     {APSK_16, "16APSK", "16apsk"},
+     {APSK_32, "32APSK", "32apsk"},
+     {DQPSK, "DQPSK", "dqpsk"},
++#if HAVE_V5_MINOR(7)
+     {QAM_4_NR, "QAM 4 NR", "qam-4-nr"},
++#endif
+     {0, NULL, NULL},
+   };
+ 

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/fix-maybe-uninitialized-warnings-when-compiling-with-Os.patch
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/fix-maybe-uninitialized-warnings-when-compiling-with-Os.patch
@@ -1,0 +1,28 @@
+From a67781000e82bd9ae3813da29401e8c0c852328a Mon Sep 17 00:00:00 2001
+From: Andre McCurdy <armccurdy@gmail.com>
+Date: Tue, 26 Jan 2016 15:16:01 -0800
+Subject: [PATCH] fix maybe-uninitialized warnings when compiling with -Os
+
+Upstream-Status: Pending
+
+Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
+---
+ gst-libs/gst/codecparsers/gstvc1parser.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gst-libs/gst/codecparsers/gstvc1parser.c b/gst-libs/gst/codecparsers/gstvc1parser.c
+index fd16ee0..ddb890c 100644
+--- a/gst-libs/gst/codecparsers/gstvc1parser.c
++++ b/gst-libs/gst/codecparsers/gstvc1parser.c
+@@ -1729,7 +1729,7 @@ gst_vc1_parse_sequence_layer (const guint8 * data, gsize size,
+     GstVC1SeqLayer * seqlayer)
+ {
+   guint32 tmp;
+-  guint8 tmp8;
++  guint8 tmp8 = 0;
+   guint8 structA[8] = { 0, };
+   guint8 structB[12] = { 0, };
+   GstBitReader br;
+-- 
+1.9.1
+

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/hls-main-thread-block.patch
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/hls-main-thread-block.patch
@@ -1,0 +1,36 @@
+From cb42f72318e284519cf155292f948a93383c09c6 Mon Sep 17 00:00:00 2001
+From: christophecvr <stefansat@telenet.be>
+Date: Fri, 24 Feb 2017 14:34:33 +0100
+Subject: [PATCH] Try-out continu in hls to avoid blocking of main thread.
+
+ Looks like the error self was false,
+ If we just continue it retries,and
+ the media just continues to play ok.
+ The main advantage is that we avoid a 
+ main e2 thread blocked with stb freeze
+ as result. Even if the media would stop,
+ We do not have a frozen stb.
+
+	modified:   ext/hls/m3u8.c
+---
+ ext/hls/m3u8.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/ext/hls/m3u8.c b/ext/hls/m3u8.c
+index e85592e..5feef75 100644
+--- a/ext/hls/m3u8.c
++++ b/ext/hls/m3u8.c
+@@ -365,8 +365,8 @@ gst_m3u8_update_check_consistent_media_seqnums (GstM3U8 * self,
+           }
+         } else if (g_str_equal (f1->uri, f2->uri)) {
+           /* Same URIs but different sequences, this is bad! */
+-          GST_ERROR ("Media sequences inconsistent, ignoring");
+-          return FALSE;
++          GST_ERROR ("Media sequences inconsistent, ignoring, but try anyway");
++          //return FALSE;
+         } else {
+           /* Not same URI, not same sequence but by construction sequence
+            * must be higher in the new one. All good in that case, if it
+-- 
+2.7.4
+

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.8.%.bbappend
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.8.%.bbappend
@@ -1,1 +1,0 @@
-PACKAGECONFIG_append = " faac faad libmms rtmp"

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_git.bb
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_git.bb
@@ -1,0 +1,42 @@
+include gstreamer1.0-plugins-bad.inc
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=73a5855a8119deb017f5f13cf327095d \
+                    file://COPYING.LIB;md5=21682e4e8fea52413fd26c60acb907e5 \
+"
+
+S = "${WORKDIR}/git"
+
+UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>(\d+(\.\d+)+))"
+
+SRCREV = "da5b0d7ad3a55b958a4203659f9ff2ab270bcc91"
+SRCREV_common = "29046b89d80bbca22eb222c18820fb40a4ac5bde"
+SRCREV_FORMAT = "base"
+
+SRC_URI = " \
+	git://anongit.freedesktop.org/gstreamer/gst-plugins-bad;branch=master \
+	git://anongit.freedesktop.org/gstreamer/common;destsuffix=git/common;name=common \
+	file://configure-allow-to-disable-libssh2.patch \
+	file://0001-Makefile.am-don-t-hardcode-libtool-name-when-running-pbad.patch \
+	file://0001-rtmp-fix-seeking-and-potential-segfault.patch \
+	file://0004-rtmp-hls-tsdemux-fix.patch \
+	file://fix-maybe-uninitialized-warnings-when-compiling-with-Os.patch \
+	file://dvbapi5-fix-old-kernel.patch \
+	file://hls-main-thread-block.patch \
+"
+
+inherit gitpkgv
+PV = "1.12.00+git${SRCPV}"
+PKGV = "1.12.00+git${GITPKGV}"
+
+EXTRA_OECONF += " \
+    --disable-openjpeg \
+"
+
+do_configure_prepend() {
+	cd ${S}
+	./autogen.sh --noconfigure
+	cd ${B}
+}
+
+TARGET_CFLAGS_append = " -Wno-error=maybe-uninitialized -Wno-error=redundant-decls "
+

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base.inc
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base.inc
@@ -1,0 +1,44 @@
+require gstreamer1.0-plugins.inc
+
+
+LICENSE = "GPLv2+ & LGPLv2+"
+
+DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'virtual/libx11 libxv', '', d)}"
+DEPENDS += "util-linux iso-codes zlib"
+
+inherit gettext
+
+PACKAGES_DYNAMIC =+ "^libgst.*"
+
+#pango gio-unix-2.0
+PACKAGECONFIG ??= " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'x11', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'alsa', 'alsa', '', d)} \
+    orc ivorbis ogg theora vorbis cdparanoia pango opus \
+    "
+
+X11DEPENDS = "virtual/libx11 libsm libxrender"
+X11ENABLEOPTS = "--enable-x --enable-xvideo --enable-xshm"
+X11DISABLEOPTS = "--disable-x --disable-xvideo --disable-xshm"
+PACKAGECONFIG[x11]          = "${X11ENABLEOPTS},${X11DISABLEOPTS},${X11DEPENDS}"
+PACKAGECONFIG[alsa]         = "--enable-alsa,--disable-alsa,alsa-lib"
+PACKAGECONFIG[ivorbis]      = "--enable-ivorbis,--disable-ivorbis,tremor"
+PACKAGECONFIG[ogg]          = "--enable-ogg,--disable-ogg,libogg"
+PACKAGECONFIG[theora]       = "--enable-theora,--disable-theora,libtheora"
+PACKAGECONFIG[vorbis]       = "--enable-vorbis,--disable-vorbis,libvorbis"
+PACKAGECONFIG[pango]        = "--enable-pango,--disable-pango,pango"
+PACKAGECONFIG[visual]       = "--enable-libvisual,--disable-libvisual,libvisual"
+PACKAGECONFIG[cdparanoia]   = "--enable-cdparanoia,--disable-cdparanoia,cdparanoia"
+PACKAGECONFIG[opus]			= "--enable-opus,--disable-opus,libopus"
+
+EXTRA_OECONF += " \
+    --enable-zlib \
+    "
+    
+CACHED_CONFIGUREVARS_append_i586 = " ac_cv_header_emmintrin_h=no ac_cv_header_xmmintrin_h=no"
+
+FILES_${MLPREFIX}libgsttag-1.0 += "${datadir}/gst-plugins-base/1.0/license-translations.dict"
+
+do_compile_prepend() {
+        export GIR_EXTRA_LIBS_PATH="${B}/gst-libs/gst/tag/.libs:${B}/gst-libs/gst/video/.libs:${B}/gst-libs/gst/audio/.libs:${B}/gst-libs/gst/rtp/.libs"
+}

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0001-Makefile.am-don-t-hardcode-libtool-name-when-running.patch
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0001-Makefile.am-don-t-hardcode-libtool-name-when-running.patch
@@ -1,0 +1,180 @@
+From 0c5843296bece8c298d5c8ca7342835f9fa9cbd6 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Sat, 19 Nov 2016 10:26:10 +0100
+Subject: [PATCH] [PATCH 1/4] Makefile.am: don't hardcode libtool name when
+ running  introspection tools
+
+Upstream-Status: Pending [review on oe-core maillist]
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+
+	modified:   gst-libs/gst/allocators/Makefile.am
+	modified:   gst-libs/gst/app/Makefile.am
+	modified:   gst-libs/gst/audio/Makefile.am
+	modified:   gst-libs/gst/fft/Makefile.am
+	modified:   gst-libs/gst/pbutils/Makefile.am
+	modified:   gst-libs/gst/riff/Makefile.am
+	modified:   gst-libs/gst/rtp/Makefile.am
+	modified:   gst-libs/gst/rtsp/Makefile.am
+	modified:   gst-libs/gst/sdp/Makefile.am
+	modified:   gst-libs/gst/tag/Makefile.am
+	modified:   gst-libs/gst/video/Makefile.am
+---
+ gst-libs/gst/allocators/Makefile.am | 2 +-
+ gst-libs/gst/app/Makefile.am        | 2 +-
+ gst-libs/gst/audio/Makefile.am      | 2 +-
+ gst-libs/gst/fft/Makefile.am        | 2 +-
+ gst-libs/gst/pbutils/Makefile.am    | 2 +-
+ gst-libs/gst/riff/Makefile.am       | 2 +-
+ gst-libs/gst/rtp/Makefile.am        | 2 +-
+ gst-libs/gst/rtsp/Makefile.am       | 2 +-
+ gst-libs/gst/sdp/Makefile.am        | 2 +-
+ gst-libs/gst/tag/Makefile.am        | 2 +-
+ gst-libs/gst/video/Makefile.am      | 2 +-
+ 11 files changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/gst-libs/gst/allocators/Makefile.am b/gst-libs/gst/allocators/Makefile.am
+index bccfdb3..c3a1cb8 100644
+--- a/gst-libs/gst/allocators/Makefile.am
++++ b/gst-libs/gst/allocators/Makefile.am
+@@ -39,7 +39,7 @@ GstAllocators-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstallocators-@
+ 		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		--library=libgstallocators-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-allocators-@GST_API_VERSION@ \
+ 		--output $@ \
+diff --git a/gst-libs/gst/app/Makefile.am b/gst-libs/gst/app/Makefile.am
+index 0033371..1869540 100644
+--- a/gst-libs/gst/app/Makefile.am
++++ b/gst-libs/gst/app/Makefile.am
+@@ -42,7 +42,7 @@ GstApp-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstapp-@GST_API_VERSIO
+ 		--library=libgstapp-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg gstreamer-base-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-app-@GST_API_VERSION@ \
+diff --git a/gst-libs/gst/audio/Makefile.am b/gst-libs/gst/audio/Makefile.am
+index 41f9c4d..c39c529 100644
+--- a/gst-libs/gst/audio/Makefile.am
++++ b/gst-libs/gst/audio/Makefile.am
+@@ -174,7 +174,7 @@ GstAudio-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstaudio-@GST_API_VE
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+ 		--include=GstTag-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg gstreamer-base-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-audio-@GST_API_VERSION@ \
+diff --git a/gst-libs/gst/fft/Makefile.am b/gst-libs/gst/fft/Makefile.am
+index 0d70422..2ded9ee 100644
+--- a/gst-libs/gst/fft/Makefile.am
++++ b/gst-libs/gst/fft/Makefile.am
+@@ -66,7 +66,7 @@ GstFft-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstfft-@GST_API_VERSIO
+ 		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		--library=libgstfft-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-fft-@GST_API_VERSION@ \
+ 		--output $@ \
+diff --git a/gst-libs/gst/pbutils/Makefile.am b/gst-libs/gst/pbutils/Makefile.am
+index c5a25ca..44be19b 100644
+--- a/gst-libs/gst/pbutils/Makefile.am
++++ b/gst-libs/gst/pbutils/Makefile.am
+@@ -100,7 +100,7 @@ GstPbutils-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstpbutils-@GST_AP
+ 		--include=GstTag-@GST_API_VERSION@ \
+ 		--include=GstVideo-@GST_API_VERSION@ \
+ 		--include=GstAudio-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg gstreamer-tag-@GST_API_VERSION@ \
+ 		--pkg gstreamer-video-@GST_API_VERSION@ \
+diff --git a/gst-libs/gst/riff/Makefile.am b/gst-libs/gst/riff/Makefile.am
+index 5fa26e5..1cf0590 100644
+--- a/gst-libs/gst/riff/Makefile.am
++++ b/gst-libs/gst/riff/Makefile.am
+@@ -48,7 +48,7 @@ libgstriff_@GST_API_VERSION@_la_LDFLAGS = $(GST_LIB_LDFLAGS) $(GST_ALL_LDFLAGS)
+ #		--include=GstAudio-@GST_API_VERSION@ \
+ #		--include=GstTag-@GST_API_VERSION@ \
+ #		--include=Gst-@GST_API_VERSION@ \
+-#		--libtool="$(top_builddir)/libtool" \
++#		--libtool="$(LIBTOOL)" \
+ #		--pkg gstreamer-@GST_API_VERSION@ \
+ #		--pkg gstreamer-tag-@GST_API_VERSION@ \
+ #		--pkg gstreamer-audio-@GST_API_VERSION@ \
+diff --git a/gst-libs/gst/rtp/Makefile.am b/gst-libs/gst/rtp/Makefile.am
+index 04b1f90..85085dc 100644
+--- a/gst-libs/gst/rtp/Makefile.am
++++ b/gst-libs/gst/rtp/Makefile.am
+@@ -66,7 +66,7 @@ GstRtp-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstrtp-@GST_API_VERSIO
+ 		--library=libgstrtp-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg gstreamer-base-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-rtp-@GST_API_VERSION@ \
+diff --git a/gst-libs/gst/rtsp/Makefile.am b/gst-libs/gst/rtsp/Makefile.am
+index 88f0853..92b5e81 100644
+--- a/gst-libs/gst/rtsp/Makefile.am
++++ b/gst-libs/gst/rtsp/Makefile.am
+@@ -73,7 +73,7 @@ GstRtsp-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstrtsp-@GST_API_VERS
+ 		--include=Gio-2.0 \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstSdp-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gio-2.0 \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg gstreamer-sdp-@GST_API_VERSION@ \
+diff --git a/gst-libs/gst/sdp/Makefile.am b/gst-libs/gst/sdp/Makefile.am
+index 6fd9693..e356b16 100644
+--- a/gst-libs/gst/sdp/Makefile.am
++++ b/gst-libs/gst/sdp/Makefile.am
+@@ -33,7 +33,7 @@ GstSdp-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstsdp-@GST_API_VERSIO
+ 		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		--library=libgstsdp-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-sdp-@GST_API_VERSION@ \
+ 		--output $@ \
+diff --git a/gst-libs/gst/tag/Makefile.am b/gst-libs/gst/tag/Makefile.am
+index c0c2d6b..490ed40 100644
+--- a/gst-libs/gst/tag/Makefile.am
++++ b/gst-libs/gst/tag/Makefile.am
+@@ -46,7 +46,7 @@ GstTag-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgsttag-@GST_API_VERSIO
+ 		--library=libgsttag-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg gstreamer-base-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-tag-@GST_API_VERSION@ \
+diff --git a/gst-libs/gst/video/Makefile.am b/gst-libs/gst/video/Makefile.am
+index 64f4978..f3ea4ea 100644
+--- a/gst-libs/gst/video/Makefile.am
++++ b/gst-libs/gst/video/Makefile.am
+@@ -121,7 +121,7 @@ GstVideo-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstvideo-@GST_API_VE
+ 		--library=libgstvideo-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg gstreamer-base-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-video-@GST_API_VERSION@ \
+-- 
+2.7.4
+

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0002-Makefile.am-prefix-calls-to-pkg-config-with-PKG_CONF.patch
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0002-Makefile.am-prefix-calls-to-pkg-config-with-PKG_CONF.patch
@@ -1,0 +1,298 @@
+From 990b653c7b6de1937ec759019982d6c5f15770f7 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Mon, 26 Oct 2015 16:38:18 +0200
+Subject: [PATCH 2/4] Makefile.am: prefix calls to pkg-config with
+ PKG_CONFIG_SYSROOT_DIR
+
+Upstream-Status: Pending [review on oe-core maillist]
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+---
+ gst-libs/gst/allocators/Makefile.am |  4 ++--
+ gst-libs/gst/app/Makefile.am        |  4 ++--
+ gst-libs/gst/audio/Makefile.am      | 12 ++++++------
+ gst-libs/gst/fft/Makefile.am        |  4 ++--
+ gst-libs/gst/pbutils/Makefile.am    | 12 ++++++------
+ gst-libs/gst/riff/Makefile.am       |  8 ++++----
+ gst-libs/gst/rtp/Makefile.am        |  8 ++++----
+ gst-libs/gst/rtsp/Makefile.am       |  4 ++--
+ gst-libs/gst/sdp/Makefile.am        |  4 ++--
+ gst-libs/gst/tag/Makefile.am        |  8 ++++----
+ gst-libs/gst/video/Makefile.am      |  8 ++++----
+ 11 files changed, 38 insertions(+), 38 deletions(-)
+
+diff --git a/gst-libs/gst/allocators/Makefile.am b/gst-libs/gst/allocators/Makefile.am
+index bc7f53a..0ef5f86 100644
+--- a/gst-libs/gst/allocators/Makefile.am
++++ b/gst-libs/gst/allocators/Makefile.am
+@@ -34,7 +34,7 @@ GstAllocators-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstallocators-@
+ 		--c-include "gst/allocators/allocators.h" \
+ 		-I$(top_srcdir)/gst-libs \
+ 		-I$(top_builddir)/gst-libs \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		--library=libgstallocators-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--libtool="$(LIBTOOL)" \
+@@ -58,7 +58,7 @@ typelibs_DATA = $(BUILT_GIRSOURCES:.gir=.typelib)
+ 		$(INTROSPECTION_COMPILER) \
+ 		--includedir=$(srcdir) \
+ 		--includedir=$(builddir) \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		$(INTROSPECTION_COMPILER_OPTS) $< -o $(@F)
+ 
+ CLEANFILES = $(BUILT_GIRSOURCES) $(typelibs_DATA)
+diff --git a/gst-libs/gst/app/Makefile.am b/gst-libs/gst/app/Makefile.am
+index dcc2fe0..dc076cb 100644
+--- a/gst-libs/gst/app/Makefile.am
++++ b/gst-libs/gst/app/Makefile.am
+@@ -47,8 +47,8 @@ GstApp-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstapp-@GST_API_VERSIO
+ 		--c-include "gst/app/app.h" \
+ 		-I$(top_srcdir)/gst-libs \
+ 		-I$(top_builddir)/gst-libs \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		--library=libgstapp-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+diff --git a/gst-libs/gst/audio/Makefile.am b/gst-libs/gst/audio/Makefile.am
+index 2374196..295eb42 100644
+--- a/gst-libs/gst/audio/Makefile.am
++++ b/gst-libs/gst/audio/Makefile.am
+@@ -96,12 +96,12 @@ GstAudio-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstaudio-@GST_API_VE
+ 		-I$(top_srcdir)/gst-libs \
+ 		-I$(top_builddir)/gst-libs \
+ 		--c-include "gst/audio/audio.h" \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		--add-include-path="$(top_builddir)/gst-libs/gst/tag/" \
+ 		--library=libgstaudio-@GST_API_VERSION@.la \
+-		--library-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=libdir gstreamer-@GST_API_VERSION@` \
+-		--library-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=libdir gstreamer-base-@GST_API_VERSION@` \
++		--library-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=libdir gstreamer-@GST_API_VERSION@` \
++		--library-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=libdir gstreamer-base-@GST_API_VERSION@` \
+ 		--library-path="$(top_builddir)/gst-libs/gst/tag/" \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+@@ -130,8 +130,8 @@ typelibs_DATA = $(BUILT_GIRSOURCES:.gir=.typelib)
+ 		--includedir=$(srcdir) \
+ 		--includedir=$(builddir) \
+ 		--includedir="$(top_builddir)/gst-libs/gst/tag/" \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		$(INTROSPECTION_COMPILER_OPTS) $< -o $(@F)
+ 
+ CLEANFILES += $(BUILT_GIRSOURCES) $(typelibs_DATA)
+diff --git a/gst-libs/gst/fft/Makefile.am b/gst-libs/gst/fft/Makefile.am
+index f545354..1bb6243 100644
+--- a/gst-libs/gst/fft/Makefile.am
++++ b/gst-libs/gst/fft/Makefile.am
+@@ -61,7 +61,7 @@ GstFft-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstfft-@GST_API_VERSIO
+ 		--c-include "gst/fft/fft.h" \
+ 		-I$(top_srcdir)/gst-libs \
+ 		-I$(top_builddir)/gst-libs \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		--library=libgstfft-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--libtool="$(LIBTOOL)" \
+@@ -85,7 +85,7 @@ typelibs_DATA = $(BUILT_GIRSOURCES:.gir=.typelib)
+ 		$(INTROSPECTION_COMPILER) \
+ 		--includedir=$(srcdir) \
+ 		--includedir=$(builddir) \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		$(INTROSPECTION_COMPILER_OPTS) $< -o $(@F)
+ 
+ CLEANFILES = $(BUILT_GIRSOURCES) $(typelibs_DATA)
+diff --git a/gst-libs/gst/pbutils/Makefile.am b/gst-libs/gst/pbutils/Makefile.am
+index 91dc214..dc8e1d3 100644
+--- a/gst-libs/gst/pbutils/Makefile.am
++++ b/gst-libs/gst/pbutils/Makefile.am
+@@ -79,14 +79,14 @@ GstPbutils-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstpbutils-@GST_AP
+ 		--c-include "gst/pbutils/pbutils.h" \
+ 		-I$(top_srcdir)/gst-libs \
+ 		-I$(top_builddir)/gst-libs \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		--add-include-path="$(top_builddir)/gst-libs/gst/tag/" \
+ 		--add-include-path="$(top_builddir)/gst-libs/gst/video/" \
+ 		--add-include-path="$(top_builddir)/gst-libs/gst/audio/" \
+ 		--library=libgstpbutils-@GST_API_VERSION@.la \
+-		--library-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=libdir gstreamer-@GST_API_VERSION@` \
+-		--library-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=libdir gstreamer-base-@GST_API_VERSION@` \
++		--library-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=libdir gstreamer-@GST_API_VERSION@` \
++		--library-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=libdir gstreamer-base-@GST_API_VERSION@` \
+ 		--library-path="$(top_builddir)/gst-libs/gst/tag/" \
+ 		--library-path="$(top_builddir)/gst-libs/gst/video/" \
+ 		--library-path="$(top_builddir)/gst-libs/gst/audio/" \
+@@ -119,8 +119,8 @@ typelibs_DATA = $(BUILT_GIRSOURCES:.gir=.typelib)
+ 		$(INTROSPECTION_COMPILER) \
+ 		--includedir=$(srcdir) \
+ 		--includedir=$(builddir) \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		--includedir="$(top_builddir)/gst-libs/gst/tag/" \
+ 		--includedir="$(top_builddir)/gst-libs/gst/video/" \
+ 		--includedir="$(top_builddir)/gst-libs/gst/audio/" \
+diff --git a/gst-libs/gst/riff/Makefile.am b/gst-libs/gst/riff/Makefile.am
+index 3bd8fc0..0a115cc 100644
+--- a/gst-libs/gst/riff/Makefile.am
++++ b/gst-libs/gst/riff/Makefile.am
+@@ -41,8 +41,8 @@ libgstriff_@GST_API_VERSION@_la_LDFLAGS = $(GST_LIB_LDFLAGS) $(GST_ALL_LDFLAGS)
+ #		--c-include "gst/riff/riff.h" \
+ #		--add-include-path=$(builddir)/../tag \
+ #		--add-include-path=$(builddir)/../audio \
+-#		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-#		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++#		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++#		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ #		--library=libgstriff-@GST_API_VERSION@.la \
+ #		--include=GstAudio-@GST_API_VERSION@ \
+ #		--include=GstTag-@GST_API_VERSION@ \
+@@ -73,8 +73,8 @@ libgstriff_@GST_API_VERSION@_la_LDFLAGS = $(GST_LIB_LDFLAGS) $(GST_ALL_LDFLAGS)
+ #		--includedir=$(builddir) \
+ #		--includedir=$(builddir)/../tag \
+ #		--includedir=$(builddir)/../audio \
+-#		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-#		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++#		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++#		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ #		$(INTROSPECTION_COMPILER_OPTS) $< -o $(@F)
+ #
+ #CLEANFILES = $(BUILT_GIRSOURCES) $(typelibs_DATA)
+diff --git a/gst-libs/gst/rtp/Makefile.am b/gst-libs/gst/rtp/Makefile.am
+index f5445c1..527c0b4 100644
+--- a/gst-libs/gst/rtp/Makefile.am
++++ b/gst-libs/gst/rtp/Makefile.am
+@@ -59,8 +59,8 @@ GstRtp-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstrtp-@GST_API_VERSIO
+ 		--c-include "gst/rtp/rtp.h" \
+ 		-I$(top_builddir)/gst-libs \
+ 		-I$(top_srcdir)/gst-libs \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		--library=libgstrtp-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+@@ -87,8 +87,8 @@ typelibs_DATA = $(BUILT_GIRSOURCES:.gir=.typelib)
+ 		$(INTROSPECTION_COMPILER) \
+ 		--includedir=$(srcdir) \
+ 		--includedir=$(builddir) \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		$(INTROSPECTION_COMPILER_OPTS) $< -o $(@F)
+ 
+ CLEANFILES += $(BUILT_GIRSOURCES) $(typelibs_DATA)
+diff --git a/gst-libs/gst/rtsp/Makefile.am b/gst-libs/gst/rtsp/Makefile.am
+index 9b0b258..4f6d9f8 100644
+--- a/gst-libs/gst/rtsp/Makefile.am
++++ b/gst-libs/gst/rtsp/Makefile.am
+@@ -66,7 +66,7 @@ GstRtsp-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstrtsp-@GST_API_VERS
+ 		-I$(top_builddir)/gst-libs \
+ 		-I$(top_srcdir)/gst-libs \
+ 		--add-include-path=$(builddir)/../sdp \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		--library=libgstrtsp-@GST_API_VERSION@.la \
+ 		--include=Gio-2.0 \
+ 		--include=Gst-@GST_API_VERSION@ \
+@@ -96,7 +96,7 @@ typelibs_DATA = $(BUILT_GIRSOURCES:.gir=.typelib)
+ 		--includedir=$(srcdir) \
+ 		--includedir=$(builddir) \
+ 		--includedir=$(builddir)/../sdp \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		$(INTROSPECTION_COMPILER_OPTS) $< -o $(@F)
+ 
+ CLEANFILES += $(BUILT_GIRSOURCES) $(typelibs_DATA)
+diff --git a/gst-libs/gst/sdp/Makefile.am b/gst-libs/gst/sdp/Makefile.am
+index 0e149b8..9aa0512 100644
+--- a/gst-libs/gst/sdp/Makefile.am
++++ b/gst-libs/gst/sdp/Makefile.am
+@@ -28,7 +28,7 @@ GstSdp-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstsdp-@GST_API_VERSIO
+ 		--warn-all \
+ 		--c-include "gst/sdp/sdp.h" \
+ 		-I$(top_srcdir)/gst-libs \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		--library=libgstsdp-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--libtool="$(LIBTOOL)" \
+@@ -52,7 +52,7 @@ typelibs_DATA = $(BUILT_GIRSOURCES:.gir=.typelib)
+ 		$(INTROSPECTION_COMPILER) \
+ 		--includedir=$(srcdir) \
+ 		--includedir=$(builddir) \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		$(INTROSPECTION_COMPILER_OPTS) $< -o $(@F)
+ 
+ CLEANFILES = $(BUILT_GIRSOURCES) $(typelibs_DATA)
+diff --git a/gst-libs/gst/tag/Makefile.am b/gst-libs/gst/tag/Makefile.am
+index cafafd3..ba99279 100644
+--- a/gst-libs/gst/tag/Makefile.am
++++ b/gst-libs/gst/tag/Makefile.am
+@@ -39,8 +39,8 @@ GstTag-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgsttag-@GST_API_VERSIO
+ 		--c-include "gst/tag/tag.h" \
+ 		-I$(top_srcdir)/gst-libs \
+ 		-I$(top_builddir)/gst-libs \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		--library=libgsttag-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+@@ -67,8 +67,8 @@ typelibs_DATA = $(BUILT_GIRSOURCES:.gir=.typelib)
+ 		$(INTROSPECTION_COMPILER) \
+ 		--includedir=$(srcdir) \
+ 		--includedir=$(builddir) \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		$(INTROSPECTION_COMPILER_OPTS) $< -o $(@F)
+ 
+ CLEANFILES = $(BUILT_GIRSOURCES) $(typelibs_DATA)
+diff --git a/gst-libs/gst/video/Makefile.am b/gst-libs/gst/video/Makefile.am
+index ac64eb3..342c8c6 100644
+--- a/gst-libs/gst/video/Makefile.am
++++ b/gst-libs/gst/video/Makefile.am
+@@ -108,8 +108,8 @@ GstVideo-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstvideo-@GST_API_VE
+ 		--c-include "gst/video/video.h" \
+ 		-I$(top_srcdir)/gst-libs \
+ 		-I$(top_builddir)/gst-libs \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		--library=libgstvideo-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+@@ -136,8 +136,8 @@ typelibs_DATA = $(BUILT_GIRSOURCES:.gir=.typelib)
+ 		$(INTROSPECTION_COMPILER) \
+ 		--includedir=$(srcdir) \
+ 		--includedir=$(builddir) \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		$(INTROSPECTION_COMPILER_OPTS) $< -o $(@F)
+ 
+ CLEANFILES += $(BUILT_GIRSOURCES) $(typelibs_DATA)
+-- 
+2.6.2
+

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0003-riff-media-added-fourcc-to-all-ffmpeg-mpeg4-video-caps.patch
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0003-riff-media-added-fourcc-to-all-ffmpeg-mpeg4-video-caps.patch
@@ -1,0 +1,48 @@
+From e83999345bfcb3ac0290a88293ebdf16199b31a3 Mon Sep 17 00:00:00 2001
+From: christophecvr <stefansat@telenet.be>
+Date: Sat, 5 Dec 2015 19:32:32 +0100
+Subject: [PATCH] riff-media: added fourcc to all mpeg4 video caps
+
+	modified:   gst-libs/gst/riff/riff-media.c
+---
+ gst-libs/gst/riff/riff-media.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/gst-libs/gst/riff/riff-media.c b/gst-libs/gst/riff/riff-media.c
+index 38e9e1a..8701fb2 100644
+--- a/gst-libs/gst/riff/riff-media.c
++++ b/gst-libs/gst/riff/riff-media.c
+@@ -456,12 +456,19 @@ gst_riff_create_video_caps (guint32 codec_fcc,
+     case GST_MAKE_FOURCC ('F', 'M', 'P', '4'):
+     case GST_MAKE_FOURCC ('U', 'M', 'P', '4'):
+     case GST_MAKE_FOURCC ('F', 'F', 'D', 'S'):
++    {
++      gchar *fstr = NULL;
+       caps = gst_caps_new_simple ("video/mpeg",
+           "mpegversion", G_TYPE_INT, 4,
+           "systemstream", G_TYPE_BOOLEAN, FALSE, NULL);
++      fstr = g_strdup_printf ("%" GST_FOURCC_FORMAT,
++          GST_FOURCC_ARGS (codec_fcc));
++      gst_caps_set_simple (caps, "fourcc", G_TYPE_STRING, fstr, NULL);
++      g_free (fstr);
+       if (codec_name)
+         *codec_name = g_strdup ("FFmpeg MPEG-4");
+       break;
++    }
+ 
+     case GST_MAKE_FOURCC ('3', 'I', 'V', '1'):
+     case GST_MAKE_FOURCC ('3', 'I', 'V', '2'):
+@@ -487,6 +494,10 @@ gst_riff_create_video_caps (guint32 codec_fcc,
+       caps = gst_caps_new_simple ("video/mpeg",
+           "mpegversion", G_TYPE_INT, 4,
+           "systemstream", G_TYPE_BOOLEAN, FALSE, NULL);
++      {gchar *fstr = g_strdup_printf ("%" GST_FOURCC_FORMAT,
++          GST_FOURCC_ARGS (codec_fcc));
++      gst_caps_set_simple (caps, "fourcc", G_TYPE_STRING, fstr, NULL);
++      g_free (fstr);}
+       if (codec_name)
+         *codec_name = g_strdup ("MPEG-4");
+       break;
+-- 
+1.9.1
+

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0004-rtsp-drop-incorrect-reference-to-gstreamer-sdp-in-Ma.patch
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base/0004-rtsp-drop-incorrect-reference-to-gstreamer-sdp-in-Ma.patch
@@ -1,0 +1,27 @@
+From 4330915d88dc4dd46eb4c28d756482b767c2747f Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Mon, 26 Oct 2015 17:30:14 +0200
+Subject: [PATCH 4/4] rtsp: drop incorrect reference to gstreamer-sdp in
+ Makefile.am
+
+Upstream-Status: Pending [review on oe-core maillist]
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+---
+ gst-libs/gst/rtsp/Makefile.am | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/gst-libs/gst/rtsp/Makefile.am b/gst-libs/gst/rtsp/Makefile.am
+index 4f6d9f8..0afa370 100644
+--- a/gst-libs/gst/rtsp/Makefile.am
++++ b/gst-libs/gst/rtsp/Makefile.am
+@@ -74,7 +74,6 @@ GstRtsp-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstrtsp-@GST_API_VERS
+ 		--libtool="$(LIBTOOL)" \
+ 		--pkg gio-2.0 \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+-		--pkg gstreamer-sdp-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-rtsp-@GST_API_VERSION@ \
+ 		--add-init-section="$(INTROSPECTION_INIT)" \
+ 		--output $@ \
+-- 
+2.6.2
+

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_git.bb
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_git.bb
@@ -1,0 +1,34 @@
+include gstreamer1.0-plugins-base.inc
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=c54ce9345727175ff66d17b67ff51f58 \
+                    file://COPYING.LIB;md5=6762ed442b3822387a51c92d928ead0d \
+                   "
+
+S = "${WORKDIR}/git"
+
+UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>(\d+(\.\d+)+))"
+
+SRCREV = "112cc33d6a3a89fb290dfe81a9d2116502a22e85"
+SRCREV_common = "29046b89d80bbca22eb222c18820fb40a4ac5bde"
+SRCREV_FORMAT = "base"
+
+SRC_URI = " \
+	git://anongit.freedesktop.org/gstreamer/gst-plugins-base;branch=master \
+	git://anongit.freedesktop.org/gstreamer/common;destsuffix=git/common;name=common \
+	file://0001-Makefile.am-don-t-hardcode-libtool-name-when-running.patch \
+	file://0002-Makefile.am-prefix-calls-to-pkg-config-with-PKG_CONF.patch \
+	file://0003-riff-media-added-fourcc-to-all-ffmpeg-mpeg4-video-caps.patch \
+	file://0004-rtsp-drop-incorrect-reference-to-gstreamer-sdp-in-Ma.patch \
+"
+
+inherit gitpkgv
+PV = "1.12.00+git${SRCPV}"
+PKGV = "1.12.00+git${GITPKGV}"
+
+
+do_configure_prepend() {
+	cd ${S}
+	./autogen.sh --noconfigure
+	cd ${B}
+}
+

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good.inc
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good.inc
@@ -1,0 +1,54 @@
+require gstreamer1.0-plugins.inc
+
+LICENSE = "GPLv2+ & LGPLv2.1+"
+
+# libid3tag
+DEPENDS += "gstreamer1.0-plugins-base zlib bzip2 libcap"
+
+inherit gettext
+
+#cairo gdk-pixbuf gudev v4l2
+PACKAGECONFIG ??= " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'x11', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'pulseaudio', 'pulseaudio', '', d)} \
+    orc flac jpeg libpng soup speex taglib vpx wavpack \
+    "
+
+X11DEPENDS = "virtual/libx11 libsm libxrender libxfixes libxdamage"
+PACKAGECONFIG[x11]        = "--enable-x,--disable-x,${X11DEPENDS}"
+PACKAGECONFIG[pulseaudio] = "--enable-pulse,--disable-pulse,pulseaudio"
+PACKAGECONFIG[cairo]      = "--enable-cairo,--disable-cairo,cairo"
+PACKAGECONFIG[flac]       = "--enable-flac,--disable-flac,flac"
+PACKAGECONFIG[gdk-pixbuf] = "--enable-gdk_pixbuf,--disable-gdk_pixbuf,gdk-pixbuf"
+PACKAGECONFIG[gudev]      = "--with-gudev,--without-gudev,libgudev"
+PACKAGECONFIG[libv4l2]    = "--with-libv4l2,--without-libv4l2,libv4l2"
+PACKAGECONFIG[jack]       = "--enable-jack,--disable-jack,jack"
+PACKAGECONFIG[jpeg]       = "--enable-jpeg,--disable-jpeg,jpeg"
+PACKAGECONFIG[libpng]     = "--enable-libpng,--disable-libpng,libpng"
+PACKAGECONFIG[soup]       = "--enable-soup,--disable-soup,libsoup-2.4"
+PACKAGECONFIG[speex]      = "--enable-speex,--disable-speex,speex"
+PACKAGECONFIG[taglib]     = "--enable-taglib,--disable-taglib,taglib"
+PACKAGECONFIG[vpx]        = "--enable-vpx,--disable-vpx,libvpx"
+PACKAGECONFIG[wavpack]    = "--enable-wavpack,--disable-wavpack,wavpack"
+PACKAGECONFIG[dv1394]     = "--enable-dv1394,--disable-dv1394,libiec61883 libavc1394 libraw1394"
+PACKAGECONFIG[v4l2]       = "--enable-gst_v4l2,--disable-gst_v4l2"
+
+EXTRA_OECONF += " \
+    --enable-oss \
+    --enable-zlib \
+    --enable-bz2 \
+    --disable-directsound \
+    --disable-waveform \
+    --disable-oss4 \
+    --disable-sunaudio \
+    --disable-osx_audio \
+    --disable-osx_video \
+    --disable-aalib \
+    --disable-aalibtest \
+    --disable-libcaca \
+    --disable-libdv \
+    --disable-shout2 \
+    --disable-examples \
+"
+
+FILES_${PN}-equalizer += "${datadir}/gstreamer-1.0/presets/*.prs"

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0001-gstrtpmp4gpay-set-dafault-value-for-MPEG4-without-co.patch
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good/0001-gstrtpmp4gpay-set-dafault-value-for-MPEG4-without-co.patch
@@ -1,0 +1,62 @@
+From c782a30482908a4b4dd9cd4abff9f9bc4016698f Mon Sep 17 00:00:00 2001
+From: Song Bing <b06498@freescale.com>
+Date: Tue, 5 Aug 2014 14:40:46 +0800
+Subject: [PATCH] gstrtpmp4gpay: set dafault value for MPEG4 without codec
+ data in caps.
+
+https://bugzilla.gnome.org/show_bug.cgi?id=734263
+
+Upstream Status: Submitted
+
+Signed-off-by: Song Bing <b06498@freescale.com>
+---
+ gst/rtp/gstrtpmp4gpay.c |   19 ++++++++++++++++++-
+ 1 file changed, 18 insertions(+), 1 deletion(-)
+
+diff --git a/gst/rtp/gstrtpmp4gpay.c b/gst/rtp/gstrtpmp4gpay.c
+index 7913d9a..1749d39 100644
+--- a/gst/rtp/gstrtpmp4gpay.c
++++ b/gst/rtp/gstrtpmp4gpay.c
+@@ -390,6 +390,7 @@ gst_rtp_mp4g_pay_setcaps (GstRTPBasePayload * payload, GstCaps * caps)
+   const GValue *codec_data;
+   const gchar *media_type = NULL;
+   gboolean res;
++  const gchar *name;
+ 
+   rtpmp4gpay = GST_RTP_MP4G_PAY (payload);
+ 
+@@ -400,7 +401,6 @@ gst_rtp_mp4g_pay_setcaps (GstRTPBasePayload * payload, GstCaps * caps)
+     GST_LOG_OBJECT (rtpmp4gpay, "got codec_data");
+     if (G_VALUE_TYPE (codec_data) == GST_TYPE_BUFFER) {
+       GstBuffer *buffer;
+-      const gchar *name;
+ 
+       buffer = gst_value_get_buffer (codec_data);
+       GST_LOG_OBJECT (rtpmp4gpay, "configuring codec_data");
+@@ -426,6 +426,23 @@ gst_rtp_mp4g_pay_setcaps (GstRTPBasePayload * payload, GstCaps * caps)
+ 
+       rtpmp4gpay->config = gst_buffer_copy (buffer);
+     }
++  } else {
++    name = gst_structure_get_name (structure);
++
++    if (!strcmp (name, "video/mpeg")) {
++      rtpmp4gpay->profile = g_strdup ("1");
++
++      /* fixed rate */
++      rtpmp4gpay->rate = 90000;
++      /* video stream type */
++      rtpmp4gpay->streamtype = "4";
++      /* no params for video */
++      rtpmp4gpay->params = NULL;
++      /* mode */
++      rtpmp4gpay->mode = "generic";
++
++      media_type = "video";
++    }
+   }
+   if (media_type == NULL)
+     goto config_failed;
+-- 
+1.7.9.5
+

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_git.bb
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_git.bb
@@ -1,0 +1,31 @@
+include gstreamer1.0-plugins-good.inc
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \
+                    file://gst/replaygain/rganalysis.c;beginline=1;endline=23;md5=b60ebefd5b2f5a8e0cab6bfee391a5fe"
+
+S = "${WORKDIR}/git"
+
+UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>(\d+(\.\d+)+))"
+
+SRCREV = "27f40eca4dee0417aa477896b98ebcf4e7c349ce"
+SRCREV_common = "29046b89d80bbca22eb222c18820fb40a4ac5bde"
+SRCREV_FORMAT = "base"
+
+SRC_URI = " \
+	git://anongit.freedesktop.org/gstreamer/gst-plugins-good;branch=master \
+	git://anongit.freedesktop.org/gstreamer/common;destsuffix=git/common;name=common \
+	file://0001-gstrtpmp4gpay-set-dafault-value-for-MPEG4-without-co.patch \
+"
+
+inherit gitpkgv
+PV = "1.12.00+git${SRCPV}"
+PKGV = "1.12.00+git${GITPKGV}"
+
+CFLAGS_append += " -Wno-maybe-uninitialized -Wno-uninitialized "
+
+do_configure_prepend() {
+	cd ${S}
+	./autogen.sh --noconfigure
+	cd ${B}
+}
+

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly.inc
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly.inc
@@ -1,0 +1,33 @@
+require gstreamer1.0-plugins.inc
+
+LICENSE = "GPLv2+ & LGPLv2.1+ & LGPLv2+"
+LICENSE_FLAGS = "commercial"
+
+DEPENDS += "gstreamer1.0-plugins-base libid3tag"
+
+inherit gettext
+
+
+PACKAGECONFIG ??= " \
+    ${GSTREAMER_ORC} \
+    orc a52dec lame mpeg2dec \
+    cdio dvdread amrnb amrwb mpg123 x264 \
+    "
+
+PACKAGECONFIG[a52dec]   = "--enable-a52dec,--disable-a52dec,liba52"
+PACKAGECONFIG[amrnb]    = "--enable-amrnb,--disable-amrnb,opencore-amr"
+PACKAGECONFIG[amrwb]    = "--enable-amrwb,--disable-amrwb,opencore-amr"
+PACKAGECONFIG[cdio]     = "--enable-cdio,--disable-cdio,libcdio"
+PACKAGECONFIG[dvdread]  = "--enable-dvdread,--disable-dvdread,libdvdread"
+PACKAGECONFIG[lame]     = "--enable-lame,--disable-lame,lame"
+PACKAGECONFIG[mpeg2dec] = "--enable-mpeg2dec,--disable-mpeg2dec,mpeg2dec"
+PACKAGECONFIG[x264]     = "--enable-x264,--disable-x264,x264"
+PACKAGECONFIG[mpg123] = "--enable-mpg123,--disable-mpg123,mpg123"
+
+EXTRA_OECONF += " \
+    --disable-sidplay \
+    --disable-twolame \
+    "
+
+FILES_${PN}-x264 += "${datadir}/gstreamer-1.0/presets/GstX264Enc.prs"
+FILES_${PN}-amrnb += "${datadir}/gstreamer-1.0/presets/GstAmrnbEnc.prs"

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.8.%.bbappend
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_1.8.%.bbappend
@@ -1,1 +1,0 @@
-PACKAGECONFIG_append = " amrnb amrwb cdio dvdread mad"

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_git.bb
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_git.bb
@@ -1,0 +1,28 @@
+include gstreamer1.0-plugins-ugly.inc
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \
+                    file://tests/check/elements/xingmux.c;beginline=1;endline=21;md5=4c771b8af188724855cb99cadd390068 "
+
+S = "${WORKDIR}/git"
+
+UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>(\d+(\.\d+)+))"
+
+SRCREV = "d2374716e2cf8d7ecf9b478e5c13e2461cab0a4d"
+SRCREV_common = "29046b89d80bbca22eb222c18820fb40a4ac5bde"
+SRCREV_FORMAT = "base"
+
+SRC_URI = " \
+	git://anongit.freedesktop.org/gstreamer/gst-plugins-ugly;branch=master \
+	git://anongit.freedesktop.org/gstreamer/common;destsuffix=git/common;name=common \
+"
+
+inherit gitpkgv
+PV = "1.12.00+git${SRCPV}"
+PKGV = "1.12.00+git${GITPKGV}"
+
+do_configure_prepend() {
+	cd ${S}
+	./autogen.sh --noconfigure
+	cd ${B}
+}
+

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins.inc
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins.inc
@@ -1,0 +1,40 @@
+SUMMARY = "Plugins for the GStreamer multimedia framework 1.x"
+HOMEPAGE = "http://gstreamer.freedesktop.org/"
+BUGTRACKER = "https://bugzilla.gnome.org/enter_bug.cgi?product=Gstreamer"
+SECTION = "multimedia"
+
+DEPENDS = "gstreamer1.0 glib-2.0-native"
+
+inherit autotools pkgconfig upstream-version-is-even gobject-introspection
+
+acpaths = "-I ${S}/common/m4 -I ${S}/m4"
+
+LIBV = "1.0"
+require gst-plugins-package.inc
+
+# Orc enables runtime JIT compilation of data processing routines from Orc
+# bytecode to SIMD instructions for various architectures (currently SSE, MMX,
+# MIPS, Altivec and NEON are supported).
+
+GSTREAMER_ORC ?= "orc"
+
+PACKAGECONFIG[debug] = "--enable-debug,--disable-debug"
+PACKAGECONFIG[orc] = "--enable-orc,--disable-orc,orc orc-native"
+PACKAGECONFIG[valgrind] = "--enable-valgrind,--disable-valgrind,valgrind"
+
+export ORCC = "${STAGING_DIR_NATIVE}${bindir}/orcc"
+
+EXTRA_OECONF = " \
+    --disable-examples \
+"
+
+SRC_URI_append = " file://0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch"
+
+delete_pkg_m4_file() {
+	# This m4 file is out of date and is missing PKG_CONFIG_SYSROOT_PATH tweaks which we need for introspection
+	rm "${S}/common/m4/pkg.m4" || true
+}
+
+do_configure[prefuncs] += " delete_pkg_m4_file"
+
+PACKAGES_DYNAMIC = "^${PN}-.*"

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0.inc
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0.inc
@@ -1,0 +1,54 @@
+SUMMARY = "GStreamer 1.0 multimedia framework"
+DESCRIPTION = "GStreamer is a multimedia framework for encoding and decoding video and sound. \
+It supports a wide range of formats including mp3, ogg, avi, mpeg and quicktime."
+HOMEPAGE = "http://gstreamer.freedesktop.org/"
+BUGTRACKER = "https://bugzilla.gnome.org/enter_bug.cgi?product=Gstreamer"
+SECTION = "multimedia"
+LICENSE = "LGPLv2+"
+
+DEPENDS = "glib-2.0 glib-2.0-native libcap libxml2 bison-native flex-native"
+
+inherit autotools pkgconfig gettext upstream-version-is-even gobject-introspection
+
+# This way common/m4/introspection.m4 will come first
+# (it has a custom INTROSPECTION_INIT macro, and so must be used instead of our common introspection.m4 file)
+acpaths = "-I ${S}/common/m4 -I ${S}/m4"
+
+PACKAGECONFIG ??= ""
+
+PACKAGECONFIG[check] = "--enable-check,--disable-check"
+PACKAGECONFIG[debug] = "--enable-debug,--disable-debug"
+PACKAGECONFIG[tests] = "--enable-tests,--disable-tests"
+PACKAGECONFIG[valgrind] = "--enable-valgrind,--disable-valgrind,valgrind,"
+
+EXTRA_OECONF = " \
+    --disable-dependency-tracking \
+    --disable-examples \
+    --disable-gtk-doc \
+"
+
+CACHED_CONFIGUREVARS += "ac_cv_header_valgrind_valgrind_h=no"
+
+# musl libc generates warnings if <sys/poll.h> is included directly
+CACHED_CONFIGUREVARS += "ac_cv_header_sys_poll_h=no"
+
+PACKAGES += "${PN}-bash-completion"
+
+FILES_${PN} += "${libdir}/gstreamer-1.0/*.so"
+FILES_${PN}-dbg += " ${libdir}/gstreamer-1.0/.debug/ ${libexecdir}/gstreamer-1.0/.debug/ ${datadir}/bash-completion/helpers/.debug/"
+FILES_${PN}-dev += "${libdir}/gstreamer-1.0/*.la ${libdir}/gstreamer-1.0/*.a ${libdir}/gstreamer-1.0/include"
+FILES_${PN}-bash-completion += "${datadir}/bash-completion/completions/ ${datadir}/bash-completion/helpers/gst*"
+
+RRECOMMENDS_${PN}_qemux86 += "kernel-module-snd-ens1370 kernel-module-snd-rawmidi"
+RRECOMMENDS_${PN}_qemux86-64 += "kernel-module-snd-ens1370 kernel-module-snd-rawmidi"
+
+delete_pkg_m4_file() {
+        # This m4 file is out of date and is missing PKG_CONFIG_SYSROOT_PATH tweaks which we need for introspection
+        rm "${S}/common/m4/pkg.m4" || true
+}
+
+do_configure[prefuncs] += " delete_pkg_m4_file"
+
+do_compile_prepend() {
+        export GIR_EXTRA_LIBS_PATH="${B}/gst/.libs:${B}/libs/gst/base/.libs"
+}

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0/0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0/0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch
@@ -1,0 +1,42 @@
+From 90916f96262fa7b27a0a99788c69f9fd6df11000 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Tue, 24 Nov 2015 16:46:27 +0200
+Subject: [PATCH] introspection.m4: prefix pkgconfig paths with
+ PKG_CONFIG_SYSROOT_DIR
+
+We can't use our tweaked introspection.m4 from gobject-introspection tarball
+because gstreamer also defines INTROSPECTION_INIT in its introspection.m4, which
+is later supplied to g-ir-scanner.
+
+Upstream-Status: Pending [review on oe-core list]
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+---
+ common/m4/introspection.m4 | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/common/m4/introspection.m4 b/common/m4/introspection.m4
+index 162be57..217a6ae 100644
+--- a/common/m4/introspection.m4
++++ b/common/m4/introspection.m4
+@@ -54,14 +54,14 @@ m4_define([_GOBJECT_INTROSPECTION_CHECK_INTERNAL],
+     INTROSPECTION_GIRDIR=
+     INTROSPECTION_TYPELIBDIR=
+     if test "x$found_introspection" = "xyes"; then
+-       INTROSPECTION_SCANNER=`$PKG_CONFIG --variable=g_ir_scanner gobject-introspection-1.0`
+-       INTROSPECTION_COMPILER=`$PKG_CONFIG --variable=g_ir_compiler gobject-introspection-1.0`
+-       INTROSPECTION_GENERATE=`$PKG_CONFIG --variable=g_ir_generate gobject-introspection-1.0`
++       INTROSPECTION_SCANNER=$PKG_CONFIG_SYSROOT_DIR`$PKG_CONFIG --variable=g_ir_scanner gobject-introspection-1.0`
++       INTROSPECTION_COMPILER=$PKG_CONFIG_SYSROOT_DIR`$PKG_CONFIG --variable=g_ir_compiler gobject-introspection-1.0`
++       INTROSPECTION_GENERATE=$PKG_CONFIG_SYSROOT_DIR`$PKG_CONFIG --variable=g_ir_generate gobject-introspection-1.0`
+        INTROSPECTION_GIRDIR=`$PKG_CONFIG --variable=girdir gobject-introspection-1.0`
+        INTROSPECTION_TYPELIBDIR="$($PKG_CONFIG --variable=typelibdir gobject-introspection-1.0)"
+        INTROSPECTION_CFLAGS=`$PKG_CONFIG --cflags gobject-introspection-1.0`
+        INTROSPECTION_LIBS=`$PKG_CONFIG --libs gobject-introspection-1.0`
+-       INTROSPECTION_MAKEFILE=`$PKG_CONFIG --variable=datadir gobject-introspection-1.0`/gobject-introspection-1.0/Makefile.introspection
++       INTROSPECTION_MAKEFILE=$PKG_CONFIG_SYSROOT_DIR`$PKG_CONFIG --variable=datadir gobject-introspection-1.0`/gobject-introspection-1.0/Makefile.introspection
+        INTROSPECTION_INIT="extern void gst_init(gint*,gchar**); gst_init(NULL,NULL);"
+     fi
+     AC_SUBST(INTROSPECTION_SCANNER)
+-- 
+2.6.2
+

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0/0001-revert-use-new-gst-adapter-get-buffer.patch
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0/0001-revert-use-new-gst-adapter-get-buffer.patch
@@ -1,0 +1,36 @@
+diff --git a/libs/gst/base/gstbaseparse.c b/libs/gst/base/gstbaseparse.c
+index eee3c92..d49aad6 100644
+--- a/libs/gst/base/gstbaseparse.c
++++ b/libs/gst/base/gstbaseparse.c
+@@ -2813,6 +2813,7 @@ gst_base_parse_chain (GstPad * pad, GstObject * parent, GstBuffer * buffer)
+   GstBuffer *tmpbuf = NULL;
+   guint fsize = 1;
+   gint skip = -1;
++  const guint8 *data;
+   guint min_size, av;
+   GstClockTime pts, dts;
+ 
+@@ -3012,7 +3011,11 @@ gst_base_parse_chain (GstPad * pad, GstObject * parent, GstBuffer * buffer)
+       parse->priv->next_dts = pts;
+ 
+     /* always pass all available data */
++    data = gst_adapter_map (parse->priv->adapter, av);
++    /* arrange for actual data to be copied if subclass tries to,
++     * since what is passed is tied to the adapter */
++    tmpbuf = gst_buffer_new_wrapped_full (GST_MEMORY_FLAG_READONLY |
++        GST_MEMORY_FLAG_NO_SHARE, (gpointer) data, av, 0, av, NULL, NULL);
+-    tmpbuf = gst_adapter_get_buffer (parse->priv->adapter, av);
+ 
+     /* already inform subclass what timestamps we have planned,
+      * at least if provided by time-based upstream */
+@@ -3029,6 +3024,9 @@ gst_base_parse_chain (GstPad * pad, GstObject * parent, GstBuffer * buffer)
+     ret = gst_base_parse_handle_buffer (parse, tmpbuf, &skip, &flush);
+     tmpbuf = NULL;
+ 
++    /* probably already implicitly unmapped due to adapter operation,
++     * but for good measure ... */
++    gst_adapter_unmap (parse->priv->adapter);
+     if (ret != GST_FLOW_OK && ret != GST_FLOW_NOT_LINKED) {
+       goto done;
+     }
+

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0_git.bb
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0_git.bb
@@ -1,0 +1,31 @@
+include gstreamer1.0.inc
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=6762ed442b3822387a51c92d928ead0d \
+                    file://gst/gst.h;beginline=1;endline=21;md5=e059138481205ee2c6fc1c079c016d0d \
+"
+
+SRC_URI = " \
+	git://anongit.freedesktop.org/gstreamer/gstreamer;branch=master \
+	git://anongit.freedesktop.org/gstreamer/common;destsuffix=git/common;name=common \
+	file://0001-revert-use-new-gst-adapter-get-buffer.patch \
+	file://0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch \
+"
+
+S = "${WORKDIR}/git"
+
+UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>(\d+(\.\d+)+))"
+
+SRCREV = "7854a6597868eeb91bca7518ad73adcb3107f56d"
+SRCREV_common = "29046b89d80bbca22eb222c18820fb40a4ac5bde"
+SRCREV_FORMAT = "base"
+
+inherit gitpkgv
+PV = "1.12.00+git${SRCPV}"
+PKGV = "1.12.00+git${GITPKGV}"
+
+do_configure_prepend() {
+	cd ${S}
+	./autogen.sh --noconfigure
+	cd ${B}
+}
+

--- a/meta-openpli/recipes-openpli/enigma2/enigma2.bb
+++ b/meta-openpli/recipes-openpli/enigma2/enigma2.bb
@@ -89,7 +89,7 @@ GST_GOOD_RDEPS = "\
 	gstreamer1.0-plugins-good-rtp \
 	gstreamer1.0-plugins-good-rtpmanager \
 	gstreamer1.0-plugins-good-rtsp \
-	gstreamer1.0-plugins-good-souphttpsrc \
+	gstreamer1.0-plugins-good-soup \
 	gstreamer1.0-plugins-good-udp \
 	gstreamer1.0-plugins-good-wavparse \
 	"


### PR DESCRIPTION
Using git recipes based on upstream oe and the work of christophecvr.
- Allows us to upgrade to new releases easily
- gstreamer1.0-plugins-good-souphttpsrc has been renamed to gstreamer1.0-plugins-good-soup
- gstreamer1.0-libav builds against our system ffmpeg instead of building it's own