### PR TITLE
Gstreamer 1.12.0 fix remaining build warnings:

### DIFF
--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-libav.inc
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-libav.inc
@@ -4,31 +4,49 @@ SECTION = "multimedia"
 LICENSE = "GPLv2+ & LGPLv2+ & ( (GPLv2+ & LGPLv2.1+) | (GPLv3+ & LGPLv3+) )"
 LICENSE_FLAGS = "commercial"
 
-DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base zlib bzip2 xz"
+DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base zlib bzip2 xz ffmpeg"
 
-inherit autotools pkgconfig upstream-version-is-even
+inherit autotools pkgconfig upstream-version-is-even gtk-doc
 
 # CAUTION: Using the system libav is not recommended. Since the libav API is changing all the time,
 # compilation errors (and other, more subtle bugs) can happen. It is usually better to rely on the
 # libav copy included in the gst-libav package.
-PACKAGECONFIG ??= "orc"
+PACKAGECONFIG ??= "orc libav"
+
+CFLAGS_append = " -Wno-deprecated-declarations "
  
 PACKAGECONFIG[gpl] = "--enable-gpl,--disable-gpl,"
 PACKAGECONFIG[libav] = "--with-system-libav,,libav"
 PACKAGECONFIG[orc] = "--enable-orc,--disable-orc,orc"
 PACKAGECONFIG[yasm] = "--enable-yasm,--disable-yasm,yasm-native"
-
+PACKAGECONFIG[valgrind] = "--enable-valgrind,--disable-valgrind,valgrind"
 
 GSTREAMER_1_0_DEBUG ?= "--disable-debug"
 
 LIBAV_EXTRA_CONFIGURE = "--with-libav-extra-configure"
+
+MIPSFPU = "${@bb.utils.contains('TARGET_FPU', 'soft', ' --disable-mipsfpu', ' --enable-mipsfpu', d)}"
+
+LIBAV_EXTRA_CONFIGURE_COMMON_ARG = "--target-os=linux \
+  --cc='${CC}' --as='${CC}' --ld='${CC}' --nm='${NM}' --ar='${AR}' \
+  --ranlib='${RANLIB}' \
+  ${@bb.utils.contains("TARGET_ARCH", "arm", "", " \
+  --disable-mipsdsp \
+  --disable-mipsdspr0 \
+  ${MIPSFPU}", d)} \
+  ${GSTREAMER_1_0_DEBUG} \
+  --cross-prefix='${HOST_PREFIX}'"
+
+# Disable assembly optimizations for X32, as this libav lacks the support
+PACKAGECONFIG_remove_linux-gnux32 = "yasm"
+LIBAV_EXTRA_CONFIGURE_COMMON_ARG_append_linux-gnux32 = " --disable-asm"
+
 LIBAV_EXTRA_CONFIGURE_COMMON = \
 '${LIBAV_EXTRA_CONFIGURE}="${LIBAV_EXTRA_CONFIGURE_COMMON_ARG}"'
 
 EXTRA_OECONF = "${LIBAV_EXTRA_CONFIGURE_COMMON}"
 
 FILES_${PN} += "${libdir}/gstreamer-1.0/*.so"
-FILES_${PN}-dbg += "${libdir}/gstreamer-1.0/.debug"
 FILES_${PN}-dev += "${libdir}/gstreamer-1.0/*.la"
 FILES_${PN}-staticdev += "${libdir}/gstreamer-1.0/*.a"
 

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-libav_git.bb
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-libav_git.bb
@@ -15,12 +15,7 @@ SRC_URI = " \
 	file://0001-Disable-yasm-for-libav-when-disable-yasm.patch \
 "
 
-
 S = "${WORKDIR}/git"
-
-DEPENDS =+ "ffmpeg"
-PACKAGECONFIG = "orc libav"
-CFLAGS_append = " -Wno-deprecated-declarations "
 
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>(\d+(\.\d+)+))"
 
@@ -30,21 +25,8 @@ inherit gitpkgv
 PV = "1.12.00+git${SRCPV}"
 PKGV = "1.12.00+git${GITPKGV}"
 
-MIPSFPU = "${@bb.utils.contains('TARGET_FPU', 'soft', ' --disable-mipsfpu', ' --enable-mipsfpu', d)}"
-
-LIBAV_EXTRA_CONFIGURE_COMMON_ARG = "--target-os=linux \
-  --cc='${CC}' --as='${CC}' --ld='${CC}' --nm='${NM}' --ar='${AR}' \
-  --ranlib='${RANLIB}' \
-  ${@bb.utils.contains("TARGET_ARCH", "arm", "", " \
-  --disable-mipsdsp \
-  --disable-mipsdspr0 \
-  ${MIPSFPU}", d)} \
-  ${GSTREAMER_1_0_DEBUG} \
-  --cross-prefix='${HOST_PREFIX}'"
-
 do_configure_prepend() {
 	cd ${S}
 	./autogen.sh --noconfigure
 	cd ${B}
 }
-

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad.inc
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad.inc
@@ -2,9 +2,7 @@ require gstreamer1.0-plugins.inc
 
 LICENSE = "GPLv2+ & LGPLv2+ & LGPLv2.1+ "
 
-DEPENDS += "gstreamer1.0-plugins-base bzip2 libpng jpeg libdca"
-
-S = "${WORKDIR}/gst-plugins-bad-${PV}"
+DEPENDS += "gstreamer1.0-plugins-base libpng jpeg libdca"
 
 inherit gettext bluetooth
 

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base.inc
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base.inc
@@ -3,39 +3,38 @@ require gstreamer1.0-plugins.inc
 
 LICENSE = "GPLv2+ & LGPLv2+"
 
-DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'virtual/libx11 libxv', '', d)}"
 DEPENDS += "util-linux iso-codes zlib"
 
 inherit gettext
 
 PACKAGES_DYNAMIC =+ "^libgst.*"
 
-#pango gio-unix-2.0
 PACKAGECONFIG ??= " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'alsa', 'alsa', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'x11', '', d)} \
     orc ivorbis ogg theora vorbis cdparanoia pango opus \
     "
 
-X11DEPENDS = "virtual/libx11 libsm libxrender"
+X11DEPENDS = "virtual/libx11 libsm libxrender libxv"
 X11ENABLEOPTS = "--enable-x --enable-xvideo --enable-xshm"
 X11DISABLEOPTS = "--disable-x --disable-xvideo --disable-xshm"
-PACKAGECONFIG[x11]          = "${X11ENABLEOPTS},${X11DISABLEOPTS},${X11DEPENDS}"
+
 PACKAGECONFIG[alsa]         = "--enable-alsa,--disable-alsa,alsa-lib"
+PACKAGECONFIG[cdparanoia]   = "--enable-cdparanoia,--disable-cdparanoia,cdparanoia"
 PACKAGECONFIG[ivorbis]      = "--enable-ivorbis,--disable-ivorbis,tremor"
 PACKAGECONFIG[ogg]          = "--enable-ogg,--disable-ogg,libogg"
-PACKAGECONFIG[theora]       = "--enable-theora,--disable-theora,libtheora"
-PACKAGECONFIG[vorbis]       = "--enable-vorbis,--disable-vorbis,libvorbis"
-PACKAGECONFIG[pango]        = "--enable-pango,--disable-pango,pango"
-PACKAGECONFIG[visual]       = "--enable-libvisual,--disable-libvisual,libvisual"
-PACKAGECONFIG[cdparanoia]   = "--enable-cdparanoia,--disable-cdparanoia,cdparanoia"
 PACKAGECONFIG[opus]         = "--enable-opus,--disable-opus,libopus"
+PACKAGECONFIG[pango]        = "--enable-pango,--disable-pango,pango"
+PACKAGECONFIG[theora]       = "--enable-theora,--disable-theora,libtheora"
+PACKAGECONFIG[visual]       = "--enable-libvisual,--disable-libvisual,libvisual"
+PACKAGECONFIG[vorbis]       = "--enable-vorbis,--disable-vorbis,libvorbis"
+PACKAGECONFIG[x11]          = "${X11ENABLEOPTS},${X11DISABLEOPTS},${X11DEPENDS}"
 
 EXTRA_OECONF += " \
     --enable-zlib \
     "
-    
-CACHED_CONFIGUREVARS_append_i586 = " ac_cv_header_emmintrin_h=no ac_cv_header_xmmintrin_h=no"
+
+CACHED_CONFIGUREVARS_append_x86 = " ac_cv_header_emmintrin_h=no ac_cv_header_xmmintrin_h=no "
 
 FILES_${MLPREFIX}libgsttag-1.0 += "${datadir}/gst-plugins-base/1.0/license-translations.dict"
 

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0.inc
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0.inc
@@ -6,25 +6,28 @@ BUGTRACKER = "https://bugzilla.gnome.org/enter_bug.cgi?product=Gstreamer"
 SECTION = "multimedia"
 LICENSE = "LGPLv2+"
 
-DEPENDS = "glib-2.0 glib-2.0-native libcap libxml2 bison-native flex-native"
+DEPENDS = "glib-2.0 glib-2.0-native libcap libxml2 bison-native flex-native elfutils"
 
-inherit autotools pkgconfig gettext upstream-version-is-even gobject-introspection
+inherit autotools pkgconfig gettext upstream-version-is-even gobject-introspection gtk-doc
 
 # This way common/m4/introspection.m4 will come first
 # (it has a custom INTROSPECTION_INIT macro, and so must be used instead of our common introspection.m4 file)
 acpaths = "-I ${S}/common/m4 -I ${S}/m4"
 
+SRC_URI_append = " \
+    file://0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch \
+"
+
 PACKAGECONFIG ??= ""
 
-PACKAGECONFIG[check] = "--enable-check,--disable-check"
 PACKAGECONFIG[debug] = "--enable-debug,--disable-debug"
 PACKAGECONFIG[tests] = "--enable-tests,--disable-tests"
 PACKAGECONFIG[valgrind] = "--enable-valgrind,--disable-valgrind,valgrind,"
+PACKAGECONFIG[gst-tracer-hooks] = "--enable-gst-tracer-hooks,--disable-gst-tracer-hooks,"
 
 EXTRA_OECONF = " \
     --disable-dependency-tracking \
     --disable-examples \
-    --disable-gtk-doc \
 "
 
 CACHED_CONFIGUREVARS += "ac_cv_header_valgrind_valgrind_h=no"
@@ -35,7 +38,6 @@ CACHED_CONFIGUREVARS += "ac_cv_header_sys_poll_h=no"
 PACKAGES += "${PN}-bash-completion"
 
 FILES_${PN} += "${libdir}/gstreamer-1.0/*.so"
-FILES_${PN}-dbg += " ${libdir}/gstreamer-1.0/.debug/ ${libexecdir}/gstreamer-1.0/.debug/ ${datadir}/bash-completion/helpers/.debug/"
 FILES_${PN}-dev += "${libdir}/gstreamer-1.0/*.la ${libdir}/gstreamer-1.0/*.a ${libdir}/gstreamer-1.0/include"
 FILES_${PN}-bash-completion += "${datadir}/bash-completion/completions/ ${datadir}/bash-completion/helpers/gst*"
 
@@ -45,9 +47,22 @@ RRECOMMENDS_${PN}_qemux86-64 += "kernel-module-snd-ens1370 kernel-module-snd-raw
 delete_pkg_m4_file() {
         # This m4 file is out of date and is missing PKG_CONFIG_SYSROOT_PATH tweaks which we need for introspection
         rm "${S}/common/m4/pkg.m4" || true
+        rm -f "${S}/common/m4/gtk-doc.m4"
 }
 
-do_configure[prefuncs] += " delete_pkg_m4_file"
+# gstreamer is not using system-wide makefiles (which we patch in gtkdoc recipe,
+# but its own custom ones, which we have to patch here
+patch_gtk_doc_makefiles() {
+        # Patch the gtk-doc makefiles so that the qemu wrapper is used to run transient binaries
+        # instead of libtool wrapper or running them directly
+        # Also substitute a bogus plugin scanner, as trying to run the real one is causing issues during build on x86_64.
+        sed -i \
+           -e "s|GTKDOC_RUN =.*|GTKDOC_RUN = \$(top_builddir)/gtkdoc-qemuwrapper|" \
+           -e "s|\$(GTKDOC_EXTRA_ENVIRONMENT)|\$(GTKDOC_EXTRA_ENVIRONMENT) GST_PLUGIN_SCANNER_1_0=\$(top_builddir)/libs/gst/helpers/gst-plugin-scanner-dummy|" \
+           ${S}/common/gtk-doc*mak
+}
+
+do_configure[prefuncs] += " delete_pkg_m4_file patch_gtk_doc_makefiles"
 
 do_compile_prepend() {
         export GIR_EXTRA_LIBS_PATH="${B}/gst/.libs:${B}/libs/gst/base/.libs"

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0_git.bb
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0_git.bb
@@ -8,7 +8,6 @@ SRC_URI = " \
 	git://anongit.freedesktop.org/gstreamer/gstreamer;branch=master;name=base \
 	git://anongit.freedesktop.org/gstreamer/common;destsuffix=git/common;name=common \
 	file://0001-revert-use-new-gst-adapter-get-buffer.patch \
-	file://0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch \
 "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
- gstreamer1.0 depends on elfutils
- Remove unused configure flags
- clean remaining unused parameters
- inherit gtk-doc like in upstream