### PR TITLE
Update ffmpeg to 3.3 and adapt for exteplayer3

### DIFF
--- a/meta-openpli/recipes-multimedia/ffmpeg/ffmpeg/000001_add_dash_demux.patch
+++ b/meta-openpli/recipes-multimedia/ffmpeg/ffmpeg/000001_add_dash_demux.patch
@@ -1,0 +1,1864 @@
+diff -uNr ffmpeg-3.2.2/libavformat/allformats.c ffmpeg-3.2.2_dash_demux/libavformat/allformats.c
+--- ffmpeg-3.2.2/libavformat/allformats.c	2016-12-06 00:28:54.000000000 +0100
++++ ffmpeg-3.2.2_dash_demux/libavformat/allformats.c	2017-01-31 23:46:22.850211062 +0100
+@@ -100,7 +100,7 @@
+     REGISTER_DEMUXER (CINE,             cine);
+     REGISTER_DEMUXER (CONCAT,           concat);
+     REGISTER_MUXER   (CRC,              crc);
+-    REGISTER_MUXER   (DASH,             dash);
++    REGISTER_MUXDEMUX(DASH,             dash);
+     REGISTER_MUXDEMUX(DATA,             data);
+     REGISTER_MUXDEMUX(DAUD,             daud);
+     REGISTER_DEMUXER (DCSTR,            dcstr);
+diff -uNr ffmpeg-3.2.2/libavformat/dashdec.c ffmpeg-3.2.2_dash_demux/libavformat/dashdec.c
+--- ffmpeg-3.2.2/libavformat/dashdec.c	1970-01-01 01:00:00.000000000 +0100
++++ ffmpeg-3.2.2_dash_demux/libavformat/dashdec.c	2017-01-31 23:49:16.481109867 +0100
+@@ -0,0 +1,1803 @@
++/*
++ * Dynamic Adaptive Streaming over HTTP demux
++ * Copyright (c) 2017 samsamsam@o2.pl based on HLS demux
++ *
++ * This file is part of FFmpeg.
++ *
++ * FFmpeg is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * FFmpeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with FFmpeg; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ */
++ 
++ /* Code prepared for ffmpeg 2.8.9 and then ported to ffmpeg 3.2.2
++  * At now it allow to play one selected representation for audio and video components.
++  * 
++  */
++
++/**
++ * @file
++ */
++#include "libavutil/avstring.h"
++#include "libavutil/avassert.h"
++#include "libavutil/intreadwrite.h"
++#include "libavutil/mathematics.h"
++#include "libavutil/opt.h"
++#include "libavutil/dict.h"
++#include "libavutil/time.h"
++#include "avformat.h"
++#include "internal.h"
++#include "avio_internal.h"
++#include "url.h"
++#include "id3v2.h"
++
++#define INITIAL_BUFFER_SIZE 32768
++
++/////////////////////////////////////////////////////////////////////////////
++/////////////////////////////////////////////////////////////////////////////
++#include <time.h>
++#include <unistd.h>
++
++static struct tm* ResolveUTCDateTime(const char *dateTimeString)
++{
++    time_t rawtime;
++    struct tm* timeInfo = NULL;
++    int y = 0;
++    int M = 0;
++    int d = 0;
++    int h = 0;
++    int m = 0;
++    float s = 0.0;
++    
++    /* ISO-8601 date parser */
++    
++    if (dateTimeString == NULL || '\0' == dateTimeString[0])
++        return NULL;
++
++
++    time ( &rawtime );
++    timeInfo = gmtime ( &rawtime );
++
++    sscanf(dateTimeString, "%d-%d-%dT%d:%d:%fZ", &y, &M, &d, &h, &m, &s);
++
++    timeInfo->tm_year = y - 1900;
++    timeInfo->tm_mon  = M - 1;
++    timeInfo->tm_mday = d;
++
++    timeInfo->tm_hour = h;
++    timeInfo->tm_min  = m;
++    timeInfo->tm_sec  = (int)s;
++
++    return timeInfo;
++}
++
++static struct tm*  GetCurrentUTCTime(void)
++{
++    time_t rawTime;
++    time(&rawTime);
++    return gmtime(&rawTime);
++}
++
++static uint32_t GetCurrentTimeInSec(void)
++{
++    return (uint32_t)mktime(GetCurrentUTCTime());
++}
++
++static uint32_t GetUTCDateTimeInSec(const char *datetime)
++{
++    return (uint32_t)mktime(ResolveUTCDateTime(datetime));
++}
++
++static uint32_t GetDurationInSec(const char *duration)
++{
++    /* ISO-8601 duration parser */
++    
++    uint32_t days = 0;
++    uint32_t hours = 0;
++    uint32_t mins = 0;
++    uint32_t secs = 0;
++
++    const char *ptr = duration;
++    while(*ptr)
++    {
++        float value = 0;
++        uint32_t charsRead;
++        char type = '\0';
++        
++        if(*ptr == 'P' || *ptr == 'T')
++        {
++            ptr++;
++            continue;
++        }
++
++        if(sscanf(ptr, "%f%c%n", &value, &type, &charsRead) != 2) {
++            return 0; /* parser error */
++        }
++        switch(type) {
++            case 'D':
++                days = (uint32_t)value;
++            break;
++            case 'H':
++                hours = (uint32_t)value;
++            break;
++            case 'M':
++                mins = (uint32_t)value;
++            break;
++            case 'S':
++                secs = (uint32_t)value;
++            break;
++            default:
++            // handle invalid type
++                break;
++        }
++        ptr += charsRead;
++    }
++    return  ((days * 24 + hours) * 60 + mins) * 60 + secs;
++}
++//###########################################################################
++
++struct segment {
++    //int64_t duration;
++    int64_t url_offset;
++    int64_t size;
++    char *url;
++};
++
++struct timeline {
++    int64_t t;
++    int32_t r;
++    int64_t d;
++};
++
++enum RepType {
++    REP_TYPE_UNSPECIFIED,
++    REP_TYPE_AUDIO,
++    REP_TYPE_VIDEO
++};
++
++enum TemUrlType {
++    TMP_URL_TYPE_UNSPECIFIED,
++    TMP_URL_TYPE_NUMBER,
++    TMP_URL_TYPE_TIME
++};
++
++/*
++ * Each playlist has its own demuxer. If it currently is active,
++ * it has an open AVIOContext too, and potentially an AVPacket
++ * containing the next packet from this stream.
++ */
++struct representation {
++    char *url_template;
++    enum TemUrlType tmp_url_type;
++    AVIOContext pb;
++    AVIOContext *input;
++    AVFormatContext *parent;
++    AVFormatContext *ctx;
++    AVPacket pkt;
++    int rep_idx;
++    int rep_count;
++    int stream_index;
++
++    enum RepType type;
++    int64_t target_duration;
++    
++    int n_segments;
++    struct segment **segments; /* VOD list of segment for profile */
++    
++    int n_timelines;
++    struct timeline **timelines;
++
++    int64_t first_seq_no;
++    int64_t last_seq_no;
++    
++    int64_t segmentDuration;
++    int64_t segmentTimescalce;
++    
++    int64_t cur_seq_no;
++    int64_t cur_seg_offset;
++    int64_t cur_seg_size;
++    struct segment *cur_seg;
++
++    /* Currently active Media Initialization Section */
++    struct segment *init_section;
++    uint8_t *init_sec_buf;
++    uint32_t init_sec_buf_size;
++    uint32_t init_sec_data_len;
++    uint32_t init_sec_buf_read_offset;
++    
++    int fix_multiple_stsd_order;
++
++    int64_t cur_timestamp;
++};
++
++typedef struct DASHContext {
++    AVClass *class;
++
++    char *base_url;
++    
++    struct representation *cur_video;
++    struct representation *cur_audio;
++    
++    uint32_t mediaPresentationDurationSec;
++    
++    uint32_t suggestedPresentationDelaySec;
++    uint32_t presentationDelaySec;
++    uint32_t availabilityStartTimeSec;
++    uint32_t publishTimeSec;
++    uint32_t minimumUpdatePeriodSec;
++    uint32_t timeShiftBufferDepthSec;
++    uint32_t minBufferTimeSec;
++    
++    uint32_t periodDurationSec;
++    uint32_t periodStartSec;
++    
++    int is_live;
++       
++    int audio_rep_index;
++    int video_rep_index;
++    
++    AVIOInterruptCB *interrupt_callback;
++    char *user_agent;                    ///< holds HTTP user agent set as an AVOption to the HTTP protocol context
++    char *cookies;                       ///< holds HTTP cookie values set in either the initial response or as an AVOption to the HTTP protocol context
++    char *headers;                       ///< holds HTTP headers set as an AVOption to the HTTP protocol context
++    AVDictionary *avio_opts;
++} DASHContext;
++
++
++static void free_segment(struct segment **seg)
++{
++    if (!seg || !(*seg)) {
++        return;
++    }
++    
++    av_freep(&(*seg)->url);
++    av_freep(seg);
++}
++
++static void free_segment_list(struct representation *pls)
++{
++    int i;
++    for (i = 0; i < pls->n_segments; i++) {
++        av_freep(&pls->segments[i]->url);
++        av_freep(&pls->segments[i]);
++    }
++    av_freep(&pls->segments);
++    pls->n_segments = 0;
++}
++
++static void free_timelines_list(struct representation *pls)
++{
++    int i;
++    for (i = 0; i < pls->n_timelines; i++) {
++        av_freep(&pls->timelines[i]);
++    }
++    av_freep(&pls->timelines);
++    pls->n_timelines = 0;
++}
++
++/*
++ * Used to reset a statically allocated AVPacket to a clean slate,
++ * containing no data.
++ */
++static void reset_packet(AVPacket *pkt)
++{
++    av_init_packet(pkt);
++    pkt->data = NULL;
++}
++
++static void free_representation(struct representation *pls)
++{
++    free_segment_list(pls);
++    free_timelines_list(pls);
++    free_segment(&pls->cur_seg);
++    free_segment(&pls->init_section);
++    av_freep(&pls->init_sec_buf);
++    av_packet_unref(&pls->pkt);
++    reset_packet(&pls->pkt);
++    av_freep(&pls->pb.buffer);
++    if (pls->input)
++        ff_format_io_close(pls->parent, &pls->input);
++    if (pls->ctx) {
++        pls->ctx->pb = NULL;
++        avformat_close_input(&pls->ctx);
++    }
++    
++    av_free(pls->url_template);
++    av_free(pls);
++}
++
++static void update_options(char **dest, const char *name, void *src)
++{
++    av_freep(dest);
++    av_opt_get(src, name, AV_OPT_SEARCH_CHILDREN, (uint8_t**)dest);
++    if (*dest && !strlen(*dest))
++        av_freep(dest);
++}
++
++static int open_url(AVFormatContext *s, AVIOContext **pb, const char *url,
++                    AVDictionary *opts, AVDictionary *opts2, int *is_http)
++{
++    DASHContext *c = s->priv_data;
++    AVDictionary *tmp = NULL;
++    const char *proto_name = NULL;
++    int ret;
++
++    av_dict_copy(&tmp, opts, 0);
++    av_dict_copy(&tmp, opts2, 0);
++
++    if (!proto_name)
++        proto_name = avio_find_protocol_name(url);
++
++    if (!proto_name)
++        return AVERROR_INVALIDDATA;
++
++    // only http(s) & file are allowed
++    if (!av_strstart(proto_name, "http", NULL) && !av_strstart(proto_name, "file", NULL))
++        return AVERROR_INVALIDDATA;
++    if (!strncmp(proto_name, url, strlen(proto_name)) && url[strlen(proto_name)] == ':')
++        ;
++    else if (strcmp(proto_name, "file") || !strncmp(url, "file,", 5))
++        return AVERROR_INVALIDDATA;
++
++    ret = s->io_open(s, pb, url, AVIO_FLAG_READ, &tmp);
++    if (ret >= 0) {
++        // update cookies on http response with setcookies.
++        void *u = (s->flags & AVFMT_FLAG_CUSTOM_IO) ? NULL : s->pb;
++        update_options(&c->cookies, "cookies", u);
++        av_dict_set(&opts, "cookies", c->cookies, 0);
++    }
++
++    av_dict_free(&tmp);
++
++    if (is_http)
++        *is_http = av_strstart(proto_name, "http", NULL);
++
++    return ret;
++}
++
++/////////////////////////////////////////////////////////////////////////////
++/////////////////////////////////////////////////////////////////////////////
++#include <libxml/parser.h>
++#include <libxml/tree.h>
++
++#include <string.h>
++#include <stdlib.h>
++#include <stddef.h>
++
++#if (__STDC_VERSION__ >= 199901L)
++#include <stdint.h>
++#endif
++
++//http://creativeandcritical.net/str-replace-c
++
++static char *repl_str(const char *str, const char *from, const char *to)
++{
++    /* Adjust each of the below values to suit your needs. */
++
++    /* Increment positions cache size initially by this number. */
++    size_t cache_sz_inc = 16;
++    /* Thereafter, each time capacity needs to be increased,
++     * multiply the increment by this factor. */
++    const size_t cache_sz_inc_factor = 3;
++    /* But never increment capacity by more than this number. */
++    const size_t cache_sz_inc_max = 1048576;
++
++    char *pret, *ret = NULL;
++    const char *pstr2, *pstr = str;
++    size_t i, count = 0;
++    #if (__STDC_VERSION__ >= 199901L)
++    uintptr_t *pos_cache_tmp, *pos_cache = NULL;
++    #else
++    ptrdiff_t *pos_cache_tmp, *pos_cache = NULL;
++    #endif
++    size_t cache_sz = 0;
++    size_t cpylen, orglen, retlen, tolen, fromlen = strlen(from);
++
++    /* Find all matches and cache their positions. */
++    while ((pstr2 = strstr(pstr, from)) != NULL) {
++        count++;
++
++        /* Increase the cache size when necessary. */
++        if (cache_sz < count) {
++            cache_sz += cache_sz_inc;
++            pos_cache_tmp = realloc(pos_cache, sizeof(*pos_cache) * cache_sz);
++            if (pos_cache_tmp == NULL) {
++                goto end_repl_str;
++            } else pos_cache = pos_cache_tmp;
++            cache_sz_inc *= cache_sz_inc_factor;
++            if (cache_sz_inc > cache_sz_inc_max) {
++                cache_sz_inc = cache_sz_inc_max;
++            }
++        }
++
++        pos_cache[count-1] = pstr2 - str;
++        pstr = pstr2 + fromlen;
++    }
++
++    orglen = pstr - str + strlen(pstr);
++
++    /* Allocate memory for the post-replacement string. */
++    if (count > 0) {
++        tolen = strlen(to);
++        retlen = orglen + (tolen - fromlen) * count;
++    } else	retlen = orglen;
++    ret = av_malloc(retlen + 1);
++    if (ret == NULL) {
++        goto end_repl_str;
++    }
++
++    if (count == 0) {
++        /* If no matches, then just duplicate the string. */
++        strcpy(ret, str);
++    } else {
++        /* Otherwise, duplicate the string whilst performing
++         * the replacements using the position cache. */
++        pret = ret;
++        memcpy(pret, str, pos_cache[0]);
++        pret += pos_cache[0];
++        for (i = 0; i < count; i++) {
++            memcpy(pret, to, tolen);
++            pret += tolen;
++            pstr = str + pos_cache[i] + fromlen;
++            cpylen = (i == count-1 ? orglen : pos_cache[i+1]) - pos_cache[i] - fromlen;
++            memcpy(pret, pstr, cpylen);
++            pret += cpylen;
++        }
++        ret[retlen] = '\0';
++    }
++
++end_repl_str:
++    /* Free the cache and return the post-replacement string,
++     * which will be NULL in the event of an error. */
++    free(pos_cache);
++    return ret;
++}
++
++static char *repl_template_str(const char * url, const char *marker)
++{
++    char *prefix = NULL;
++    char *start = 0;
++    char *end   = NULL;
++    char *tmp_url = NULL;
++    char *new_url = NULL;
++    int marker_len;
++    
++    prefix = av_strdup(marker);
++    marker_len = strlen(prefix)-1;
++    prefix[marker_len] = '\0';
++    
++    start = strstr(url, prefix);
++    if (!start)
++        goto finish;
++    end = strchr(start+1, '$');
++    if (!end)
++        goto finish;
++
++    if (start[marker_len] != '%')
++        goto finish;
++
++    if (end[-1] != 'd')
++        goto finish;
++    
++    tmp_url = av_mallocz(MAX_URL_SIZE);
++    strncpy(tmp_url, url, start - url);
++    strncat(tmp_url, start + marker_len, end - start - marker_len -1);
++    strcat(tmp_url, PRId64);
++    strcat(tmp_url, end+1);
++finish:
++    av_free(prefix);
++    new_url = repl_str(tmp_url ? tmp_url : url, marker, "%"PRId64);
++    av_free(tmp_url);
++    return new_url;
++}
++
++static char * get_content_url(xmlNodePtr *baseUrlNodes, int n_baseUrlNodes, xmlChar *rep_id_val, xmlChar *rep_bandwidth_val, xmlChar *val)
++{
++    char *tmp_str = av_mallocz(MAX_URL_SIZE);
++    char *url = NULL;
++    int i;
++    for (i = 0; i < n_baseUrlNodes; ++i) {
++        if (baseUrlNodes[i] && baseUrlNodes[i]->children && baseUrlNodes[i]->children->type == XML_TEXT_NODE) {
++            xmlChar *text = xmlNodeGetContent(baseUrlNodes[i]->children);
++            if (text) {
++                char *tmp_str_2 = av_mallocz(MAX_URL_SIZE);
++                ff_make_absolute_url(tmp_str_2, MAX_URL_SIZE, tmp_str, text);
++                av_free(tmp_str);
++                tmp_str = tmp_str_2;
++                xmlFree(text);
++            }
++        }
++    }
++    
++    if (val)
++        strcat(tmp_str, (const char*)val);
++        
++    if (rep_id_val) {
++        url = repl_str(tmp_str, "$RepresentationID$", (const char*)rep_id_val);
++        av_free(tmp_str);
++        tmp_str = url;
++    }
++        
++    if (rep_bandwidth_val && tmp_str)
++        url = repl_str(tmp_str, "$Bandwidth$", (const char*)rep_bandwidth_val);
++    
++    if (tmp_str != url)
++        av_free(tmp_str);
++    
++    return url;
++}
++
++static xmlChar * get_val_from_nodes_tab(xmlNodePtr *nodes, const int n_nodes, const xmlChar *attrName)
++{
++    int i;
++    for (i = 0; i < n_nodes; ++i) {
++        if (nodes[i]) {
++            xmlChar *val = xmlGetProp(nodes[i], attrName);
++            if (val)
++                return val;
++        }
++    }
++    return NULL;
++}
++
++static xmlNodePtr findChildNodeByName(xmlNodePtr rootnode, const xmlChar *nodename)
++{
++    xmlNodePtr node = rootnode;
++    if (node == NULL) {
++        return NULL;
++    }
++
++    node = xmlFirstElementChild(node);
++    while (node != NULL) {
++
++        if (!xmlStrcmp(node->name, nodename)) {
++            return node; 
++        }
++        node = xmlNextElementSibling(node);
++    }
++    return NULL;
++}
++
++static enum RepType get_content_type(xmlNodePtr node) 
++{
++    enum RepType type = REP_TYPE_UNSPECIFIED;
++    if (node) {
++        int i = 0;
++        while (type == REP_TYPE_UNSPECIFIED && i < 2) {
++            const char *attr = (i == 0) ? "contentType" : "mimeType"; 
++            xmlChar *val = xmlGetProp(node, attr);
++            if (val) {
++                if (strstr((const char *) val, "video"))
++                    type = REP_TYPE_VIDEO;
++                else if (strstr((const char *) val, "audio"))
++                    type = REP_TYPE_AUDIO;
++                xmlFree(val);
++            }
++            i += 1;
++        }
++    }
++    return type;
++}
++
++static int parse_mainifest(AVFormatContext *s, const char *url, AVIOContext *in)
++{
++    DASHContext *c = s->priv_data;
++    int ret = 0;
++    int close_in = 0;
++    uint8_t *new_url = NULL;
++    
++    int64_t filesize = 0;
++    char *buffer = NULL;
++
++    if (!in) {
++        AVDictionary *opts = NULL;
++        close_in = 1;
++        /* This is XML mainfest there is no need to set range header */
++        av_dict_set(&opts, "seekable", "0", 0);
++
++        // broker prior HTTP options that should be consistent across requests
++        av_dict_set(&opts, "user-agent", c->user_agent, 0);
++        av_dict_set(&opts, "cookies", c->cookies, 0);
++        av_dict_set(&opts, "headers", c->headers, 0);
++
++        ret = avio_open2(&in, url, AVIO_FLAG_READ,
++                         c->interrupt_callback, &opts);
++        av_dict_free(&opts);
++        if (ret < 0)
++            return ret;
++    }
++
++    if (av_opt_get(in, "location", AV_OPT_SEARCH_CHILDREN, &new_url) >= 0) {
++        c->base_url = av_strdup(new_url);
++    } else {
++        c->base_url = av_strdup(url);
++    }
++    
++    filesize = avio_size(in);
++    if (filesize <= 0){
++        filesize = 8 * 1024;
++    }
++      
++    buffer = av_mallocz(filesize);
++    
++    if (!buffer) {
++        return AVERROR(ENOMEM);
++    }
++    
++    filesize = avio_read(in, buffer, filesize);
++    if (filesize > 0) {
++        xmlDoc *doc = NULL;
++        xmlNodePtr root_element = NULL;
++        xmlNodePtr node = NULL;
++        xmlNodePtr periodNode = NULL;
++        xmlNodePtr mpdBaseUrlNode = NULL;
++        xmlNodePtr periodBaseUrlNode = NULL;
++        xmlNodePtr adaptionSetNode = NULL;
++        xmlAttrPtr attr = NULL;
++        xmlChar * val  = NULL;
++        uint32_t perdiodDurationSec = 0;
++        uint32_t perdiodStartSec = 0;
++        
++        int32_t audioRepIdx = 0;
++        int32_t videoRepIdx = 0;
++        
++        LIBXML_TEST_VERSION
++    
++        doc = xmlReadMemory(buffer, filesize, c->base_url, NULL, 0);
++        root_element = xmlDocGetRootElement(doc);
++        node = root_element;
++        
++        if (!node) {
++            ret = AVERROR_INVALIDDATA;
++            av_log(s, AV_LOG_ERROR, "Unable to parse '%s' - missing root node\n", url);
++            goto cleanup;
++        }
++        
++        if (node->type != XML_ELEMENT_NODE || 
++            xmlStrcmp(node->name, (const xmlChar *)"MPD")) {
++            ret = AVERROR_INVALIDDATA;
++            av_log(s, AV_LOG_ERROR, "Unable to parse '%s' - wrong root node name[%s] type[%d]\n", url, node->name, (int)node->type);
++            goto cleanup;
++        }
++        
++        val = xmlGetProp(node, "type");
++        if (!val) {
++            av_log(s, AV_LOG_ERROR, "Unable to parse '%s' - missing type attrib\n", url);
++            ret = AVERROR_INVALIDDATA;
++            goto cleanup;
++        }
++        if (!xmlStrcmp(val, (const xmlChar *)"dynamic"))
++            c->is_live = 1;
++        xmlFree(val);
++        
++        attr = node->properties;
++        while(attr) {
++            val = xmlGetProp(node, attr->name);
++            
++            if (!xmlStrcmp(attr->name, (const xmlChar *)"availabilityStartTime"))
++                c->availabilityStartTimeSec = GetUTCDateTimeInSec((const char *)val);
++            else if (!xmlStrcmp(attr->name, (const xmlChar *)"publishTime"))
++                c->publishTimeSec = GetUTCDateTimeInSec((const char *)val);
++            else if (!xmlStrcmp(attr->name, (const xmlChar *)"minimumUpdatePeriod"))
++                c->minimumUpdatePeriodSec = GetDurationInSec((const char *)val);
++            else if (!xmlStrcmp(attr->name, (const xmlChar *)"timeShiftBufferDepth"))
++                c->timeShiftBufferDepthSec = GetDurationInSec((const char *)val);
++            else if (!xmlStrcmp(attr->name, (const xmlChar *)"minBufferTime"))
++                c->minBufferTimeSec = GetDurationInSec((const char *)val);
++            else if (!xmlStrcmp(attr->name, (const xmlChar *)"suggestedPresentationDelay"))
++                c->suggestedPresentationDelaySec = GetDurationInSec((const char *)val);
++            else if (!xmlStrcmp(attr->name, (const xmlChar *)"mediaPresentationDuration"))
++                c->mediaPresentationDurationSec = GetDurationInSec((const char *)val);
++            
++            attr = attr->next;
++            
++            xmlFree(val);
++        } 
++        
++        mpdBaseUrlNode = findChildNodeByName(node, "BaseURL");
++        
++        // at now we can handle only one period, with the longest duration
++        node = xmlFirstElementChild(node);
++        while (node) {
++            if (!xmlStrcmp(node->name, (const xmlChar *)"Period")) {
++                perdiodDurationSec = 0;
++                perdiodStartSec = 0;
++                attr = node->properties;
++                while(attr) {
++                    val = xmlGetProp(node, attr->name);
++                    
++                    if (!xmlStrcmp(attr->name, (const xmlChar *)"duration"))
++                        perdiodDurationSec = GetDurationInSec((const char *)val);
++                    else if (!xmlStrcmp(attr->name, (const xmlChar *)"start"))
++                        perdiodStartSec = GetDurationInSec((const char *)val);
++                    attr = attr->next;
++                    
++                    xmlFree(val);
++                }
++                
++                if ((perdiodDurationSec) >= (c->periodDurationSec)) {
++                    periodNode = node;
++                    c->periodDurationSec = perdiodDurationSec;
++                    c->periodStartSec = perdiodStartSec;
++                    if (c->periodStartSec > 0)
++                        c->mediaPresentationDurationSec = c->periodDurationSec;
++                }
++            }
++            
++            node = xmlNextElementSibling(node);
++        }
++        
++        if (!periodNode) {
++            av_log(s, AV_LOG_ERROR, "Unable to parse '%s' - missing Period node\n", url);
++            ret = AVERROR_INVALIDDATA;
++            goto cleanup;
++        }
++        
++        // explore AdaptationSet
++        adaptionSetNode = xmlFirstElementChild(periodNode);
++        while (adaptionSetNode) {
++            if (!xmlStrcmp(adaptionSetNode->name, (const xmlChar *)"BaseURL")) {
++                periodBaseUrlNode = adaptionSetNode;
++            } else if (!xmlStrcmp(adaptionSetNode->name, (const xmlChar *)"AdaptationSet")) {
++                xmlNodePtr segmentTemplateNode = NULL;
++                xmlNodePtr contentComponentNode = NULL;
++                xmlNodePtr adaptionSetBaseUrlNode = NULL;
++                
++                node = xmlFirstElementChild(adaptionSetNode);
++                while (node) {
++                    if (!xmlStrcmp(node->name, (const xmlChar *)"SegmentTemplate")) {
++                        segmentTemplateNode = node;
++                    } else if (!xmlStrcmp(node->name, (const xmlChar *)"ContentComponent")) {
++                        contentComponentNode = node;
++                    } else if (!xmlStrcmp(node->name, (const xmlChar *)"BaseURL")) {
++                        adaptionSetBaseUrlNode = node;
++                    } else if (!xmlStrcmp(node->name, (const xmlChar *)"Representation")) {
++                        xmlNodePtr representationNode = node;
++                        xmlChar *rep_id_val = xmlGetProp(representationNode, "id");
++                        xmlChar *rep_bandwidth_val = xmlGetProp(representationNode, "bandwidth");
++                        enum RepType type = REP_TYPE_UNSPECIFIED;
++                        
++                        
++                        // try get information from representation
++                        if (type == REP_TYPE_UNSPECIFIED)
++                            type = get_content_type(representationNode);
++                        // try get information from contentComponen
++                        if (type == REP_TYPE_UNSPECIFIED)
++                            type = get_content_type(contentComponentNode);
++                        // try get information from adaption set
++                        if (type == REP_TYPE_UNSPECIFIED)
++                            type = get_content_type(adaptionSetNode);
++                        
++                        if (type == REP_TYPE_UNSPECIFIED) {
++                            av_log(s, AV_LOG_VERBOSE, "Parsing '%s' - skipp not supported representation type\n", url);
++                        } else if ( (type == REP_TYPE_VIDEO && ((c->video_rep_index < 0 && !c->cur_video) || videoRepIdx == (int32_t)c->video_rep_index )) || 
++                                    (type == REP_TYPE_AUDIO && ((c->audio_rep_index < 0 && !c->cur_audio) || audioRepIdx == (int32_t)c->audio_rep_index )) ) {
++                            
++                            // convert selected representation to our internal struct
++                            struct representation *rep = av_mallocz(sizeof(struct representation));
++                            xmlNodePtr representationSegmentTemplateNode = findChildNodeByName(representationNode, "SegmentTemplate");
++                            xmlNodePtr representationBaseUrlNode = findChildNodeByName(representationNode, "BaseURL");
++                            xmlNodePtr representationSegmentListNode = findChildNodeByName(representationNode, "SegmentList");
++                            reset_packet(&rep->pkt);
++                            if (representationSegmentTemplateNode || segmentTemplateNode) {
++                                xmlNodePtr segmentTimelineNode = NULL;
++                                
++                                xmlNodePtr segmentTemplatesTab[2] = {representationSegmentTemplateNode, segmentTemplateNode};
++                                xmlChar *duration_val        = get_val_from_nodes_tab(segmentTemplatesTab,  2, "duration");
++                                xmlChar *startNumber_val     = get_val_from_nodes_tab(segmentTemplatesTab,  2, "startNumber");
++                                xmlChar *timescale_val       = get_val_from_nodes_tab(segmentTemplatesTab,  2, "timescale");
++                                
++                                xmlChar *initialization_val  = get_val_from_nodes_tab(segmentTemplatesTab,  2, "initialization");
++                                xmlChar *media_val           = get_val_from_nodes_tab(segmentTemplatesTab,  2, "media");
++                                
++                                xmlNodePtr baseUrlNodes[4] = {mpdBaseUrlNode, periodBaseUrlNode, adaptionSetBaseUrlNode, representationBaseUrlNode};
++                                
++                                if (initialization_val) {
++                                    rep->init_section = av_mallocz(sizeof(struct segment));
++                                    rep->init_section->url = get_content_url(baseUrlNodes, 4, rep_id_val, rep_bandwidth_val, initialization_val);
++                                    rep->init_section->size = -1;
++                                    xmlFree(initialization_val);
++                                }
++                                
++                                if (media_val) {
++                                    char * tmp_str = get_content_url(baseUrlNodes, 4, rep_id_val, rep_bandwidth_val, media_val);
++                                    if (tmp_str) {
++                                        if (strstr(tmp_str, "$Number")) {
++                                            rep->url_template = repl_template_str(tmp_str, "$Number$");
++                                            //  A URL template is provided from which clients build a chunk list where the chunk URLs include chunk numbers (like index numbers).
++                                            rep->tmp_url_type = TMP_URL_TYPE_NUMBER; // (Chunk) Number-Based.
++                                        } else if (strstr(tmp_str, "$Time")) {
++                                            rep->url_template = repl_template_str(tmp_str, "$Time$");
++                                            // A URL template is provided from which clients build a chunk list where the chunk URLs include chunk start times.
++                                            rep->tmp_url_type = TMP_URL_TYPE_TIME; // (CTime-Based.
++                                        } else {
++                                            rep->url_template = tmp_str;
++                                            tmp_str = NULL;
++                                        }
++                                        av_free(tmp_str);
++                                    }
++                                    xmlFree(media_val);
++                                }
++                                
++                                if (duration_val) {
++                                    rep->segmentDuration = (int64_t) atoll((const char *)duration_val);
++                                    xmlFree(duration_val);
++                                }
++                                
++                                if (timescale_val) {
++                                    rep->segmentTimescalce = (int64_t) atoll((const char *)timescale_val);
++                                    xmlFree(timescale_val);
++                                }
++                                
++                                if (startNumber_val) {
++                                    rep->first_seq_no = (int64_t) atoll((const char *)startNumber_val);
++                                    xmlFree(startNumber_val);
++                                }
++                                
++                                segmentTimelineNode = findChildNodeByName(representationSegmentTemplateNode, "SegmentTimeline");
++                                if (!segmentTimelineNode) 
++                                    segmentTimelineNode = findChildNodeByName(segmentTemplateNode, "SegmentTimeline");
++                                
++                                if (segmentTimelineNode) {
++                                    segmentTimelineNode = xmlFirstElementChild(segmentTimelineNode);
++                                    while (segmentTimelineNode) {
++                                        if (!xmlStrcmp(segmentTimelineNode->name, (const xmlChar *)"S")) {
++                                            struct timeline *tml = av_mallocz(sizeof(struct timeline));
++                                            attr = segmentTimelineNode->properties;
++                                            while(attr) {
++                                                val = xmlGetProp(segmentTimelineNode, attr->name);
++                                                
++                                                if (!xmlStrcmp(attr->name, (const xmlChar *)"t"))
++                                                    tml->t = (int64_t)atoll((const char *)val);
++                                                else if (!xmlStrcmp(attr->name, (const xmlChar *)"r"))
++                                                    tml->r =(int32_t) atoi((const char *)val);
++                                                else if (!xmlStrcmp(attr->name, (const xmlChar *)"d"))
++                                                    tml->d = (int64_t)atoll((const char *)val);
++                                                attr = attr->next;
++                                                xmlFree(val);
++                                            }
++                                            
++                                            dynarray_add(&rep->timelines, &rep->n_timelines, tml);
++                                        }
++                                        segmentTimelineNode = xmlNextElementSibling(segmentTimelineNode);
++                                    }
++                                }
++                            } else if (representationBaseUrlNode && !representationSegmentListNode) {
++                                xmlNodePtr baseUrlNodes[4] = {mpdBaseUrlNode, periodBaseUrlNode, adaptionSetBaseUrlNode, representationBaseUrlNode};
++                                struct segment *seg = av_mallocz(sizeof(struct segment));
++                                seg->url = get_content_url(baseUrlNodes, 4, rep_id_val, rep_bandwidth_val, NULL);
++                                seg->size = -1;
++                                dynarray_add(&rep->segments, &rep->n_segments, seg);
++                            } else if (!representationBaseUrlNode && representationSegmentListNode) {
++                               // TODO: https://www.brendanlong.com/the-structure-of-an-mpeg-dash-mpd.html
++                               // http://www-itec.uni-klu.ac.at/dash/ddash/mpdGenerator.php?segmentlength=15&type=full
++                                xmlNodePtr segmentUrlNode = NULL;
++                                xmlChar *duration_val        = xmlGetProp(representationSegmentListNode, "duration");
++                                xmlChar *timescale_val       = xmlGetProp(representationSegmentListNode, "timescale");
++                                
++                                if (duration_val) {
++                                    rep->segmentDuration = (int64_t) atoll((const char *)duration_val);
++                                    xmlFree(duration_val);
++                                }
++                                
++                                if (timescale_val) {
++                                    rep->segmentTimescalce = (int64_t) atoll((const char *)timescale_val);
++                                    xmlFree(timescale_val);
++                                }
++                                
++                                segmentUrlNode = xmlFirstElementChild(representationSegmentListNode);
++                                while (segmentUrlNode) {
++                                    if (!xmlStrcmp(segmentUrlNode->name, (const xmlChar *)"Initialization")) {
++                                        xmlChar *initialization_val = xmlGetProp(segmentUrlNode, "sourceURL");
++                                        if (initialization_val) {
++                                            xmlNodePtr baseUrlNodes[4] = {mpdBaseUrlNode, periodBaseUrlNode, adaptionSetBaseUrlNode, representationBaseUrlNode};
++                                            rep->init_section = av_mallocz(sizeof(struct segment));
++                                            rep->init_section->url = get_content_url(baseUrlNodes, 4, rep_id_val, rep_bandwidth_val, initialization_val);
++                                            rep->init_section->size = -1;
++                                            xmlFree(initialization_val);
++                                        }
++                                    } else if (!xmlStrcmp(segmentUrlNode->name, (const xmlChar *)"SegmentURL")) {
++                                        xmlChar *media_val = xmlGetProp(segmentUrlNode, "media");
++                                        if (media_val) {
++                                            xmlNodePtr baseUrlNodes[4] = {mpdBaseUrlNode, periodBaseUrlNode, adaptionSetBaseUrlNode, representationBaseUrlNode};
++                                            struct segment *seg = av_mallocz(sizeof(struct segment));
++                                            seg->url = get_content_url(baseUrlNodes, 4, rep_id_val, rep_bandwidth_val, media_val);
++                                            seg->size = -1;
++                                            dynarray_add(&rep->segments, &rep->n_segments, seg);
++                                            xmlFree(media_val);
++                                        }
++                                    }
++                                    segmentUrlNode = xmlNextElementSibling(segmentUrlNode);
++                                }
++                            } else {
++                                free_representation(rep);
++                                rep = NULL;
++                                av_log(s, AV_LOG_ERROR, "Unknown format of Representation node id[%s] \n", (const char *)rep_id_val);
++                            }
++                            
++                            if (rep) {
++                                if (rep->segmentDuration > 0 && rep->segmentTimescalce == 0)
++                                    rep->segmentTimescalce = 1;
++                                
++                                if (type == REP_TYPE_VIDEO) {
++                                    rep->rep_idx = videoRepIdx;
++                                    c->cur_video = rep;
++                                }
++                                else {
++                                    rep->rep_idx = audioRepIdx;
++                                    c->cur_audio = rep;
++                                }
++                            }
++                        }
++                        
++                        if (type == REP_TYPE_VIDEO) {
++                            videoRepIdx += 1;
++                        } if (type == REP_TYPE_AUDIO) {
++                            audioRepIdx += 1;
++                        }
++                        
++                        if (rep_id_val)
++                            xmlFree(rep_id_val);
++                        
++                        if (rep_bandwidth_val)
++                            xmlFree(rep_bandwidth_val);
++                    }
++                    node = xmlNextElementSibling(node);
++                }
++            }
++            adaptionSetNode = xmlNextElementSibling(adaptionSetNode);
++        }
++        
++        if (c->cur_video) {
++            c->cur_video->rep_count = videoRepIdx;
++            c->cur_video->fix_multiple_stsd_order = 1;
++            
++            av_log(s, AV_LOG_VERBOSE, "rep_idx[%d]\n", (int)c->cur_video->rep_idx);
++            av_log(s, AV_LOG_VERBOSE, "rep_count[%d]\n", (int)videoRepIdx);
++        }
++        
++        if (c->cur_audio) {
++            c->cur_audio->rep_count = audioRepIdx;
++        }
++
++cleanup:
++        /*free the document */
++        xmlFreeDoc(doc);
++        xmlCleanupParser();
++
++    } else {
++        av_log(s, AV_LOG_ERROR, "Unable to read to offset '%s'\n", url);
++        ret = AVERROR_INVALIDDATA;
++    }
++    
++    av_free(new_url);
++    av_free(buffer);
++    if (close_in) {
++        avio_close(in);
++    }
++    return ret;
++}
++
++/////////////////////////////////////////////////////////////////////////////
++/////////////////////////////////////////////////////////////////////////////
++
++static int64_t calc_cur_seg_no(struct representation *pls)
++{
++    DASHContext *c = pls->parent->priv_data;
++    int64_t num = 0;
++    if (c->is_live) {
++        num = pls->first_seq_no + (((GetCurrentTimeInSec() - c->availabilityStartTimeSec) - c->presentationDelaySec) * pls->segmentTimescalce) / pls->segmentDuration;
++    } else {
++        num = pls->first_seq_no;
++    }
++    return num;
++}
++
++static int64_t calc_min_seg_no(struct representation *pls)
++{
++    DASHContext *c = pls->parent->priv_data;
++    int64_t num = 0;
++    if (c->is_live) { 
++        num = pls->first_seq_no + (((GetCurrentTimeInSec() - c->availabilityStartTimeSec) - c->timeShiftBufferDepthSec) * pls->segmentTimescalce)  / pls->segmentDuration;
++    } else {
++        num = pls->first_seq_no;
++    }
++    return num;
++}
++
++static int64_t calc_max_seg_no(struct representation *pls)
++{
++    DASHContext *c = pls->parent->priv_data;
++    int64_t num = 0;
++    if (c->is_live) { 
++        num = pls->first_seq_no + (((GetCurrentTimeInSec() - c->availabilityStartTimeSec)) * pls->segmentTimescalce)  / pls->segmentDuration;
++    } else {
++        if (pls->n_segments) {
++            num = pls->first_seq_no + pls->n_segments - 1;
++        } else if (pls->n_timelines) {
++            int i = 0;
++            num = pls->first_seq_no + pls->n_timelines - 1;
++            for (i=0; i<pls->n_timelines; ++i) {
++                num += pls->timelines[i]->r;
++            }
++        }
++        else {
++            num = pls->first_seq_no + (c->mediaPresentationDurationSec * pls->segmentTimescalce) / pls->segmentDuration;
++        }
++    }
++    return num;
++}
++
++static int64_t get_segment_start_time(struct representation *pls, int64_t cur_seq_no)
++{
++    int64_t startTime = 0;
++    if (pls->n_timelines) {
++        int64_t i = 0;
++        int64_t j = 0;
++        int64_t num = 0;
++        
++        for (i=0; i<pls->n_timelines; ++i) {
++            if (pls->timelines[i]->t > 0) {
++                startTime = pls->timelines[i]->t;
++            }
++            
++            if (num == cur_seq_no)
++                goto finish;
++            
++            startTime += pls->timelines[i]->d;
++            
++            for (j = 0; j < pls->timelines[i]->r; ++j) {
++                num += 1;
++                if (num == cur_seq_no)
++                    goto finish;
++                startTime += pls->timelines[i]->d;
++            }
++            num += 1;
++            
++        }
++    }
++finish:
++    return startTime;
++}
++
++static struct segment *get_current_segment(struct representation *pls)
++{
++    char *tmp_str = NULL;
++    struct segment *seg = NULL;
++    DASHContext *c = pls->parent->priv_data;
++    
++    if (pls->n_segments > 0) {
++        if (pls->cur_seq_no < pls->n_segments) {
++            struct segment *seg_ptr = pls->segments[pls->cur_seq_no];
++            seg = av_mallocz(sizeof(struct segment));
++            seg->url = av_strdup(seg_ptr->url);
++            seg->size = seg_ptr->size;
++            seg->url_offset = seg_ptr->url_offset;
++            return seg;
++        }
++    }
++    
++    if (c->is_live) {
++        while (1) {
++            int64_t min_seq_no = calc_min_seg_no(pls);
++            int64_t max_seq_no = calc_max_seg_no(pls);
++            
++            if (pls->cur_seq_no <= min_seq_no) {
++                av_log(pls->parent, AV_LOG_VERBOSE, "%s to old segment: cur[%"PRId64"] min[%"PRId64"] max[%"PRId64"], playlist %d\n", __FUNCTION__, (int64_t)pls->cur_seq_no, min_seq_no, max_seq_no, (int)pls->rep_idx);
++                pls->cur_seq_no = calc_cur_seg_no(pls);
++            } else if (pls->cur_seq_no > max_seq_no) {
++                av_log(pls->parent, AV_LOG_VERBOSE, "%s wait for new segment: min[%"PRId64"] max[%"PRId64"], playlist %d\n", __FUNCTION__, min_seq_no, max_seq_no, (int)pls->rep_idx);
++                sleep(2);
++                continue;
++            }
++            break;
++        }
++        seg = av_mallocz(sizeof(struct segment));
++    } else if (pls->cur_seq_no <= pls->last_seq_no) {
++        seg = av_mallocz(sizeof(struct segment));
++    }
++    
++    if (seg) {
++        if (pls->tmp_url_type != TMP_URL_TYPE_UNSPECIFIED) {
++            int64_t tmp_val = pls->tmp_url_type == TMP_URL_TYPE_NUMBER ? pls->cur_seq_no : get_segment_start_time(pls, pls->cur_seq_no);
++            tmp_str = av_mallocz(MAX_URL_SIZE);
++            snprintf(tmp_str, MAX_URL_SIZE-1, pls->url_template, (int64_t)tmp_val);
++            seg->url = av_strdup(tmp_str);
++        } else {
++            av_log(pls->parent, AV_LOG_ERROR, "Unable to unable to resolve template url '%s'\n", pls->url_template);
++            seg->url = av_strdup(pls->url_template);
++        }
++        seg->size = -1;
++    }
++    
++    av_free(tmp_str);
++    return seg;
++}
++
++enum ReadFromURLMode {
++    READ_NORMAL,
++    READ_COMPLETE,
++};
++
++static int read_from_url(struct representation *pls, struct segment *seg,
++                         uint8_t *buf, int buf_size,
++                         enum ReadFromURLMode mode)
++{
++    int ret;
++
++     /* limit read if the segment was only a part of a file */
++    if (seg->size >= 0)
++        buf_size = FFMIN(buf_size, pls->cur_seg_size - pls->cur_seg_offset);
++
++    if (mode == READ_COMPLETE) {
++        ret = avio_read(pls->input, buf, buf_size);
++        if (ret != buf_size)
++            av_log(NULL, AV_LOG_ERROR, "Could not read complete segment.\n");
++    } else
++        ret = avio_read(pls->input, buf, buf_size);
++
++    if (ret > 0)
++        pls->cur_seg_offset += ret;
++
++    return ret;
++}
++
++static int open_input(DASHContext *c, struct representation *pls, struct segment *seg)
++{
++    AVDictionary *opts = NULL;
++    char url[MAX_URL_SIZE];
++    int ret;
++
++    // broker prior HTTP options that should be consistent across requests
++    av_dict_set(&opts, "user-agent", c->user_agent, 0);
++    av_dict_set(&opts, "cookies", c->cookies, 0);
++    av_dict_set(&opts, "headers", c->headers, 0);
++    if (c->is_live) {
++        av_dict_set(&opts, "seekable", "0", 0);
++    }
++
++    if (seg->size >= 0) {
++        /* try to restrict the HTTP request to the part we want
++         * (if this is in fact a HTTP request) */
++        av_dict_set_int(&opts, "offset", seg->url_offset, 0);
++        av_dict_set_int(&opts, "end_offset", seg->url_offset + seg->size, 0);
++    }
++
++    ff_make_absolute_url(url, MAX_URL_SIZE, c->base_url, seg->url);
++    
++    av_log(pls->parent, AV_LOG_VERBOSE, "DASH request for url '%s', offset %"PRId64", playlist %d\n",
++           url, seg->url_offset, pls->rep_idx);
++    
++    ret = open_url(pls->parent, &pls->input, url, c->avio_opts, opts, NULL);
++    if (ret < 0) {
++        goto cleanup;
++    }
++
++    /* Seek to the requested position. If this was a HTTP request, the offset
++     * should already be where want it to, but this allows e.g. local testing
++     * without a HTTP server. */
++    if (ret == 0 && seg->url_offset) {
++        int64_t seekret = avio_seek(pls->input, seg->url_offset, SEEK_SET);
++        if (seekret < 0) {
++            av_log(pls->parent, AV_LOG_ERROR, "Unable to seek to offset %"PRId64" of DASH segment '%s'\n", seg->url_offset, seg->url);
++            ret = (int) seekret;
++            ff_format_io_close(pls->parent, &pls->input);
++        }
++    }
++    
++cleanup:
++    av_dict_free(&opts);
++    pls->cur_seg_offset = 0;
++    pls->cur_seg_size = seg->size;
++    return ret;
++}
++
++static int update_init_section(struct representation *pls)
++{
++    static const int max_init_section_size = 1024*1024;
++    DASHContext *c = pls->parent->priv_data;
++    int64_t sec_size;
++    int64_t urlsize;
++    int ret;
++
++    /* read init section only once per representation */
++    if (!pls->init_section || pls->init_sec_buf) {
++        return 0;
++    }
++
++    ret = open_input(c, pls, pls->init_section);
++    if (ret < 0) {
++        av_log(pls->parent, AV_LOG_WARNING,
++               "Failed to open an initialization section in playlist %d\n",
++               pls->rep_idx);
++        return ret;
++    }
++
++    if (pls->init_section->size >= 0)
++        sec_size = pls->init_section->size;
++    else if ((urlsize = avio_size(pls->input)) >= 0)
++        sec_size = urlsize;
++    else
++        sec_size = max_init_section_size;
++
++    av_log(pls->parent, AV_LOG_DEBUG,
++           "Downloading an initialization section of size %"PRId64"\n",
++           sec_size);
++
++    sec_size = FFMIN(sec_size, max_init_section_size);
++
++    av_fast_malloc(&pls->init_sec_buf, &pls->init_sec_buf_size, sec_size);
++
++    ret = read_from_url(pls, pls->init_section, pls->init_sec_buf,
++                        pls->init_sec_buf_size, READ_COMPLETE);
++    ff_format_io_close(pls->parent, &pls->input);
++
++    if (ret < 0)
++        return ret;
++    if (pls->fix_multiple_stsd_order && pls->rep_idx > 0) {
++        uint8_t **stsd_entries = NULL;
++        int *stsd_entries_size = NULL;
++        
++        int i = 4;
++        while(i <= ret-4) {
++            // find start stsd atom
++            if (0 == memcmp(pls->init_sec_buf + i, "stsd", 4)) {
++                // 1B version
++                // 3B flags
++                // 4B num of entries
++                int stsd_first_offset = i + 8;
++                int stsd_offset = 0;
++                int j = 0;
++                uint32_t stsd_count = AV_RB32(pls->init_sec_buf + stsd_first_offset);
++                stsd_first_offset += 4;
++                if (stsd_count != pls->rep_count) {
++                    i += 1;
++                    continue;
++                }
++                
++                // find all stsd entries
++                stsd_entries = av_mallocz_array(stsd_count, sizeof(*stsd_entries));
++                stsd_entries_size = av_mallocz_array(stsd_count, sizeof(*stsd_entries_size));
++                for (j=0; j<stsd_count; ++j) {
++                    // 4B - size
++                    // 4B - format
++                    stsd_entries_size[j] = AV_RB32(pls->init_sec_buf + stsd_first_offset + stsd_offset);
++                    stsd_entries[j] = av_malloc(stsd_entries_size[j]);
++                    memcpy(stsd_entries[j], pls->init_sec_buf + stsd_first_offset + stsd_offset, stsd_entries_size[j]);
++                    stsd_offset += stsd_entries_size[j];
++                }
++                
++                // reorder stsd entries
++                // as first put stsd entry for current representation
++                j = pls->rep_idx;
++                stsd_offset = stsd_first_offset;
++                memcpy(pls->init_sec_buf + stsd_offset, stsd_entries[j], stsd_entries_size[j]);
++                stsd_offset += stsd_entries_size[j];
++                
++                for (j=0; j<stsd_count; ++j) {
++                    if (j != pls->rep_idx) {
++                        memcpy(pls->init_sec_buf + stsd_offset, stsd_entries[j], stsd_entries_size[j]);
++                        stsd_offset += stsd_entries_size[j];
++                    }
++                    av_free(stsd_entries[j]);
++                }
++                
++                av_freep(&stsd_entries);
++                av_freep(&stsd_entries_size);
++                break;
++            }
++            i += 1;
++        }
++    }
++
++    av_log(pls->parent, AV_LOG_TRACE, "%s pls[%p] init section size[%d]\n", __FUNCTION__, pls, (int)ret);
++    pls->init_sec_data_len = ret;
++    pls->init_sec_buf_read_offset = 0;
++    
++    return 0;
++}
++
++static int64_t seek_data(void *opaque, int64_t offset, int whence)
++{
++    struct representation *v = opaque;
++    if (v->n_segments == 1 && 0 == v->init_sec_data_len) {
++        return avio_seek(v->input, offset, whence);
++    }
++    
++    return AVERROR(ENOSYS);
++}
++
++static int read_data(void *opaque, uint8_t *buf, int buf_size)
++{
++    struct representation *v = opaque;
++    DASHContext *c = v->parent->priv_data;
++    int ret = 0;
++restart:
++    if (!v->input) {
++        free_segment(&v->cur_seg);
++        v->cur_seg = get_current_segment(v);
++        if (!v->cur_seg) {
++            ret = AVERROR_EOF;
++            goto end;
++        }
++
++        /* load/update Media Initialization Section, if any */
++        ret = update_init_section(v);
++        if (ret)
++            goto end;
++
++        ret = open_input(c, v, v->cur_seg);
++        if (ret < 0) {
++            if (ff_check_interrupt(c->interrupt_callback)) {
++                goto end;
++                ret = AVERROR_EXIT;
++            }
++            av_log(v->parent, AV_LOG_WARNING, "Failed to open segment of playlist %d\n",
++                   v->rep_idx);
++            v->cur_seq_no += 1;
++            goto restart;
++        }
++    }
++
++    if (v->init_sec_buf_read_offset < v->init_sec_data_len) {
++        /* Push init section out first before first actual segment */
++        int copy_size = FFMIN(v->init_sec_data_len - v->init_sec_buf_read_offset, buf_size);
++        memcpy(buf, v->init_sec_buf, copy_size);
++        v->init_sec_buf_read_offset += copy_size;
++        ret = copy_size;
++        goto end;
++    }
++    
++    if (!v->cur_seg) {
++        v->cur_seg = get_current_segment(v);
++    }
++    
++    if (!v->cur_seg) {
++        ret = AVERROR_EOF;
++        goto end;
++    }
++    
++    ret = read_from_url(v, v->cur_seg, buf, buf_size, READ_NORMAL);
++
++    if (ret > 0)
++        goto end;
++    
++    ff_format_io_close(v->parent, &v->input);
++    v->cur_seq_no += 1;
++
++    goto restart;
++end:
++    return ret;
++}
++
++static int save_avio_options(AVFormatContext *s)
++{
++    DASHContext *c = s->priv_data;
++    const char *opts[] = { "headers", "user_agent", "user-agent", "cookies", NULL }, **opt = opts;
++    uint8_t *buf = NULL;
++    int ret = 0;
++
++    while (*opt) {
++        if (av_opt_get(s->pb, *opt, AV_OPT_SEARCH_CHILDREN, &buf) >= 0) {
++            if (buf != NULL && buf[0] != '\0') {
++                ret = av_dict_set(&c->avio_opts, *opt, buf,
++                                  AV_DICT_DONT_STRDUP_VAL);
++                if (ret < 0)
++                    return ret;
++            }
++        }
++        opt++;
++    }
++
++    return ret;
++}
++
++static int nested_io_open(AVFormatContext *s, AVIOContext **pb, const char *url,
++                          int flags, AVDictionary **opts)
++{
++    av_log(s, AV_LOG_ERROR,
++           "A HDS playlist item '%s' referred to an external file '%s'. "
++           "Opening this file was forbidden for security reasons\n",
++           s->filename, url);
++    return AVERROR(EPERM);
++}
++
++static int reopen_demux_for_component(AVFormatContext *s, struct representation *pls)
++{    
++    DASHContext *c = s->priv_data;
++    AVInputFormat *in_fmt = NULL;
++    AVDictionary  *in_fmt_opts = NULL;
++    uint8_t *avio_ctx_buffer  = NULL;
++    int ret = 0;
++    
++    if (pls->ctx) {
++        /* note: the internal buffer could have changed, and be != avio_ctx_buffer */
++        av_freep(&pls->pb.buffer);
++        memset(&pls->pb, 0x00, sizeof(AVIOContext));
++        
++        pls->ctx->pb = NULL;
++        avformat_close_input(&pls->ctx);
++        pls->ctx = NULL;
++    }
++    
++    if (!(pls->ctx = avformat_alloc_context())) {
++        ret = AVERROR(ENOMEM);
++        goto fail;
++    }
++
++    avio_ctx_buffer  = av_malloc(INITIAL_BUFFER_SIZE);
++    if (!avio_ctx_buffer ){
++        ret = AVERROR(ENOMEM);
++        avformat_free_context(pls->ctx);
++        pls->ctx = NULL;
++        goto fail;
++    }
++    
++    if (c->is_live) {
++        ffio_init_context(&pls->pb, avio_ctx_buffer , INITIAL_BUFFER_SIZE, 0, pls,
++                          read_data, NULL, NULL);
++    } else {
++        ffio_init_context(&pls->pb, avio_ctx_buffer , INITIAL_BUFFER_SIZE, 0, pls,
++                  read_data, NULL, seek_data);
++    }
++    
++    pls->pb.seekable = 0;
++
++    if ((ret = ff_copy_whiteblacklists(pls->ctx, s)) < 0)
++        goto fail;
++
++    pls->ctx->flags = AVFMT_FLAG_CUSTOM_IO;
++    pls->ctx->probesize = 1024 * 4;
++    pls->ctx->max_analyze_duration = 4 * AV_TIME_BASE; 
++    /////////////////
++#if 1
++    ret = av_probe_input_buffer(&pls->pb, &in_fmt, "",
++                                NULL, 0, 0);
++    if (ret < 0) {
++        av_log(s, AV_LOG_ERROR, "Error when loading first segment, playlist %d\n", (int)pls->rep_idx);
++        avformat_free_context(pls->ctx);
++        pls->ctx = NULL;
++        goto fail;
++    }
++#else
++    in_fmt = av_find_input_format("mp4");
++#endif
++
++    pls->ctx->pb = &pls->pb;
++    pls->ctx->io_open  = nested_io_open;
++    ////////////////////
++    
++    // provide additional information from mpd if available
++    // av_dict_set(&in_fmt_opts, "video_size", "640x480", 0);
++    // av_dict_set(&in_fmt_opts, "pixel_format", "rgb24", 0);
++    ret = avformat_open_input(&pls->ctx, "", in_fmt, &in_fmt_opts); //pls->init_section->url
++    av_dict_free(&in_fmt_opts);
++    if (ret < 0)
++        goto fail;
++    
++    if (pls->n_segments == 1) {
++        //pls->ctx->ctx_flags &= ~AVFMTCTX_NOHEADER;
++        ret = avformat_find_stream_info(pls->ctx, NULL);
++        if (ret < 0)
++            goto fail;
++    }
++        
++    av_log(pls->parent, AV_LOG_VERBOSE, "%s nb_streams[%d]\n", __FUNCTION__, (int)pls->ctx->nb_streams);
++    
++fail:
++    return ret;
++}
++
++static int open_demux_for_component(AVFormatContext *s, struct representation *pls)
++{
++    int ret = 0;
++    int i;
++    
++    pls->parent = s;
++    pls->cur_seq_no  = calc_cur_seg_no(pls);
++    pls->last_seq_no = calc_max_seg_no(pls);
++
++
++    ret = reopen_demux_for_component(s, pls);
++    if (ret < 0) {
++        goto fail;
++    }
++    
++    for (i = 0; i < pls->ctx->nb_streams; i++) {
++        AVStream *st = avformat_new_stream(s, NULL);
++        AVStream *ist = pls->ctx->streams[i];
++        if (!st) {
++            ret = AVERROR(ENOMEM);
++            goto fail;
++        }
++        st->id = i;
++
++        // avcodec_copy_context(st->codec, pls->ctx->streams[i]->codec);
++        avcodec_parameters_copy(st->codecpar, pls->ctx->streams[i]->codecpar);
++        avpriv_set_pts_info(st, ist->pts_wrap_bits, ist->time_base.num, ist->time_base.den);
++    }   
++    
++    return 0;
++fail:
++    return ret;
++}
++
++static int dash_read_header(AVFormatContext *s)
++{
++    void *u = (s->flags & AVFMT_FLAG_CUSTOM_IO) ? NULL : s->pb;
++    DASHContext *c = s->priv_data;
++    int ret = 0;
++    int stream_index = 0;
++
++    c->interrupt_callback = &s->interrupt_callback;
++
++    // if the URL context is good, read important options we must broker later
++    if (u) {
++        update_options(&c->user_agent, "user-agent", u);
++        update_options(&c->cookies, "cookies", u);
++        update_options(&c->headers, "headers", u);
++    }
++
++    if ((ret = parse_mainifest(s, s->filename, s->pb)) < 0)
++        goto fail;
++
++    if ((ret = save_avio_options(s)) < 0)
++        goto fail;
++    
++    /* If this isn't a live stream, fill the total duration of the
++     * stream. */
++    if (!c->is_live) {
++        s->duration = c->mediaPresentationDurationSec * AV_TIME_BASE;
++    }
++
++    /* Open the demuxer for curent video and current audio components if available */
++    if (0 == ret && c->cur_video) {
++        ret = open_demux_for_component(s, c->cur_video);
++        if (ret == 0) {
++            c->cur_video->stream_index = stream_index;
++            ++stream_index;
++        } else {
++            free_representation(c->cur_video);
++            c->cur_video = NULL;
++        }
++    }
++    
++    if (0 == ret && c->cur_audio) {
++        ret = open_demux_for_component(s, c->cur_audio);
++        if (ret == 0) {
++            c->cur_audio->stream_index = stream_index;
++            ++stream_index;
++        } else {
++            free_representation(c->cur_audio);
++            c->cur_audio = NULL;
++        }
++    }
++    
++    if (0 == stream_index) {
++        ret = AVERROR_INVALIDDATA;
++        goto fail;
++    }
++    
++    /* Create a program */
++    if (0 == ret) {
++        AVProgram *program;
++        program = av_new_program(s, 0);
++        if (!program) {
++            goto fail;
++        }
++        
++        if (c->cur_video) {
++            av_program_add_stream_index(s, 0, c->cur_video->stream_index);
++        }
++        
++        if (c->cur_audio) {
++            av_program_add_stream_index(s, 0, c->cur_audio->stream_index);
++        }
++    }
++
++    return 0;
++fail:
++    return ret;
++}
++
++static int dash_read_packet(AVFormatContext *s, AVPacket *pkt)
++{
++    DASHContext *c = s->priv_data;
++    int ret = 0;
++    struct representation *cur = NULL;
++    
++    if (!c->cur_audio && !c->cur_video) {
++        return AVERROR_INVALIDDATA;
++    }
++    
++    if (c->cur_audio && !c->cur_video) {
++        cur = c->cur_audio;
++    } else if (!c->cur_audio && c->cur_video) {
++        cur = c->cur_video;
++    }
++    
++    else if (c->cur_video->cur_timestamp < c->cur_audio->cur_timestamp) {
++        cur = c->cur_video;
++    } else {
++        cur = c->cur_audio;
++    }
++
++    if (cur->ctx) {
++        ret = av_read_frame(cur->ctx, &cur->pkt);
++        if (0 == ret) {
++            /* If we got a packet, return it */
++            *pkt = cur->pkt;
++            cur->cur_timestamp = av_rescale(pkt->pts, (int64_t)cur->ctx->streams[0]->time_base.num * 90000, cur->ctx->streams[0]->time_base.den);
++            pkt->stream_index = cur->stream_index;
++            reset_packet(&cur->pkt);
++            return 0;
++        } else {
++            reset_packet(&cur->pkt);
++        }
++    }
++    
++    return AVERROR_EOF;
++}
++
++static int dash_close(AVFormatContext *s)
++{
++    DASHContext *c = s->priv_data;
++    
++    if (c->cur_audio) {
++        free_representation(c->cur_audio);
++    }
++    
++    if (c->cur_video) {
++        free_representation(c->cur_video);
++    }
++    
++    av_freep(&c->cookies);
++    av_freep(&c->user_agent);
++    av_dict_free(&c->avio_opts);
++    av_freep(&c->base_url);
++    return 0;
++}
++    
++static int dash_seek(AVFormatContext *s, struct representation *pls, int64_t seekPosMSec, int flags)
++{
++    int ret = 0;
++    
++    av_log(pls->parent, AV_LOG_VERBOSE, "DASH seek pos[%"PRId64"ms], playlist %d\n", seekPosMSec, pls->rep_idx);
++           
++    // single segment mode
++    if (pls->n_segments == 1) {
++        pls->cur_timestamp = 0;
++        pls->cur_seg_offset = 0;
++        ff_read_frame_flush(pls->ctx);
++        return av_seek_frame(pls->ctx, -1, seekPosMSec*1000, flags);
++    }
++    
++    if (pls->input)
++        ff_format_io_close(pls->parent, &pls->input);
++    
++    // find the nearest segment
++    if (pls->n_timelines > 0 && pls->segmentTimescalce > 0) {
++        int64_t duration = 0;
++        int i;
++        int j;
++        int64_t num = pls->first_seq_no;
++        av_log(pls->parent, AV_LOG_VERBOSE, "dash_seek with SegmentTimeline start n_timelines[%d] last_seq_no[%"PRId64"], playlist %d.\n", (int)pls->n_timelines, (int64_t)pls->last_seq_no, (int)pls->rep_idx);
++        for (i = 0; i < pls->n_timelines; ++i) {
++            if (pls->timelines[i]->t > 0) {
++                duration = pls->timelines[i]->t;
++            }
++            
++            duration += pls->timelines[i]->d;
++            if (seekPosMSec < ((duration * 1000) /  pls->segmentTimescalce)) {
++                goto set_seq_num;
++            }
++            
++            for (j = 0; j < pls->timelines[i]->r; ++j) {
++                duration += pls->timelines[i]->d;
++                num += 1;
++                if (seekPosMSec < ((duration * 1000) /  pls->segmentTimescalce)) {
++                    goto set_seq_num;
++                }
++            }
++            num += 1;
++        }
++set_seq_num:
++        pls->cur_seq_no = num > pls->last_seq_no ? pls->last_seq_no : num;
++        av_log(pls->parent, AV_LOG_VERBOSE, "dash_seek with SegmentTimeline end cur_seq_no[%"PRId64"], playlist %d.\n", (int64_t)pls->cur_seq_no, (int)pls->rep_idx);
++    }
++    else if(pls->segmentDuration > 0) {
++        pls->cur_seq_no = pls->first_seq_no + ((seekPosMSec * pls->segmentTimescalce) / pls->segmentDuration) / 1000;
++    } else {
++        av_log(pls->parent, AV_LOG_ERROR, "dash_seek missing segmentDuration\n");
++        pls->cur_seq_no = pls->first_seq_no;
++    }
++    pls->cur_timestamp = 0;
++    pls->cur_seg_offset = 0;
++    
++    pls->init_sec_buf_read_offset = 0;
++    ret = reopen_demux_for_component(s, pls);
++
++    return ret;
++}
++
++static int dash_read_seek(AVFormatContext *s, int stream_index,
++                               int64_t timestamp, int flags)
++{
++    int ret = 0;
++    DASHContext *c = s->priv_data;
++    int64_t seekPosMSec = av_rescale_rnd(timestamp, 1000,
++                            s->streams[stream_index]->time_base.den,
++                            flags & AVSEEK_FLAG_BACKWARD ?
++                            AV_ROUND_DOWN : AV_ROUND_UP);
++    
++    if ((flags & AVSEEK_FLAG_BYTE) || c->is_live)
++        return AVERROR(ENOSYS);
++    
++    if (c->cur_audio) {
++        ret = dash_seek(s, c->cur_audio, seekPosMSec, flags);
++    } 
++    
++    if (0 == ret && c->cur_video) {
++        ret = dash_seek(s, c->cur_video, seekPosMSec, flags);
++    }
++    
++    return ret;
++}
++
++static int dash_probe(AVProbeData *p)
++{
++    if (!strstr(p->buf, "<MPD"))
++        return 0;
++    
++    if (strstr(p->buf, "dash:profile:isoff-on-demand:2011") ||
++        strstr(p->buf, "dash:profile:isoff-live:2011") ||
++        strstr(p->buf, "dash:profile:isoff-live:2012") ||
++        strstr(p->buf, "dash:profile:isoff-main:2011")) {
++        return AVPROBE_SCORE_MAX;
++    }
++    
++    if (strstr(p->buf, "dash:profile")) {
++        return AVPROBE_SCORE_MAX / 2;
++    }
++    
++    return 0;
++}
++
++#define OFFSET(x) offsetof(DASHContext, x)
++#define FLAGS AV_OPT_FLAG_DECODING_PARAM
++static const AVOption dash_options[] = {
++    {"audio_rep_index", "audio representation index to be used",
++        OFFSET(audio_rep_index), AV_OPT_TYPE_INT, {.i64 = -1}, INT_MIN, INT_MAX, FLAGS},
++    {"video_rep_index", "video representation index to be used",
++        OFFSET(video_rep_index), AV_OPT_TYPE_INT, {.i64 = -1}, INT_MIN, INT_MAX, FLAGS},
++    {NULL}
++};
++
++static const AVClass dash_class = {
++    .class_name = "dash",
++    .item_name  = av_default_item_name,
++    .option     = dash_options,
++    .version    = LIBAVUTIL_VERSION_INT,
++};
++
++AVInputFormat ff_dash_demuxer = {
++    .name           = "dash",
++    .long_name      = NULL_IF_CONFIG_SMALL("Dynamic Adaptive Streaming over HTTP"),
++    .priv_class     = &dash_class,
++    .priv_data_size = sizeof(DASHContext),
++    .read_probe     = dash_probe,
++    .read_header    = dash_read_header,
++    .read_packet    = dash_read_packet,
++    .read_close     = dash_close,
++    .read_seek      = dash_read_seek,
++    .flags          = AVFMT_NO_BYTE_SEEK,
++};
+diff -uNr ffmpeg-3.2.2/libavformat/Makefile ffmpeg-3.2.2_dash_demux/libavformat/Makefile
+--- ffmpeg-3.2.2/libavformat/Makefile	2016-12-06 00:28:54.000000000 +0100
++++ ffmpeg-3.2.2_dash_demux/libavformat/Makefile	2017-01-31 23:46:22.854211062 +0100
+@@ -134,6 +134,7 @@
+ OBJS-$(CONFIG_DATA_DEMUXER)              += rawdec.o
+ OBJS-$(CONFIG_DATA_MUXER)                += rawdec.o
+ OBJS-$(CONFIG_DASH_MUXER)                += dashenc.o
++OBJS-$(CONFIG_DASH_DEMUXER)              += dashdec.o
+ OBJS-$(CONFIG_DAUD_DEMUXER)              += dauddec.o
+ OBJS-$(CONFIG_DAUD_MUXER)                += daudenc.o
+ OBJS-$(CONFIG_DCSTR_DEMUXER)             += dcstr.o
+--- a/configure	2017-06-07 20:40:05.995269967 +0200
++++ b/configure	2017-06-07 20:50:03.622116521 +0200
+@@ -292,6 +292,7 @@
+   --disable-securetransport disable Secure Transport, needed for TLS support
+                            on OSX if openssl and gnutls are not used [autodetect]
+   --disable-xlib           disable xlib [autodetect]
++  --disable-xml2           disable XML parsing using the C library libxml2 [autodetect]
+   --disable-zlib           disable zlib [autodetect]
+ 
+   The following libraries provide various hardware acceleration features:
+@@ -1497,6 +1498,7 @@
+     sdl2
+     securetransport
+     xlib
++    xml2
+     zlib
+ "
+ 
+@@ -2916,6 +2918,7 @@
+ caf_demuxer_select="iso_media riffdec"
+ caf_muxer_select="iso_media"
+ dash_muxer_select="mp4_muxer"
++dash_demuxer_select="xml2"
+ dirac_demuxer_select="dirac_parser"
+ dts_demuxer_select="dca_parser"
+ dtshd_demuxer_select="dca_parser"
+@@ -5730,6 +5733,7 @@
+ disabled  zlib || check_lib  zlib.h      zlibVersion    -lz    || disable  zlib
+ disabled bzlib || check_lib bzlib.h BZ2_bzlibVersion    -lbz2  || disable bzlib
+ disabled  lzma || check_lib  lzma.h lzma_version_number -llzma || disable lzma
++disabled  xml2 || check_lib libxml/xmlversion.h xmlCheckVersion -lxml2 || disable xml2
+ 
+ check_lib math.h sin -lm && LIBM="-lm"
+ disabled crystalhd || check_lib "stdint.h libcrystalhd/libcrystalhd_if.h" DtsCrystalHDVersion -lcrystalhd || disable crystalhd

--- a/meta-openpli/recipes-multimedia/ffmpeg/ffmpeg/000003_allow_to_choose_rtmp_impl_at_runtime.patch
+++ b/meta-openpli/recipes-multimedia/ffmpeg/ffmpeg/000003_allow_to_choose_rtmp_impl_at_runtime.patch
@@ -1,0 +1,114 @@
+diff -uNr ffmpeg-3.2.2/configure ffmpeg-3.2.2_both_rtmp/configure
+--- ffmpeg-3.2.2/configure    2016-10-01 03:12:41.000000000 +0200
++++ ffmpeg-3.2.2_both_rtmp/configure    2016-10-13 10:55:16.843636047 +0200
+@@ -2934,10 +2934,8 @@
+ # protocols
+ async_protocol_deps="threads"
+ bluray_protocol_deps="libbluray"
+-ffrtmpcrypt_protocol_deps="!librtmp_protocol"
+ ffrtmpcrypt_protocol_deps_any="gcrypt gmp openssl"
+ ffrtmpcrypt_protocol_select="tcp_protocol"
+-ffrtmphttp_protocol_deps="!librtmp_protocol"
+ ffrtmphttp_protocol_select="http_protocol"
+ ftp_protocol_select="tcp_protocol"
+ gopher_protocol_select="network"
+@@ -2954,14 +2952,12 @@
+ libssh_protocol_deps="libssh"
+ mmsh_protocol_select="http_protocol"
+ mmst_protocol_select="network"
+-rtmp_protocol_deps="!librtmp_protocol"
+-rtmp_protocol_select="tcp_protocol"
+-rtmpe_protocol_select="ffrtmpcrypt_protocol"
+-rtmps_protocol_deps="!librtmp_protocol"
+-rtmps_protocol_select="tls_protocol"
+-rtmpt_protocol_select="ffrtmphttp_protocol"
+-rtmpte_protocol_select="ffrtmpcrypt_protocol ffrtmphttp_protocol"
+-rtmpts_protocol_select="ffrtmphttp_protocol https_protocol"
++ffrtmp_protocol_select="tcp_protocol"
++ffrtmpe_protocol_select="ffrtmpcrypt_protocol"
++ffrtmps_protocol_select="tls_protocol"
++ffrtmpt_protocol_select="ffrtmphttp_protocol"
++ffrtmpte_protocol_select="ffrtmpcrypt_protocol ffrtmphttp_protocol"
++ffrtmpts_protocol_select="ffrtmphttp_protocol https_protocol"
+ rtp_protocol_select="udp_protocol"
+ sctp_protocol_deps="struct_sctp_event_subscribe struct_msghdr_msg_flags"
+ sctp_protocol_select="network"
+diff -Naur ffmpeg-3.2.2/libavformat/rtmpproto.c ffmpeg-3.2.2_both_rtmp/libavformat/rtmpproto.c
+--- ffmpeg-3.2.2/libavformat/rtmpproto.c    2016-10-01 03:12:42.000000000 +0200
++++ ffmpeg-3.2.2_both_rtmp/libavformat/rtmpproto.c    2016-10-13 10:55:16.862635525 +0200
+@@ -2578,7 +2578,7 @@
+ static int rtmp_open(URLContext *s, const char *uri, int flags)
+ {
+     RTMPContext *rt = s->priv_data;
+-    char proto[8], hostname[256], path[1024], auth[100], *fname;
++    char *proto, tmpProto[10], hostname[256], path[1024], auth[100], *fname;
+     char *old_app, *qmark, *n, fname_buffer[1024];
+     uint8_t buf[2048];
+     int port;
+@@ -2590,7 +2590,7 @@
+ 
+     rt->is_input = !(flags & AVIO_FLAG_WRITE);
+ 
+-    av_url_split(proto, sizeof(proto), auth, sizeof(auth),
++    memset(tmpProto, 0, sizeof(tmpProto)); proto = &tmpProto[2]; av_url_split(tmpProto, sizeof(tmpProto), auth, sizeof(auth),
+                  hostname, sizeof(hostname), &port,
+                  path, sizeof(path), s->filename);
+ 
+@@ -3124,9 +3124,9 @@
+ };
+ 
+ 
+-RTMP_PROTOCOL(rtmp)
+-RTMP_PROTOCOL(rtmpe)
+-RTMP_PROTOCOL(rtmps)
+-RTMP_PROTOCOL(rtmpt)
+-RTMP_PROTOCOL(rtmpte)
+-RTMP_PROTOCOL(rtmpts)
++RTMP_PROTOCOL(ffrtmp)
++RTMP_PROTOCOL(ffrtmpe)
++RTMP_PROTOCOL(ffrtmps)
++RTMP_PROTOCOL(ffrtmpt)
++RTMP_PROTOCOL(ffrtmpte)
++RTMP_PROTOCOL(ffrtmpts)
+--- a/libavformat/Makefile	2017-06-07 20:40:05.995269967 +0200
++++ b/libavformat/Makefile	2017-06-07 20:42:50.035131075 +0200
+@@ -566,12 +566,12 @@
+ OBJS-$(CONFIG_MMST_PROTOCOL)             += mmst.o mms.o asf.o
+ OBJS-$(CONFIG_PIPE_PROTOCOL)             += file.o
+ OBJS-$(CONFIG_PROMPEG_PROTOCOL)          += prompeg.o
+-OBJS-$(CONFIG_RTMP_PROTOCOL)             += rtmpproto.o rtmppkt.o
+-OBJS-$(CONFIG_RTMPE_PROTOCOL)            += rtmpproto.o rtmppkt.o
+-OBJS-$(CONFIG_RTMPS_PROTOCOL)            += rtmpproto.o rtmppkt.o
+-OBJS-$(CONFIG_RTMPT_PROTOCOL)            += rtmpproto.o rtmppkt.o
+-OBJS-$(CONFIG_RTMPTE_PROTOCOL)           += rtmpproto.o rtmppkt.o
+-OBJS-$(CONFIG_RTMPTS_PROTOCOL)           += rtmpproto.o rtmppkt.o
++OBJS-$(CONFIG_FFRTMP_PROTOCOL)           += rtmpproto.o rtmppkt.o
++OBJS-$(CONFIG_FFRTMPE_PROTOCOL)          += rtmpproto.o rtmppkt.o
++OBJS-$(CONFIG_FFRTMPS_PROTOCOL)          += rtmpproto.o rtmppkt.o
++OBJS-$(CONFIG_FFRTMPT_PROTOCOL)          += rtmpproto.o rtmppkt.o
++OBJS-$(CONFIG_FFRTMPTE_PROTOCOL)         += rtmpproto.o rtmppkt.o
++OBJS-$(CONFIG_FFRTMPTS_PROTOCOL)         += rtmpproto.o rtmppkt.o
+ OBJS-$(CONFIG_RTP_PROTOCOL)              += rtpproto.o
+ OBJS-$(CONFIG_SCTP_PROTOCOL)             += sctp.o
+ OBJS-$(CONFIG_SRTP_PROTOCOL)             += srtpproto.o srtp.o
+--- a/libavformat/protocols.c	2017-06-07 20:40:05.996269942 +0200
++++ b/libavformat/protocols.c	2017-06-07 20:45:58.584373798 +0200
+@@ -44,12 +44,12 @@
+ extern const URLProtocol ff_md5_protocol;
+ extern const URLProtocol ff_pipe_protocol;
+ extern const URLProtocol ff_prompeg_protocol;
+-extern const URLProtocol ff_rtmp_protocol;
+-extern const URLProtocol ff_rtmpe_protocol;
+-extern const URLProtocol ff_rtmps_protocol;
+-extern const URLProtocol ff_rtmpt_protocol;
+-extern const URLProtocol ff_rtmpte_protocol;
+-extern const URLProtocol ff_rtmpts_protocol;
++extern const URLProtocol ff_ffrtmp_protocol;
++extern const URLProtocol ff_ffrtmpe_protocol;
++extern const URLProtocol ff_ffrtmps_protocol;
++extern const URLProtocol ff_ffrtmpt_protocol;
++extern const URLProtocol ff_ffrtmpte_protocol;
++extern const URLProtocol ff_ffrtmpts_protocol;
+ extern const URLProtocol ff_rtp_protocol;
+ extern const URLProtocol ff_sctp_protocol;
+ extern const URLProtocol ff_srtp_protocol;

--- a/meta-openpli/recipes-multimedia/ffmpeg/ffmpeg/ffmpeg-aac.patch
+++ b/meta-openpli/recipes-multimedia/ffmpeg/ffmpeg/ffmpeg-aac.patch
@@ -1,0 +1,61 @@
+--- a/libavcodec/aacdec_template.c	2015-12-20 04:07:43.000000000 +0200
++++ b/libavcodec/aacdec_template.c	2016-01-16 14:12:36.559889936 +0200
+@@ -2343,7 +2343,7 @@
+  * @param   decode  1 if tool is used normally, 0 if tool is used in LTP.
+  * @param   coef    spectral coefficients
+  */
+-static void apply_tns(INTFLOAT coef[1024], TemporalNoiseShaping *tns,
++static __attribute__((optimize(0))) void apply_tns(INTFLOAT coef[1024], TemporalNoiseShaping *tns,
+                       IndividualChannelStream *ics, int decode)
+ {
+     const int mmm = FFMIN(ics->tns_max_bands, ics->max_sfb);
+--- a/libavcodec/mdct_template.c
++++ b/libavcodec/mdct_template.c
+@@ -101,7 +101,7 @@ av_cold int ff_mdct_init(FFTContext *s, int nbits, int inverse, double scale)
+  * @param output N/2 samples
+  * @param input N/2 samples
+  */
+-void ff_imdct_half_c(FFTContext *s, FFTSample *output, const FFTSample *input)
++void __attribute__((optimize(0))) ff_imdct_half_c(FFTContext *s, FFTSample *output, const FFTSample *input)
+ {
+     int k, n8, n4, n2, n, j;
+     const uint16_t *revtab = s->revtab;
+@@ -109,7 +109,6 @@ void ff_imdct_half_c(FFTContext *s, FFTSample *output, const FFTSample *input)
+     const FFTSample *tsin = s->tsin;
+     const FFTSample *in1, *in2;
+     FFTComplex *z = (FFTComplex *)output;
+-
+     n = 1 << s->mdct_bits;
+     n2 = n >> 1;
+     n4 = n >> 2;
+--- a/libavcodec/aacps.c	2016-01-16 14:08:47.122752224 +0200
++++ b/libavcodec/aacps.c	2016-01-16 14:15:59.300895278 +0200
+@@ -654,7 +654,7 @@
+     par[ 1] = AAC_HALF_SUM(par[ 0], par[ 1]);
+ }
+ 
+-static void decorrelation(PSContext *ps, INTFLOAT (*out)[32][2], const INTFLOAT (*s)[32][2], int is34)
++static void __attribute__((optimize(0))) decorrelation(PSContext *ps, INTFLOAT (*out)[32][2], const INTFLOAT (*s)[32][2], int is34)
+ {
+     LOCAL_ALIGNED_16(INTFLOAT, power, [34], [PS_QMF_TIME_SLOTS]);
+     LOCAL_ALIGNED_16(INTFLOAT, transient_gain, [34], [PS_QMF_TIME_SLOTS]);
+--- a/libavcodec/fft_template.c
++++ b/libavcodec/fft_template.c
+@@ -452,7 +452,7 @@
+     pass(z,FFT_NAME(ff_cos_##n),n4/2);\
+ }
+ 
+-static void fft4(FFTComplex *z)
++static void __attribute__((optimize(0))) fft4(FFTComplex *z)
+ {
+     FFTDouble t1, t2, t3, t4, t5, t6, t7, t8;
+ 
+@@ -466,7 +466,7 @@
+     BF(z[2].im, z[0].im, t2, t5);
+ }
+ 
+-static void fft8(FFTComplex *z)
++static void __attribute__((optimize(0))) fft8(FFTComplex *z)
+ {
+     FFTDouble t1, t2, t3, t4, t5, t6;
+ 

--- a/meta-openpli/recipes-multimedia/ffmpeg/ffmpeg/ffmpeg-buffer-size.patch
+++ b/meta-openpli/recipes-multimedia/ffmpeg/ffmpeg/ffmpeg-buffer-size.patch
@@ -1,0 +1,64 @@
+--- a/libavformat/avio.h	2016-01-16 13:54:30.822506061 +0200
++++ b/libavformat/avio.h	2016-01-16 13:56:34.175117736 +0200
+@@ -191,13 +191,6 @@
+     int writeout_count;
+ 
+     /**
+-     * Original buffer size
+-     * used internally after probing and ensure seekback to reset the buffer size
+-     * This field is internal to libavformat and access from outside is not allowed.
+-     */
+-    int orig_buffer_size;
+-
+-    /**
+      * Threshold to favor readahead over seek.
+      * This is current internal only, do not use from outside.
+      */
+--- a/libavformat/aviobuf.c	2015-12-20 04:07:49.000000000 +0200
++++ b/libavformat/aviobuf.c	2016-01-16 14:03:01.233037056 +0200
+@@ -33,7 +33,7 @@
+ #include "url.h"
+ #include <stdarg.h>
+ 
+-#define IO_BUFFER_SIZE 32768
++#define IO_BUFFER_SIZE 262144
+ 
+ /**
+  * Do seeks within this distance ahead of the current buffer by skipping
+@@ -79,7 +79,6 @@
+                   int64_t (*seek)(void *opaque, int64_t offset, int whence))
+ {
+     s->buffer      = buffer;
+-    s->orig_buffer_size =
+     s->buffer_size = buffer_size;
+     s->buf_ptr     = buffer;
+     s->opaque      = opaque;
+@@ -464,16 +463,16 @@
+     }
+ 
+     /* make buffer smaller in case it ended up large after probing */
+-    if (s->read_packet && s->orig_buffer_size && s->buffer_size > s->orig_buffer_size) {
++    if (s->read_packet && s->buffer_size > max_buffer_size) {
+         if (dst == s->buffer) {
+-            int ret = ffio_set_buf_size(s, s->orig_buffer_size);
++            int ret = ffio_set_buf_size(s, max_buffer_size);
+             if (ret < 0)
+                 av_log(s, AV_LOG_WARNING, "Failed to decrease buffer size\n");
+ 
+             s->checksum_ptr = dst = s->buffer;
+         }
+-        av_assert0(len >= s->orig_buffer_size);
+-        len = s->orig_buffer_size;
++        av_assert0(len >= max_buffer_size);
++        len = max_buffer_size;
+     }
+ 
+     if (s->read_packet)
+@@ -845,7 +844,6 @@
+ 
+     av_free(s->buffer);
+     s->buffer = buffer;
+-    s->orig_buffer_size =
+     s->buffer_size = buf_size;
+     s->buf_ptr = buffer;
+     url_resetbuf(s, s->write_flag ? AVIO_FLAG_WRITE : AVIO_FLAG_READ);

--- a/meta-openpli/recipes-multimedia/ffmpeg/ffmpeg/ffmpeg-fix-edit-list-parsing.patch
+++ b/meta-openpli/recipes-multimedia/ffmpeg/ffmpeg/ffmpeg-fix-edit-list-parsing.patch
@@ -1,0 +1,16 @@
+Taapat: disable log to fix freezing on edit list parsing intruduced in:
+http://git.videolan.org/gitweb.cgi/ffmpeg.git/?p=ffmpeg.git;a=commitdiff;h=ca6cae73db207f17a0d5507609de12842d8f0ca3
+
+--- a/libavformat/mov.c	2016-11-14 20:09:13.779085246 +0200
++++ b/libavformat/mov.c	2016-11-14 20:09:30.715351822 +0200
+@@ -3067,8 +3067,10 @@
+             curr_cts = current->timestamp + msc->dts_shift;
+ 
+             if (ctts_data_old && ctts_index_old < ctts_count_old) {
++                /*
+                 av_log(mov->fc, AV_LOG_DEBUG, "shifted frame pts, curr_cts: %"PRId64" @ %"PRId64", ctts: %d, ctts_count: %"PRId64"\n",
+                        curr_cts, ctts_index_old, ctts_data_old[ctts_index_old].duration, ctts_count_old);
++                */
+                 curr_cts += ctts_data_old[ctts_index_old].duration;
+                 ctts_sample_old++;
+                 if (ctts_sample_old == ctts_data_old[ctts_index_old].count) {

--- a/meta-openpli/recipes-multimedia/ffmpeg/ffmpeg/ffmpeg-fix-hls.patch
+++ b/meta-openpli/recipes-multimedia/ffmpeg/ffmpeg/ffmpeg-fix-hls.patch
@@ -1,0 +1,15 @@
+--- a/libavformat/hls.c	2015-10-15 22:48:16.312638807 +0300
++++ b/libavformat/hls.c	2015-10-15 22:48:30.812710713 +0300
+@@ -1834,8 +1834,10 @@
+     HLSContext *c = s->priv_data;
+     int ret, i, minplaylist = -1;
+ 
+-    recheck_discard_flags(s, c->first_packet);
+-    c->first_packet = 0;
++    if (c->first_packet) {
++        recheck_discard_flags(s, 1);
++        c->first_packet = 0;
++    }
+ 
+     for (i = 0; i < c->n_playlists; i++) {
+         struct playlist *pls = c->playlists[i];

--- a/meta-openpli/recipes-multimedia/ffmpeg/ffmpeg/ffmpeg-fix-mpegts.patch
+++ b/meta-openpli/recipes-multimedia/ffmpeg/ffmpeg/ffmpeg-fix-mpegts.patch
@@ -1,0 +1,18 @@
+Fix VIDEO_GET_PTS error in libeplayer3 intruduced in:
+http://git.videolan.org/gitweb.cgi/ffmpeg.git/?p=ffmpeg.git;a=commitdiff;h=14f7a3d55a43c1082ee1186a1990a431c641052d
+
+--- a/libavformat/mpegts.c	2016-06-27 02:54:30.000000000 +0300
++++ b/libavformat/mpegts.c	2016-08-20 01:39:36.668873256 +0300
+@@ -904,10 +904,10 @@
+     pes->buffer = NULL;
+     reset_pes_packet_state(pes);
+ 
+-    sd = av_packet_new_side_data(pkt, AV_PKT_DATA_MPEGTS_STREAM_ID, 1);
++    /*sd = av_packet_new_side_data(pkt, AV_PKT_DATA_MPEGTS_STREAM_ID, 1);
+     if (!sd)
+         return AVERROR(ENOMEM);
+-    *sd = pes->stream_id;
++    *sd = pes->stream_id;*/
+ 
+     return 0;
+ }

--- a/meta-openpli/recipes-multimedia/ffmpeg/ffmpeg/mips64_cpu_detection.patch
+++ b/meta-openpli/recipes-multimedia/ffmpeg/ffmpeg/mips64_cpu_detection.patch
@@ -1,0 +1,32 @@
+It will add -mips64r6 and -mips64r2 to cmdline which will
+cause conflicts
+
+in OE we user mips32r2 and mips64r2 for mips arch versions
+so there is no benefit of detecting it automatically by
+poking at tools especially in cross env
+
+Fixes errors like
+
+linking -mnan=2008 module with previous -mnan=legacy modules
+failed to merge target specific data of file
+
+-Khem
+Upstream-Status: Inappropriate [OE-Specific]
+
+Index: ffmpeg-3.1.1/configure
+===================================================================
+--- ffmpeg-3.1.1.orig/configure
++++ ffmpeg-3.1.1/configure
+@@ -5220,12 +5220,9 @@ elif enabled mips; then
+ 
+     # Enable minimum ISA based on selected options
+     if enabled mips64; then
+-        enabled mips64r6 && check_inline_asm_flags mips64r6 '"dlsa $0, $0, $0, 1"' '-mips64r6'
+         enabled mips64r2 && check_inline_asm_flags mips64r2 '"dext $0, $0, 0, 1"' '-mips64r2'
+         disabled mips64r6 && disabled mips64r2 && check_inline_asm_flags mips64r1 '"daddi $0, $0, 0"' '-mips64'
+     else
+-        enabled mips32r6 && check_inline_asm_flags mips32r6 '"aui $0, $0, 0"' '-mips32r6'
+-        enabled mips32r5 && check_inline_asm_flags mips32r5 '"eretnc"' '-mips32r5'
+         enabled mips32r2 && check_inline_asm_flags mips32r2 '"ext $0, $0, 0, 1"' '-mips32r2'
+         disabled mips32r6 && disabled mips32r5 && disabled mips32r2 && check_inline_asm_flags mips32r1 '"addi $0, $0, 0"' '-mips32'
+     fi

--- a/meta-openpli/recipes-multimedia/ffmpeg/ffmpeg_3.%.bbappend
+++ b/meta-openpli/recipes-multimedia/ffmpeg/ffmpeg_3.%.bbappend
@@ -1,8 +1,235 @@
 RSUGGESTS_${PN} = ""
 
-PROVIDES =+ " libavcodec53 libavformat53 libav"
-PACKAGES =+ " libavcodec53 libavformat53 libav"
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-EXTRA_OECONF_append = " --disable-mipsdsp --disable-mipsdspr2 --disable-mipsfpu "
+PROVIDES =+ " libavcodec53 libavformat53 "
+RDEPENDS_${PN} =+ " libbluray rtmpdump libxml2 openssl "
+DEPENDS =+ " libxml2 "
 
-PACKAGECONFIG[avdevice] = "--enable-avdevice,--disable-avdevice"
+PACKAGECONFIG[librtmp] = "--enable-librtmp,--disable-librtmp,rtmpdump"
+PACKAGECONFIG[libbluray] = "--enable-libbluray --enable-protocol=bluray,--disable-libbluray,libbluray"
+
+PACKAGECONFIG = "avdevice avfilter avcodec avformat swresample swscale postproc \
+		bzlib gpl theora x264 openssl avresample libvorbis vpx librtmp libbluray"
+
+PACKAGES =+ " libavcodec53 libavformat53 libav "
+
+MIPSFPU = "${@bb.utils.contains('TARGET_FPU', 'soft', '--disable-mipsfpu', '--enable-mipsfpu', d)}"
+
+SRC_URI_append = " \
+    file://ffmpeg-fix-hls.patch \
+    file://ffmpeg-buffer-size.patch \
+    file://ffmpeg-aac.patch \
+    file://ffmpeg-fix-mpegts.patch \
+    file://000003_allow_to_choose_rtmp_impl_at_runtime.patch \
+    file://ffmpeg-fix-edit-list-parsing.patch \
+    file://000001_add_dash_demux.patch \
+"
+
+EXTRA_FFCONF = " \
+    --disable-static \
+    --disable-runtime-cpudetect \
+    --enable-ffprobe \
+    --disable-altivec \
+    --disable-amd3dnow \
+    --disable-amd3dnowext \
+    --disable-mmx \
+    --disable-mmxext \
+    --disable-sse \
+    --disable-sse2 \
+    --disable-sse3 \
+    --disable-ssse3 \
+    --disable-sse4 \
+    --disable-sse42 \
+    --disable-avx \
+    --disable-xop \
+    --disable-fma3 \
+    --disable-fma4 \
+    --disable-avx2 \
+    --disable-armv5te \
+    --disable-armv6 \
+    --disable-armv6t2 \
+    --disable-vfp \
+    --disable-neon \
+    --disable-inline-asm \
+    --disable-yasm \
+    --disable-fast-unaligned \
+    --disable-muxers \
+    --enable-muxer=mpeg1video \
+    --enable-encoders \
+    --enable-encoder=mpeg1video \
+    --enable-encoder=png \
+    --disable-decoders \
+    --enable-decoder=alac \
+    --enable-decoder=ape \
+    --enable-decoder=atrac1 \
+    --enable-decoder=atrac3 \
+    --enable-decoder=atrac3p \
+    --enable-decoder=cook \
+    --enable-decoder=dca \
+    --enable-decoder=dsd_lsbf \
+    --enable-decoder=dsd_lsbf_planar \
+    --enable-decoder=dsd_msbf \
+    --enable-decoder=dsd_msbf_planar \
+    --enable-decoder=eac3 \
+    --enable-decoder=evrc \
+    --enable-decoder=h264 \
+    --enable-decoder=iac \
+    --enable-decoder=imc \
+    --enable-decoder=mace3 \
+    --enable-decoder=mace6 \
+    --enable-decoder=metasound \
+    --enable-decoder=mjpeg \
+    --enable-decoder=mlp \
+    --enable-decoder=mp1 \
+    --enable-decoder=mp3 \
+    --enable-decoder=mp3adu \
+    --enable-decoder=mp3on4 \
+    --enable-decoder=mpeg1video \
+    --enable-decoder=nellymoser \
+    --enable-decoder=pcm_alaw \
+    --enable-decoder=pcm_bluray \
+    --enable-decoder=pcm_dvd \
+    --enable-decoder=pcm_f32be \
+    --enable-decoder=pcm_f32le \
+    --enable-decoder=pcm_f64be \
+    --enable-decoder=pcm_f64le \
+    --enable-decoder=pcm_lxf \
+    --enable-decoder=pcm_mulaw \
+    --enable-decoder=pcm_s16be \
+    --enable-decoder=pcm_s16be_planar \
+    --enable-decoder=pcm_s16le \
+    --enable-decoder=pcm_s16le_planar \
+    --enable-decoder=pcm_s24be \
+    --enable-decoder=pcm_s24daud \
+    --enable-decoder=pcm_s24le \
+    --enable-decoder=pcm_s24le_planar \
+    --enable-decoder=pcm_s32be \
+    --enable-decoder=pcm_s32le \
+    --enable-decoder=pcm_s32le_planar \
+    --enable-decoder=pcm_s8 \
+    --enable-decoder=pcm_s8_planar \
+    --enable-decoder=pcm_u16be \
+    --enable-decoder=pcm_u16le \
+    --enable-decoder=pcm_u24be \
+    --enable-decoder=pcm_u24le \
+    --enable-decoder=pcm_u32be \
+    --enable-decoder=pcm_u32le \
+    --enable-decoder=pcm_u8 \
+    --enable-decoder=pcm_zork \
+    --enable-decoder=png \
+    --enable-decoder=ra_144 \
+    --enable-decoder=ra_288 \
+    --enable-decoder=ralf \
+    --enable-decoder=s302m \
+    --enable-decoder=shorten \
+    --enable-decoder=sipr \
+    --enable-decoder=sonic \
+    --enable-decoder=tak \
+    --enable-decoder=truehd \
+    --enable-decoder=truespeech \
+    --enable-decoder=tta \
+    --enable-decoder=wmalossless \
+    --enable-decoder=wmapro \
+    --enable-decoder=wmav1 \
+    --enable-decoder=wmav2 \
+    --enable-decoder=wmavoice \
+    --enable-decoder=aac \
+    --enable-decoder=aac_latm \
+    --enable-decoder=libfdk_aac \
+    --enable-decoder=adpcm_ct \
+    --enable-decoder=adpcm_g722 \
+    --enable-decoder=adpcm_g726 \
+    --enable-decoder=adpcm_g726le \
+    --enable-decoder=adpcm_ima_amv \
+    --enable-decoder=adpcm_ima_oki \
+    --enable-decoder=adpcm_ima_qt \
+    --enable-decoder=adpcm_ima_rad \
+    --enable-decoder=adpcm_ima_wav \
+    --enable-decoder=adpcm_ms \
+    --enable-decoder=adpcm_sbpro_2 \
+    --enable-decoder=adpcm_sbpro_3 \
+    --enable-decoder=adpcm_sbpro_4 \
+    --enable-decoder=adpcm_swf \
+    --enable-decoder=adpcm_yamaha \
+    --enable-decoder=flac \
+    --enable-decoder=g723_1 \
+    --enable-decoder=g729 \
+    --enable-decoder=opus \
+    --enable-decoder=qcelp \
+    --enable-decoder=qdm2 \
+    --enable-decoder=vorbis \
+    --enable-decoder=wavpack \
+    --disable-demuxer=adp \
+    --disable-demuxer=adx \
+    --disable-demuxer=afc \
+    --disable-demuxer=anm \
+    --disable-demuxer=apc \
+    --disable-demuxer=ast \
+    --disable-demuxer=avs \
+    --disable-demuxer=bethsoftvid \
+    --disable-demuxer=bfi \
+    --disable-demuxer=bink \
+    --disable-demuxer=bmv \
+    --disable-demuxer=brstm \
+    --disable-demuxer=c93 \
+    --disable-demuxer=cdg \
+    --disable-demuxer=dnxhd \
+    --disable-demuxer=dsicin \
+    --disable-demuxer=dfa \
+    --disable-demuxer=dxa \
+    --disable-demuxer=ea \
+    --disable-demuxer=ea_cdata \
+    --disable-demuxer=frm \
+    --disable-demuxer=gif \
+    --disable-demuxer=gsm \
+    --disable-demuxer=gxf \
+    --disable-demuxer=hnm \
+    --disable-demuxer=ico \
+    --disable-demuxer=ilbc \
+    --disable-demuxer=iss \
+    --disable-demuxer=jv \
+    --disable-demuxer=mm \
+    --disable-demuxer=paf \
+    --disable-demuxer=pva \
+    --disable-demuxer=qcp \
+    --disable-demuxer=redspark \
+    --disable-demuxer=rl2 \
+    --disable-demuxer=roq \
+    --disable-demuxer=rsd \
+    --disable-demuxer=rso \
+    --disable-demuxer=siff \
+    --disable-demuxer=smjpeg \
+    --disable-demuxer=smush \
+    --disable-demuxer=sol \
+    --disable-demuxer=thp \
+    --disable-demuxer=tiertexseq \
+    --disable-demuxer=tmv \
+    --disable-demuxer=tty \
+    --disable-demuxer=txd \
+    --disable-demuxer=vqf \
+    --disable-demuxer=wsaud \
+    --disable-demuxer=wsvqa \
+    --disable-demuxer=xa \
+    --disable-demuxer=xbin \
+    --disable-demuxer=yop \
+    --disable-demuxer=ingenient \
+    --disable-demuxer=image_dds_pipe \
+    --disable-demuxer=image_dpx_pipe \
+    --disable-demuxer=image_exr_pipe \
+    --disable-demuxer=image_j2k_pipe \
+    --disable-demuxer=image_pictor_pipe \
+    --disable-demuxer=image_qdraw_pipe \
+    --disable-demuxer=image_sgi_pipe \
+    --disable-demuxer=image_sunrast_pipe \
+    --enable-demuxer=image2 \
+    --disable-filters \
+    --enable-filter=scale \
+    ${@bb.utils.contains("TARGET_ARCH", "arm", "", "${MIPSFPU}", d)} \
+    --disable-debug \
+    --pkg-config="pkg-config" \
+    --enable-zlib \
+    --extra-cflags="${TARGET_CFLAGS} ${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS} -ffunction-sections -fdata-sections -fno-aggressive-loop-optimizations" \
+    --extra-ldflags="${TARGET_LDFLAGS},--gc-sections -Wl,--print-gc-sections,-lrt" \
+    --prefix=${prefix} \
+"

--- a/meta-openpli/recipes-multimedia/ffmpeg/ffmpeg_3.3.bb
+++ b/meta-openpli/recipes-multimedia/ffmpeg/ffmpeg_3.3.bb
@@ -1,0 +1,146 @@
+SUMMARY = "A complete, cross-platform solution to record, convert and stream audio and video."
+DESCRIPTION = "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, \
+               mux, demux, stream, filter and play pretty much anything that humans and machines \
+               have created. It supports the most obscure ancient formats up to the cutting edge."
+HOMEPAGE = "https://www.ffmpeg.org/"
+SECTION = "libs"
+
+LICENSE = "BSD & GPLv2+ & LGPLv2.1+ & MIT"
+LICENSE_${PN} = "GPLv2+"
+LICENSE_libavcodec = "${@bb.utils.contains('PACKAGECONFIG', 'gpl', 'GPLv2+', 'LGPLv2.1+', d)}"
+LICENSE_libavdevice = "${@bb.utils.contains('PACKAGECONFIG', 'gpl', 'GPLv2+', 'LGPLv2.1+', d)}"
+LICENSE_libavfilter = "${@bb.utils.contains('PACKAGECONFIG', 'gpl', 'GPLv2+', 'LGPLv2.1+', d)}"
+LICENSE_libavformat = "${@bb.utils.contains('PACKAGECONFIG', 'gpl', 'GPLv2+', 'LGPLv2.1+', d)}"
+LICENSE_libavresample = "${@bb.utils.contains('PACKAGECONFIG', 'gpl', 'GPLv2+', 'LGPLv2.1+', d)}"
+LICENSE_libavutil = "${@bb.utils.contains('PACKAGECONFIG', 'gpl', 'GPLv2+', 'LGPLv2.1+', d)}"
+LICENSE_libpostproc = "GPLv2+"
+LICENSE_libswresample = "${@bb.utils.contains('PACKAGECONFIG', 'gpl', 'GPLv2+', 'LGPLv2.1+', d)}"
+LICENSE_libswscale = "${@bb.utils.contains('PACKAGECONFIG', 'gpl', 'GPLv2+', 'LGPLv2.1+', d)}"
+LICENSE_FLAGS = "commercial"
+
+LIC_FILES_CHKSUM = "file://COPYING.GPLv2;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+                    file://COPYING.GPLv3;md5=d32239bcb673463ab874e80d47fae504 \
+                    file://COPYING.LGPLv2.1;md5=bd7a443320af8c812e4c18d1b79df004 \
+                    file://COPYING.LGPLv3;md5=e6a600fd5e1d9cbde2d983680233ad02"
+
+SRC_URI = "https://www.ffmpeg.org/releases/${BP}.tar.xz \
+           file://mips64_cpu_detection.patch \
+          "
+SRC_URI[md5sum] = "368f1fff4bdadaf2823934cc0aadd71d"
+SRC_URI[sha256sum] = "599e7f7c017221c22011c4037b88bdcd1c47cd40c1e466838bc3c465f3e9569d"
+
+# Build fails when thumb is enabled: https://bugzilla.yoctoproject.org/show_bug.cgi?id=7717
+ARM_INSTRUCTION_SET = "arm"
+
+# Should be API compatible with libav (which was a fork of ffmpeg)
+# libpostproc was previously packaged from a separate recipe
+PROVIDES = "libav libpostproc"
+
+DEPENDS = "alsa-lib zlib libogg yasm-native"
+
+inherit autotools pkgconfig
+
+PACKAGECONFIG ??= "avdevice avfilter avcodec avformat swresample swscale postproc \
+                   bzlib gpl lzma theora x264 \
+                   ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'xv', '', d)}"
+
+# libraries to build in addition to avutil
+PACKAGECONFIG[avdevice] = "--enable-avdevice,--disable-avdevice"
+PACKAGECONFIG[avfilter] = "--enable-avfilter,--disable-avfilter"
+PACKAGECONFIG[avcodec] = "--enable-avcodec,--disable-avcodec"
+PACKAGECONFIG[avformat] = "--enable-avformat,--disable-avformat"
+PACKAGECONFIG[swresample] = "--enable-swresample,--disable-swresample"
+PACKAGECONFIG[swscale] = "--enable-swscale,--disable-swscale"
+PACKAGECONFIG[postproc] = "--enable-postproc,--disable-postproc"
+PACKAGECONFIG[avresample] = "--enable-avresample,--disable-avresample"
+
+# features to support
+PACKAGECONFIG[bzlib] = "--enable-bzlib,--disable-bzlib,bzip2"
+PACKAGECONFIG[gpl] = "--enable-gpl,--disable-gpl"
+PACKAGECONFIG[gsm] = "--enable-libgsm,--disable-libgsm,libgsm"
+PACKAGECONFIG[jack] = "--enable-indev=jack,--disable-indev=jack,jack"
+PACKAGECONFIG[libvorbis] = "--enable-libvorbis,--disable-libvorbis,libvorbis"
+PACKAGECONFIG[lzma] = "--enable-lzma,--disable-lzma,xz"
+PACKAGECONFIG[mp3lame] = "--enable-libmp3lame,--disable-libmp3lame,lame"
+PACKAGECONFIG[openssl] = "--enable-openssl,--disable-openssl,openssl"
+PACKAGECONFIG[schroedinger] = "--enable-libschroedinger,--disable-libschroedinger,schroedinger"
+PACKAGECONFIG[speex] = "--enable-libspeex,--disable-libspeex,speex"
+PACKAGECONFIG[theora] = "--enable-libtheora,--disable-libtheora,libtheora"
+PACKAGECONFIG[vaapi] = "--enable-vaapi,--disable-vaapi,libva"
+PACKAGECONFIG[vdpau] = "--enable-vdpau,--disable-vdpau,libvdpau"
+PACKAGECONFIG[vpx] = "--enable-libvpx,--disable-libvpx,libvpx"
+PACKAGECONFIG[x264] = "--enable-libx264,--disable-libx264,x264"
+PACKAGECONFIG[xv] = "--enable-outdev=xv,--disable-outdev=xv,libxv"
+
+# Check codecs that require --enable-nonfree
+USE_NONFREE = "${@bb.utils.contains_any('PACKAGECONFIG', [ 'openssl' ], 'yes', '', d)}"
+
+def cpu(d):
+    for arg in (d.getVar('TUNE_CCARGS', True) or '').split():
+        if arg.startswith('-mcpu='):
+            return arg[6:]
+    return 'generic'
+
+EXTRA_OECONF = " \
+    --disable-stripping \
+    --enable-pic \
+    --enable-shared \
+    --enable-pthreads \
+    ${@bb.utils.contains('USE_NONFREE', 'yes', '--enable-nonfree', '', d)} \
+    \
+    --cross-prefix=${TARGET_PREFIX} \
+    \
+    --ld="${CCLD}" \
+    --cc="${CC}" \
+    --cxx="${CXX}" \
+    --arch=${TARGET_ARCH} \
+    --target-os="linux" \
+    --enable-cross-compile \
+    --extra-cflags="${TARGET_CFLAGS} ${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS}" \
+    --extra-ldflags="${TARGET_LDFLAGS}" \
+    --sysroot="${STAGING_DIR_TARGET}" \
+    --enable-hardcoded-tables \
+    ${EXTRA_FFCONF} \
+    --libdir=${libdir} \
+    --shlibdir=${libdir} \
+    --datadir=${datadir}/ffmpeg \
+    ${@bb.utils.contains('AVAILTUNES', 'mips32r2', '', '--disable-mipsdsp --disable-mipsdspr2', d)} \
+    --cpu=${@cpu(d)} \
+"
+
+EXTRA_OECONF_append_linux-gnux32 = " --disable-asm"
+
+do_configure() {
+    ${S}/configure ${EXTRA_OECONF}
+}
+
+PACKAGES =+ "libavcodec \
+             libavdevice \
+             libavfilter \
+             libavformat \
+             libavresample \
+             libavutil \
+             libpostproc \
+             libswresample \
+             libswscale"
+
+FILES_libavcodec = "${libdir}/libavcodec${SOLIBS}"
+FILES_libavdevice = "${libdir}/libavdevice${SOLIBS}"
+FILES_libavfilter = "${libdir}/libavfilter${SOLIBS}"
+FILES_libavformat = "${libdir}/libavformat${SOLIBS}"
+FILES_libavresample = "${libdir}/libavresample${SOLIBS}"
+FILES_libavutil = "${libdir}/libavutil${SOLIBS}"
+FILES_libpostproc = "${libdir}/libpostproc${SOLIBS}"
+FILES_libswresample = "${libdir}/libswresample${SOLIBS}"
+FILES_libswscale = "${libdir}/libswscale${SOLIBS}"
+
+# ffmpeg disables PIC on some platforms (e.g. x86-32)
+INSANE_SKIP_${MLPREFIX}libavcodec = "textrel"
+INSANE_SKIP_${MLPREFIX}libavdevice = "textrel"
+INSANE_SKIP_${MLPREFIX}libavfilter = "textrel"
+INSANE_SKIP_${MLPREFIX}libavformat = "textrel"
+INSANE_SKIP_${MLPREFIX}libavutil = "textrel"
+INSANE_SKIP_${MLPREFIX}libavresample = "textrel"
+INSANE_SKIP_${MLPREFIX}libswscale = "textrel"
+INSANE_SKIP_${MLPREFIX}libswresample = "textrel"
+INSANE_SKIP_${MLPREFIX}libpostproc = "textrel"

--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-systemplugins-serviceapp.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-systemplugins-serviceapp.bb
@@ -7,6 +7,7 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 DEPENDS = "enigma2 uchardet openssl"
 RDEPENDS_${PN} = "enigma2 uchardet openssl"
+RRECOMMENDS_${PN} = "exteplayer3 gstplayer"
 
 SRC_URI = "git://github.com/mx3L/serviceapp.git;branch=develop"
 


### PR DESCRIPTION
Thanks to SSS, mx3L and Taapat for making it possible.
FFMpeg:
- Update to ffmpeg 3.3 recipe from upstream oe
- Initial support for mpeg-dash streams
- aac and buffersize patches from duckbox developers
- fixes for hls and mpegts
- Taapat: disable log to fix freezing on edit list parsing
- samsamsam: Allow exteplayer3 to select between ffmpeg internal rtmp or external librtmp support
- mips64_cpu_detection.patch from upstream oe
- Adapt bbappend based for ffmpeg 3.3
ServiceApp:
- Add exteplayer3 and gstplayer to RRECOMMENDS_${PN} so they get installed as well.