### PR TITLE
dreambox: restore manufacturer splash

### DIFF
--- a/meta-dream/conf/machine/dm500hd.conf
+++ b/meta-dream/conf/machine/dm500hd.conf
@@ -17,3 +17,5 @@ CHIPSET = "bcm7405"
 
 # Do not install samba due to small flash size
 IMAGE_INSTALL_remove = "samba-base"
+
+MACHINE_EXTRA_RRECOMMENDS += "dreambox-bootlogo"

--- a/meta-dream/conf/machine/dm7020hd.conf
+++ b/meta-dream/conf/machine/dm7020hd.conf
@@ -16,3 +16,4 @@ DVBMEDIASINK_CONFIG = "--with-pcm --with-wma --with-wmv --with-dtsdownmix --with
 CHIPSET = "bcm7405"
 
 MACHINE_EXTRA_RRECOMMENDS += "dreambox-enigma2-config"
+MACHINE_EXTRA_RRECOMMENDS += "dreambox-bootlogo"

--- a/meta-dream/conf/machine/dm8000.conf
+++ b/meta-dream/conf/machine/dm8000.conf
@@ -15,3 +15,4 @@ DVBMEDIASINK_CONFIG = "--with-pcm --with-wma --with-wmv --with-dtsdownmix --with
 CHIPSET = "bcm7400"
 
 MACHINE_EXTRA_RRECOMMENDS += "dreambox-enigma2-config"
+MACHINE_EXTRA_RRECOMMENDS += "dreambox-bootlogo"

--- a/meta-dream/conf/machine/dm800se.conf
+++ b/meta-dream/conf/machine/dm800se.conf
@@ -22,3 +22,5 @@ KERNEL_IMAGE_MAXSIZE = "6500000"
 
 # Do not install samba due to small flash size
 IMAGE_INSTALL_remove = "samba-base"
+
+MACHINE_EXTRA_RRECOMMENDS += "dreambox-bootlogo"

--- a/meta-dream/recipes-bsp/drivers/dreambox-bootlogo.bb
+++ b/meta-dream/recipes-bsp/drivers/dreambox-bootlogo.bb
@@ -1,0 +1,64 @@
+SUMMARY = "Dreambox bootlogo(splash)"
+LICENSE = "CLOSED"
+PV="1.3"
+
+BINARY_VERSION = "1.3"
+
+SRC_URI = "http://dreamboxupdate.com/download/opendreambox/2.0.0/dreambox-bootlogo/dreambox-bootlogo_${BINARY_VERSION}_${MACHINE}.tar.bz2;name=${MACHINE}"
+
+SRC_URI[dm8000.md5sum] = "1b63ac7e2bd5c0db0748606acc310d47"
+SRC_URI[dm8000.sha256sum] = "91e4402190fe88cf394ae780141d968a1ebecd8db7b23c1f0ca3f4bfa9c9512a"
+SRC_URI[dm800se.md5sum] = "3413a894a3d77e02cae34b96d302817d"
+SRC_URI[dm800se.sha256sum] = "8a283442c231e82ee1a2093e53dc5bf52c478e12d22c79af7e7026b52711fc9c"
+SRC_URI[dm500hd.md5sum] = "b9ada70304ca1f9a8e36a55bd38834c6"
+SRC_URI[dm500hd.sha256sum] = "d4b0f650711d5d6fdecb42efe9e13987ef803cba829d0950e899608a784ae3b2"
+SRC_URI[dm7020hd.md5sum] = "f8e423dbf7661367659fa86a68b74bc4"
+SRC_URI[dm7020hd.sha256sum] = "118d7bb57c4b41dd45c7bdd9a056a0745454f42092692fb4309997e035eb6908"
+
+S = "${WORKDIR}/dreambox-bootlogo_${BINARY_VERSION}_${MACHINE}"
+
+do_install(){
+install -d ${D}/boot
+install -m 0755 ${S}/bootlogo-${MACHINE}.elf.gz ${D}/boot
+install -m 0755 ${S}/bootlogo-${MACHINE}.jpg ${D}/boot
+}
+
+FILES_${PN} = "/boot"
+
+pkg_preinst_${PN}_dreambox() {
+	if [ -z "$D" ]
+	then
+		if mountpoint -q /boot
+		then
+			mount -o remount,rw,compr=none /boot
+		else
+			mount -t jffs2 -o rw,compr=none mtd:boot /boot
+		fi
+	fi
+}
+
+pkg_postinst_${PN}_dreambox() {
+	if [ -z "$D" ]
+	then
+		umount /boot
+	fi
+}
+
+pkg_prerm_${PN}_dreambox() {
+	if [ -z "$D" ]
+	then
+		if mountpoint -q /boot
+		then
+			mount -o remount,rw,compr=none /boot
+		else
+			mount -t jffs2 -o rw,compr=none mtd:boot /boot
+		fi
+	fi
+}
+
+pkg_postrm_${PN}_dreambox() {
+	if [ -z "$D" ]
+	then
+		umount /boot
+	fi
+}


### PR DESCRIPTION
Manufacturer splash is banned from meta-openpli.
See commit:
https://github.com/OpenPLi/openpli-oe-core/commit/9139f0986a543de8f8d967d09fd33282a7821e3c

Wich result in a missing splash after a flash.
Restore splash in the place where it belongs.