### PR TITLE
Plugin youtube: add python-pyopenssl in rdepends

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-youtube.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-youtube.bb
@@ -19,6 +19,7 @@ RDEPENDS_${PN} = " \
 	python-codecs \
 	python-json \
 	python-netclient \
+	python-pyopenssl \
 	python-zlib \
 	python-twisted-web \
 	"


### PR DESCRIPTION
In the plugin has no direct openpssl import, but it is necessary when using twisted-web for https links