### PR TITLE
Remove ffmpeg from exteplayer3 rdepends

### DIFF
--- a/meta-openpli/recipes-multimedia/exteplayer3/exteplayer3_git.bb
+++ b/meta-openpli/recipes-multimedia/exteplayer3/exteplayer3_git.bb
@@ -5,7 +5,6 @@ LICENSE = "GPL-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
 
 DEPENDS = "ffmpeg"
-RDEPENDS_${PN} = "ffmpeg"
 
 inherit gitpkgv
 


### PR DESCRIPTION
exteplayer3 not use ffmpeg but its libraries, which are added automatically.