### PR TITLE
Gstreamer: move the duplicate code into one file

### DIFF
--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-common.inc
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-common.inc
@@ -12,6 +12,8 @@ inherit gitpkgv
 PV = "1.12.1+git${SRCPV}"
 PKGV = "1.12.1+git${GITPKGV}"
 
+GST_BRANCH ?= "1.12"
+
 do_configure_prepend() {
 	cd ${S}
 	./autogen.sh --noconfigure

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-common.inc
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-common.inc
@@ -1,0 +1,20 @@
+SRC_URI_append = "\
+    git://anongit.freedesktop.org/gstreamer/common;destsuffix=git/common;name=common \
+"
+
+S = "${WORKDIR}/git"
+
+UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>(\d+(\.\d+)+))"
+
+SRCREV_FORMAT = "base"
+
+inherit gitpkgv
+PV = "1.12.1+git${SRCPV}"
+PKGV = "1.12.1+git${GITPKGV}"
+
+do_configure_prepend() {
+	cd ${S}
+	./autogen.sh --noconfigure
+	cd ${B}
+}
+

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-libav_git.bb
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-libav_git.bb
@@ -1,4 +1,5 @@
 require gstreamer1.0-libav.inc
+include gstreamer1.0-common.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
                     file://COPYING.LIB;md5=6762ed442b3822387a51c92d928ead0d \
@@ -11,22 +12,6 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
 # warnings in gstreamer1.0-libav.inc
 SRC_URI = " \
 	git://anongit.freedesktop.org/gstreamer/gst-libav;branch=1.12;name=base \
-	git://anongit.freedesktop.org/gstreamer/common;destsuffix=git/common;name=common \
 	file://0001-Disable-yasm-for-libav-when-disable-yasm.patch \
 "
 
-S = "${WORKDIR}/git"
-
-UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>(\d+(\.\d+)+))"
-
-SRCREV_FORMAT = "base"
-
-inherit gitpkgv
-PV = "1.12.1+git${SRCPV}"
-PKGV = "1.12.1+git${GITPKGV}"
-
-do_configure_prepend() {
-	cd ${S}
-	./autogen.sh --noconfigure
-	cd ${B}
-}

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-libav_git.bb
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-libav_git.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
 # and remove the ffmpeg sources from SRC_URI below. However, first note the
 # warnings in gstreamer1.0-libav.inc
 SRC_URI = " \
-	git://anongit.freedesktop.org/gstreamer/gst-libav;branch=1.12;name=base \
+	git://anongit.freedesktop.org/gstreamer/gst-libav;branch=${GST_BRANCH};name=base \
 	file://0001-Disable-yasm-for-libav-when-disable-yasm.patch \
 "
 

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_git.bb
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=73a5855a8119deb017f5f13cf327095d \
 "
 
 SRC_URI = " \
-	git://anongit.freedesktop.org/gstreamer/gst-plugins-bad;branch=1.12;name=base \
+	git://anongit.freedesktop.org/gstreamer/gst-plugins-bad;branch=${GST_BRANCH};name=base \
 	file://configure-allow-to-disable-libssh2.patch \
 	file://0001-Makefile.am-don-t-hardcode-libtool-name-when-running-pbad.patch \
 	file://0001-rtmp-fix-seeking-and-potential-segfault.patch \

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_git.bb
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_git.bb
@@ -1,18 +1,12 @@
 require gstreamer1.0-plugins-bad.inc
+include gstreamer1.0-common.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=73a5855a8119deb017f5f13cf327095d \
                     file://COPYING.LIB;md5=21682e4e8fea52413fd26c60acb907e5 \
 "
 
-S = "${WORKDIR}/git"
-
-UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>(\d+(\.\d+)+))"
-
-SRCREV_FORMAT = "base"
-
 SRC_URI = " \
 	git://anongit.freedesktop.org/gstreamer/gst-plugins-bad;branch=1.12;name=base \
-	git://anongit.freedesktop.org/gstreamer/common;destsuffix=git/common;name=common \
 	file://configure-allow-to-disable-libssh2.patch \
 	file://0001-Makefile.am-don-t-hardcode-libtool-name-when-running-pbad.patch \
 	file://0001-rtmp-fix-seeking-and-potential-segfault.patch \
@@ -23,19 +17,9 @@ SRC_URI = " \
 	file://hls-main-thread-block.patch \
 "
 
-inherit gitpkgv
-PV = "1.12.1+git${SRCPV}"
-PKGV = "1.12.1+git${GITPKGV}"
-
 EXTRA_OECONF += " \
     --disable-openjpeg \
 "
-
-do_configure_prepend() {
-	cd ${S}
-	./autogen.sh --noconfigure
-	cd ${B}
-}
 
 TARGET_CFLAGS_append = " -Wno-error=maybe-uninitialized -Wno-error=redundant-decls "
 

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_git.bb
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_git.bb
@@ -1,18 +1,12 @@
 require gstreamer1.0-plugins-base.inc
+include gstreamer1.0-common.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=c54ce9345727175ff66d17b67ff51f58 \
                     file://COPYING.LIB;md5=6762ed442b3822387a51c92d928ead0d \
                    "
 
-S = "${WORKDIR}/git"
-
-UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>(\d+(\.\d+)+))"
-
-SRCREV_FORMAT = "base"
-
 SRC_URI = " \
 	git://anongit.freedesktop.org/gstreamer/gst-plugins-base;branch=1.12;name=base \
-	git://anongit.freedesktop.org/gstreamer/common;destsuffix=git/common;name=common \
 	file://0001-Makefile.am-don-t-hardcode-libtool-name-when-running.patch \
 	file://0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch \
 	file://0002-Makefile.am-prefix-calls-to-pkg-config-with-PKG_CONF.patch \
@@ -20,15 +14,4 @@ SRC_URI = " \
 	file://0004-rtsp-drop-incorrect-reference-to-gstreamer-sdp-in-Ma.patch \
 	file://subparse-avoid-false-negatives-dealing-with-UTF-8.patch \
 "
-
-inherit gitpkgv
-PV = "1.12.1+git${SRCPV}"
-PKGV = "1.12.1+git${GITPKGV}"
-
-
-do_configure_prepend() {
-	cd ${S}
-	./autogen.sh --noconfigure
-	cd ${B}
-}
 

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_git.bb
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=c54ce9345727175ff66d17b67ff51f58 \
                    "
 
 SRC_URI = " \
-	git://anongit.freedesktop.org/gstreamer/gst-plugins-base;branch=1.12;name=base \
+	git://anongit.freedesktop.org/gstreamer/gst-plugins-base;branch=${GST_BRANCH};name=base \
 	file://0001-Makefile.am-don-t-hardcode-libtool-name-when-running.patch \
 	file://0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch \
 	file://0002-Makefile.am-prefix-calls-to-pkg-config-with-PKG_CONF.patch \

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_git.bb
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_git.bb
@@ -1,29 +1,14 @@
 require gstreamer1.0-plugins-good.inc
+include gstreamer1.0-common.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \
                     file://gst/replaygain/rganalysis.c;beginline=1;endline=23;md5=b60ebefd5b2f5a8e0cab6bfee391a5fe"
 
-S = "${WORKDIR}/git"
-
-UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>(\d+(\.\d+)+))"
-
-SRCREV_FORMAT = "base"
-
 SRC_URI = " \
 	git://anongit.freedesktop.org/gstreamer/gst-plugins-good;branch=1.12;name=base \
-	git://anongit.freedesktop.org/gstreamer/common;destsuffix=git/common;name=common \
 	file://0001-gstrtpmp4gpay-set-dafault-value-for-MPEG4-without-co.patch \
 	file://0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch \
 "
 
-inherit gitpkgv
-PV = "1.12.1+git${SRCPV}"
-PKGV = "1.12.1+git${GITPKGV}"
-
 CFLAGS_append += " -Wno-maybe-uninitialized -Wno-uninitialized "
 
-do_configure_prepend() {
-	cd ${S}
-	./autogen.sh --noconfigure
-	cd ${B}
-}

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_git.bb
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \
                     file://gst/replaygain/rganalysis.c;beginline=1;endline=23;md5=b60ebefd5b2f5a8e0cab6bfee391a5fe"
 
 SRC_URI = " \
-	git://anongit.freedesktop.org/gstreamer/gst-plugins-good;branch=1.12;name=base \
+	git://anongit.freedesktop.org/gstreamer/gst-plugins-good;branch=${GST_BRANCH};name=base \
 	file://0001-gstrtpmp4gpay-set-dafault-value-for-MPEG4-without-co.patch \
 	file://0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch \
 "

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_git.bb
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_git.bb
@@ -1,27 +1,11 @@
 require gstreamer1.0-plugins-ugly.inc
+include gstreamer1.0-common.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \
                     file://tests/check/elements/xingmux.c;beginline=1;endline=21;md5=4c771b8af188724855cb99cadd390068 "
 
-S = "${WORKDIR}/git"
-
-UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>(\d+(\.\d+)+))"
-
-SRCREV_FORMAT = "base"
-
 SRC_URI = " \
 	git://anongit.freedesktop.org/gstreamer/gst-plugins-ugly;branch=1.12;name=base \
-	git://anongit.freedesktop.org/gstreamer/common;destsuffix=git/common;name=common \
 	file://0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch \
 "
-
-inherit gitpkgv
-PV = "1.12.1+git${SRCPV}"
-PKGV = "1.12.1+git${GITPKGV}"
-
-do_configure_prepend() {
-	cd ${S}
-	./autogen.sh --noconfigure
-	cd ${B}
-}
 

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_git.bb
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \
                     file://tests/check/elements/xingmux.c;beginline=1;endline=21;md5=4c771b8af188724855cb99cadd390068 "
 
 SRC_URI = " \
-	git://anongit.freedesktop.org/gstreamer/gst-plugins-ugly;branch=1.12;name=base \
+	git://anongit.freedesktop.org/gstreamer/gst-plugins-ugly;branch=${GST_BRANCH};name=base \
 	file://0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch \
 "
 

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0_git.bb
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0_git.bb
@@ -1,4 +1,5 @@
 require gstreamer1.0.inc
+include gstreamer1.0-common.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6762ed442b3822387a51c92d928ead0d \
                     file://gst/gst.h;beginline=1;endline=21;md5=e059138481205ee2c6fc1c079c016d0d \
@@ -6,25 +7,8 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6762ed442b3822387a51c92d928ead0d \
 
 SRC_URI = " \
 	git://anongit.freedesktop.org/gstreamer/gstreamer;branch=1.12;name=base \
-	git://anongit.freedesktop.org/gstreamer/common;destsuffix=git/common;name=common \
 	file://deterministic-unwind.patch \
 	file://0001-revert-use-new-gst-adapter-get-buffer.patch \
 	file://0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch \
 "
-
-S = "${WORKDIR}/git"
-
-UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>(\d+(\.\d+)+))"
-
-SRCREV_FORMAT = "base"
-
-inherit gitpkgv
-PV = "1.12.1+git${SRCPV}"
-PKGV = "1.12.1+git${GITPKGV}"
-
-do_configure_prepend() {
-	cd ${S}
-	./autogen.sh --noconfigure
-	cd ${B}
-}
 

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0_git.bb
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6762ed442b3822387a51c92d928ead0d \
 "
 
 SRC_URI = " \
-	git://anongit.freedesktop.org/gstreamer/gstreamer;branch=1.12;name=base \
+	git://anongit.freedesktop.org/gstreamer/gstreamer;branch=${GST_BRANCH};name=base \
 	file://deterministic-unwind.patch \
 	file://0001-revert-use-new-gst-adapter-get-buffer.patch \
 	file://0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch \


### PR DESCRIPTION
This allows on the update or on corrections perform them in a single file, rather than make the same changes in many files, which can lead to inadvertent errors.