### PR TITLE
enigma2: use --with-7segment also for receivers with 7seg in MACHINE_FEATURES

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2/enigma2.bb
+++ b/meta-openpli/recipes-openpli/enigma2/enigma2.bb
@@ -202,6 +202,7 @@ EXTRA_OECONF = "\
 	${@get_crashaddr(d)} \
 	${@bb.utils.contains("MACHINE_FEATURES", "textlcd", "--with-textlcd" , "", d)} \
 	${@bb.utils.contains("MACHINE_FEATURES", "7segment", "--with-7segment" , "", d)} \
+	${@base_contains("MACHINE_FEATURES", "7seg", "--with-7segment" , "", d)} \
 	BUILD_SYS=${BUILD_SYS} \
 	HOST_SYS=${HOST_SYS} \
 	STAGING_INCDIR=${STAGING_INCDIR} \


### PR DESCRIPTION
This allow use skin_text_7segment.xml aslo for edision, spycat and formuler if they do not use their skin_text.xml.

Tested only on formuler f3 but should work on all receivers with 7 segment display.

This commit dublicate https://github.com/OpenPLi/openpli-oe-core/commit/4782aecd8c2fc51d742a0be24905e1df3e4ab5b5
Whitch is lost after the merge.