### PR TITLE
nfs-utils: properly silence the bash provider not found

### DIFF
--- a/meta-openpli/recipes-connectivity/nfs-utils/nfs-utils_1.%.bbappend
+++ b/meta-openpli/recipes-connectivity/nfs-utils/nfs-utils_1.%.bbappend
@@ -3,7 +3,6 @@
 # bbappend basically reverses that commit.
 #
 RDEPENDS_${PN}-client = "rpcbind"
-RDEPENDS_${PN} = "${PN}-client"
 
 # The startup script does a check that doesn't work, replace it. It's
 # also overly complex, so simplified it too.

--- a/meta-openpli/recipes-connectivity/nfs-utils/nfs-utils_1.%.bbappend
+++ b/meta-openpli/recipes-connectivity/nfs-utils/nfs-utils_1.%.bbappend
@@ -2,7 +2,7 @@
 # bash into our system, which we definitely don't want to happen. This
 # bbappend basically reverses that commit.
 #
-RDEPENDS_${PN}-client = "rpcbind bash"
+RDEPENDS_${PN}-client = "rpcbind"
 RDEPENDS_${PN} = "${PN}-client"
 
 # The startup script does a check that doesn't work, replace it. It's


### PR DESCRIPTION
The nfs-utils-client doesn't really require bash in order to work. As the bbappend mentions in comments.
The nfs-utils requires bash due to osd_login. Until somebody patches the osd_login to use sh, use original depends from open-embedded that already include bash.

~ opkg files nfs-utils-client | grep "/" | xargs fgrep "/bin/bash"
~ opkg files nfs-utils-client | grep "/" | xargs fgrep "/bin/sh"
/etc/init.d/nfscommon:#!/bin/sh
/usr/sbin/start-statd:#!/bin/sh
~ opkg files nfs-utils | grep "/" | xargs fgrep "/bin/bash"
/sbin/osd_login:#!/bin/bash
~ opkg files nfs-utils | grep "/" | xargs fgrep "/bin/sh"
/etc/init.d/nfsserver:#!/bin/sh

Please note that by default we do not install nfs-utils, so most probably the wrongly installed bash will go way and that might have undesired behaviour.
