### PR TITLE
autofs auto.master file as CONFFILES

### DIFF
--- a/meta-openpli/recipes-daemons/autofs/autofs_5.1.%.bbappend
+++ b/meta-openpli/recipes-daemons/autofs/autofs_5.1.%.bbappend
@@ -4,6 +4,8 @@ EXTRA_OECONF += "--with-confdir=/etc/default"
 
 SRC_URI += " file://99_autofs"
 
+CONFFILES = "/etc/auto.master /etc/auto.net"
+
 # Remove and change configuration files
 do_install_append() {
 	echo "/media/net /etc/auto.net --ghost" > ${D}/etc/auto.master


### PR DESCRIPTION
Same for auto.net file (created as example), if some user using it as one file with params for mountpoint