### PR TITLE
gstplayer: remove gstplayer_gst-1.0 simlink on package remove

### DIFF
--- a/meta-openpli/recipes-multimedia/gstplayer/gstplayer_0.1.bb
+++ b/meta-openpli/recipes-multimedia/gstplayer/gstplayer_0.1.bb
@@ -24,5 +24,9 @@ do_install() {
 }
 
 pkg_postinst_${PN}() {
-    ln -s gstplayer $D${bindir}/gstplayer_gst-1.0
+    ln -s gstplayer ${bindir}/gstplayer_gst-1.0
+}
+
+pkg_prerm_${PN}() {
+    rm -f ${bindir}/gstplayer_gst-1.0
 }


### PR DESCRIPTION
In https://github.com/OpenPLi/openpli-oe-core/commit/d23e4f19355c9d4f86ae62d9b80009647000ebf2 added postinst script witch create simlink to gstplayer_gst-1.0.
But on the package remove this symlynk is not removed and remains.
This causes an error on each package update:
Configuring gstplayer.
ln: /usr/bin/gstplayer_gst-1.0: File exists
Collected errors:
 * pkg_run_script: package gstplayer postinst script returned status 1.
 * opkg_configure: gstplayer.postinst returned 1.

Add prerm script witch remove symlynk on package remove
and fix this error.

Also remove unnecessary variable  in postinst script.