### PR TITLE
Remove ABM

### DIFF
--- a/meta-openpli/conf/distro/reporefs.conf
+++ b/meta-openpli/conf/distro/reporefs.conf
@@ -230,7 +230,6 @@ SRCREV_pn-enigma2-plugin-extensions-systemtools = "6008851f1d4556b213fbafaee7340
 SRCREV_pn-enigma2-plugin-extensions-usbformatwizard = "${AUTOREV}"
 SRCREV_pn-enigma2-plugin-extensions-wakeonlan = "ff4efd65559655d4b44991c89dc6506bfb8efb2b"
 SRCREV_pn-enigma2-plugin-extensions-xpower = "3a1e16483589cf4a3a7ae09e8000876a41de66c5"
-SRCREV_pn-enigma2-plugin-systemplugins-autobouquetsmaker = "00251de3c30a14a018cdf19a9efa4f5e6b2efab4"
 SRCREV_pn-enigma2-plugin-systemplugins-autoshutdown = "b0ca70667886d9dd78d7adedca9913ed27a8d2a1"
 SRCREV_pn-enigma2-plugin-systemplugins-crossepg = "${AUTOREV}"
 SRCREV_pn-enigma2-plugin-systemplugins-satscan = "78c7d56f6ed498e378949b95f8d90f0862509594"


### PR DESCRIPTION
PLI insists on using outdated version
Avoid downgrades if users installs newer version