### PR TITLE
ofgwrite: fix PV to allow updates

### DIFF
--- a/meta-openpli/recipes-extended/ofgwrite/ofgwrite.bb
+++ b/meta-openpli/recipes-extended/ofgwrite/ofgwrite.bb
@@ -7,6 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=0636e73ff0215e8d672dc4c32c317bb3 \
 
 inherit gitpkgv
 
+PV = "3.x+git${SRCPV}"
 PKGV = "3.x+git${GITPKGV}"
 
 SRC_URI = "git://github.com/oe-alliance/ofgwrite.git"


### PR DESCRIPTION
The PV by default has value 1.0 if we dont override it.
That causes the ofgwrite not to get updated when using AUTOREV.