### PR TITLE
Fix building OpenPLi with gcc 7

### DIFF
--- a/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/0001-build-Provide-alternatives-for-glibc-assumptions-hel.patch
+++ b/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/0001-build-Provide-alternatives-for-glibc-assumptions-hel.patch
@@ -1,0 +1,1051 @@
+From 054fedda5ab9b84160d40d90cb967f2f5822b889 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 31 Dec 2015 06:35:34 +0000
+Subject: [PATCH] build: Provide alternatives for glibc assumptions helps
+ compiling it on musl
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+Rebase to 0.68
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+---
+ Makefile.am                      |  2 +-
+ lib/color.c                      |  3 ++-
+ lib/crc32_file.c                 |  1 +
+ lib/fixedsizehash.h              |  1 -
+ lib/system.h                     | 10 ++++++++++
+ lib/xmalloc.c                    |  2 +-
+ libasm/asm_end.c                 |  2 +-
+ libasm/asm_newscn.c              |  2 +-
+ libcpu/i386_gendis.c             |  2 +-
+ libcpu/i386_lex.c                |  2 +-
+ libcpu/i386_parse.c              |  2 +-
+ libdw/Makefile.am                |  4 +++-
+ libdw/libdw_alloc.c              |  2 +-
+ libdwfl/dwfl_build_id_find_elf.c |  3 ++-
+ libdwfl/dwfl_error.c             |  4 +++-
+ libdwfl/dwfl_module_getdwarf.c   |  1 +
+ libdwfl/find-debuginfo.c         |  2 +-
+ libdwfl/libdwfl_crc32_file.c     | 10 ++++++++++
+ libdwfl/linux-kernel-modules.c   |  1 +
+ libebl/eblopenbackend.c          |  2 +-
+ libelf/elf.h                     |  8 ++++++--
+ libelf/libelf.h                  |  1 +
+ libelf/libelfP.h                 |  1 +
+ src/addr2line.c                  |  2 +-
+ src/ar.c                         |  2 +-
+ src/arlib.c                      |  2 +-
+ src/arlib2.c                     |  2 +-
+ src/elfcmp.c                     |  2 +-
+ src/elflint.c                    |  2 +-
+ src/findtextrel.c                |  2 +-
+ src/nm.c                         |  2 +-
+ src/objdump.c                    |  2 +-
+ src/ranlib.c                     |  2 +-
+ src/readelf.c                    |  2 +-
+ src/size.c                       |  2 +-
+ src/stack.c                      |  2 +-
+ src/strings.c                    |  2 +-
+ src/strip.c                      |  2 +-
+ src/unstrip.c                    |  2 +-
+ tests/addrscopes.c               |  2 +-
+ tests/allregs.c                  |  2 +-
+ tests/backtrace-data.c           |  2 +-
+ tests/backtrace-dwarf.c          |  2 +-
+ tests/backtrace.c                |  2 +-
+ tests/buildid.c                  |  2 +-
+ tests/debugaltlink.c             |  2 +-
+ tests/debuglink.c                |  2 +-
+ tests/deleted.c                  |  2 +-
+ tests/dwfl-addr-sect.c           |  2 +-
+ tests/dwfl-bug-addr-overflow.c   |  2 +-
+ tests/dwfl-bug-fd-leak.c         |  2 +-
+ tests/dwfl-bug-getmodules.c      |  2 +-
+ tests/dwfl-report-elf-align.c    |  2 +-
+ tests/dwfllines.c                |  2 +-
+ tests/dwflmodtest.c              |  2 +-
+ tests/dwflsyms.c                 |  2 +-
+ tests/early-offscn.c             |  2 +-
+ tests/ecp.c                      |  2 +-
+ tests/find-prologues.c           |  2 +-
+ tests/funcretval.c               |  2 +-
+ tests/funcscopes.c               |  2 +-
+ tests/getsrc_die.c               |  2 +-
+ tests/line2addr.c                |  2 +-
+ tests/low_high_pc.c              |  2 +-
+ tests/md5-sha1-test.c            |  2 +-
+ tests/rdwrmmap.c                 |  2 +-
+ tests/saridx.c                   |  2 +-
+ tests/sectiondump.c              |  2 +-
+ tests/varlocs.c                  |  2 +-
+ tests/vdsosyms.c                 |  2 +-
+ 70 files changed, 98 insertions(+), 64 deletions(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index 2ff444e..41f77df 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -28,7 +28,7 @@ pkginclude_HEADERS = version.h
+ 
+ # Add doc back when we have some real content.
+ SUBDIRS = config m4 lib libelf libebl libdwelf libdwfl libdw libcpu libasm \
+-	  backends src po tests
++	  backends po tests
+ 
+ EXTRA_DIST = elfutils.spec GPG-KEY NOTES CONTRIBUTING \
+ 	     COPYING COPYING-GPLV2 COPYING-LGPLV3
+diff --git a/lib/color.c b/lib/color.c
+index fde2d9d..73292ac 100644
+--- a/lib/color.c
++++ b/lib/color.c
+@@ -32,12 +32,13 @@
+ #endif
+ 
+ #include <argp.h>
+-#include <error.h>
++#include <err.h>
+ #include <libintl.h>
+ #include <stdlib.h>
+ #include <string.h>
+ #include <unistd.h>
+ #include "libeu.h"
++#include "system.h"
+ 
+ 
+ /* Prototype for option handler.  */
+diff --git a/lib/crc32_file.c b/lib/crc32_file.c
+index a8434d4..57e4298 100644
+--- a/lib/crc32_file.c
++++ b/lib/crc32_file.c
+@@ -35,6 +35,7 @@
+ #include <unistd.h>
+ #include <sys/stat.h>
+ #include <sys/mman.h>
++#include "system.h"
+ 
+ int
+ crc32_file (int fd, uint32_t *resp)
+diff --git a/lib/fixedsizehash.h b/lib/fixedsizehash.h
+index dac2a5f..43016fc 100644
+--- a/lib/fixedsizehash.h
++++ b/lib/fixedsizehash.h
+@@ -30,7 +30,6 @@
+ #include <errno.h>
+ #include <stdlib.h>
+ #include <string.h>
+-#include <sys/cdefs.h>
+ 
+ #include <system.h>
+ 
+diff --git a/lib/system.h b/lib/system.h
+index ccd99d6..0e93e60 100644
+--- a/lib/system.h
++++ b/lib/system.h
+@@ -55,6 +55,16 @@
+ #else
+ # error "Unknown byte order"
+ #endif
++#ifndef TEMP_FAILURE_RETRY
++#define TEMP_FAILURE_RETRY(expression) \
++  (__extension__							      \
++    ({ long int __result;						      \
++       do __result = (long int) (expression);				      \
++       while (__result == -1L && errno == EINTR);			      \
++       __result; }))
++#endif
++
++#define error(status, errno, ...) err(status, __VA_ARGS__)
+ 
+ #ifndef MAX
+ #define MAX(m, n) ((m) < (n) ? (n) : (m))
+diff --git a/lib/xmalloc.c b/lib/xmalloc.c
+index 0cde384..217b054 100644
+--- a/lib/xmalloc.c
++++ b/lib/xmalloc.c
+@@ -30,7 +30,7 @@
+ # include <config.h>
+ #endif
+ 
+-#include <error.h>
++#include <err.h>
+ #include <libintl.h>
+ #include <stddef.h>
+ #include <stdlib.h>
+diff --git a/libasm/asm_end.c b/libasm/asm_end.c
+index 191a535..bf5ab06 100644
+--- a/libasm/asm_end.c
++++ b/libasm/asm_end.c
+@@ -32,7 +32,7 @@
+ #endif
+ 
+ #include <assert.h>
+-#include <error.h>
++#include <err.h>
+ #include <libintl.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+diff --git a/libasm/asm_newscn.c b/libasm/asm_newscn.c
+index ddbb25d..74a598d 100644
+--- a/libasm/asm_newscn.c
++++ b/libasm/asm_newscn.c
+@@ -32,7 +32,7 @@
+ #endif
+ 
+ #include <assert.h>
+-#include <error.h>
++#include <err.h>
+ #include <libintl.h>
+ #include <stdlib.h>
+ #include <string.h>
+diff --git a/libcpu/i386_gendis.c b/libcpu/i386_gendis.c
+index aae5eae..6d76016 100644
+--- a/libcpu/i386_gendis.c
++++ b/libcpu/i386_gendis.c
+@@ -31,7 +31,7 @@
+ # include <config.h>
+ #endif
+ 
+-#include <error.h>
++#include <err.h>
+ #include <errno.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+diff --git a/libcpu/i386_lex.c b/libcpu/i386_lex.c
+index b670608..b842c25 100644
+--- a/libcpu/i386_lex.c
++++ b/libcpu/i386_lex.c
+@@ -592,7 +592,7 @@ char *i386_text;
+ #endif
+ 
+ #include <ctype.h>
+-#include <error.h>
++#include <err.h>
+ #include <libintl.h>
+ 
+ #include <libeu.h>
+diff --git a/libcpu/i386_parse.c b/libcpu/i386_parse.c
+index 724addf..5b67802 100644
+--- a/libcpu/i386_parse.c
++++ b/libcpu/i386_parse.c
+@@ -107,7 +107,7 @@
+ #include <assert.h>
+ #include <ctype.h>
+ #include <errno.h>
+-#include <error.h>
++#include <err.h>
+ #include <inttypes.h>
+ #include <libintl.h>
+ #include <math.h>
+diff --git a/libdw/Makefile.am b/libdw/Makefile.am
+index 082d96c..51cbea0 100644
+--- a/libdw/Makefile.am
++++ b/libdw/Makefile.am
+@@ -102,6 +102,8 @@ endif
+ libdw_pic_a_SOURCES =
+ am_libdw_pic_a_OBJECTS = $(libdw_a_SOURCES:.c=.os)
+ 
++fts_LDADD = -lfts
++
+ libdw_so_SOURCES =
+ libdw.so$(EXEEXT): $(srcdir)/libdw.map libdw_pic.a ../libdwelf/libdwelf_pic.a \
+ 	  ../libdwfl/libdwfl_pic.a ../libebl/libebl.a \
+@@ -112,7 +114,7 @@ libdw.so$(EXEEXT): $(srcdir)/libdw.map libdw_pic.a ../libdwelf/libdwelf_pic.a \
+ 		-Wl,--enable-new-dtags,-rpath,$(pkglibdir) \
+ 		-Wl,--version-script,$<,--no-undefined \
+ 		-Wl,--whole-archive $(filter-out $<,$^) -Wl,--no-whole-archive\
+-		-ldl -lz $(argp_LDADD) $(zip_LIBS)
++		-ldl -lz $(argp_LDADD) $(zip_LIBS) $(fts_LDADD)
+ 	@$(textrel_check)
+ 	$(AM_V_at)ln -fs $@ $@.$(VERSION)
+ 
+diff --git a/libdw/libdw_alloc.c b/libdw/libdw_alloc.c
+index 28a8cf6..29aeb3f 100644
+--- a/libdw/libdw_alloc.c
++++ b/libdw/libdw_alloc.c
+@@ -31,7 +31,7 @@
+ # include <config.h>
+ #endif
+ 
+-#include <error.h>
++#include <err.h>
+ #include <errno.h>
+ #include <stdlib.h>
+ #include "libdwP.h"
+diff --git a/libdwfl/dwfl_build_id_find_elf.c b/libdwfl/dwfl_build_id_find_elf.c
+index 903e193..b00d10c 100644
+--- a/libdwfl/dwfl_build_id_find_elf.c
++++ b/libdwfl/dwfl_build_id_find_elf.c
+@@ -27,6 +27,7 @@
+    not, see <http://www.gnu.org/licenses/>.  */
+ 
+ #include "libdwflP.h"
++#include "system.h"
+ #include <inttypes.h>
+ #include <fcntl.h>
+ #include <unistd.h>
+@@ -94,7 +95,7 @@ __libdwfl_open_by_build_id (Dwfl_Module *mod, bool debug, char **file_name,
+ 	{
+ 	  if (*file_name != NULL)
+ 	    free (*file_name);
+-	  *file_name = canonicalize_file_name (name);
++	  *file_name = realpath (name, NULL);
+ 	  if (*file_name == NULL)
+ 	    {
+ 	      *file_name = name;
+diff --git a/libdwfl/dwfl_error.c b/libdwfl/dwfl_error.c
+index 7bcf61c..c345797 100644
+--- a/libdwfl/dwfl_error.c
++++ b/libdwfl/dwfl_error.c
+@@ -140,6 +140,7 @@ __libdwfl_seterrno (Dwfl_Error error)
+ const char *
+ dwfl_errmsg (int error)
+ {
++  static __thread char s[64] = "";
+   if (error == 0 || error == -1)
+     {
+       int last_error = global_error;
+@@ -154,7 +155,8 @@ dwfl_errmsg (int error)
+   switch (error &~ 0xffff)
+     {
+     case OTHER_ERROR (ERRNO):
+-      return strerror_r (error & 0xffff, "bad", 0);
++      strerror_r (error & 0xffff, s, sizeof(s));
++      return s;
+     case OTHER_ERROR (LIBELF):
+       return elf_errmsg (error & 0xffff);
+     case OTHER_ERROR (LIBDW):
+diff --git a/libdwfl/dwfl_module_getdwarf.c b/libdwfl/dwfl_module_getdwarf.c
+index 0e8810b..82ad665 100644
+--- a/libdwfl/dwfl_module_getdwarf.c
++++ b/libdwfl/dwfl_module_getdwarf.c
+@@ -31,6 +31,7 @@
+ #include <fcntl.h>
+ #include <string.h>
+ #include <unistd.h>
++#include "system.h"
+ #include "../libdw/libdwP.h"	/* DWARF_E_* values are here.  */
+ #include "../libelf/libelfP.h"
+ 
+diff --git a/libdwfl/find-debuginfo.c b/libdwfl/find-debuginfo.c
+index 80515db..80b0148 100644
+--- a/libdwfl/find-debuginfo.c
++++ b/libdwfl/find-debuginfo.c
+@@ -385,7 +385,7 @@ dwfl_standard_find_debuginfo (Dwfl_Module *mod,
+       /* If FILE_NAME is a symlink, the debug file might be associated
+ 	 with the symlink target name instead.  */
+ 
+-      char *canon = canonicalize_file_name (file_name);
++      char *canon = realpath (file_name, NULL);
+       if (canon != NULL && strcmp (file_name, canon))
+ 	fd = find_debuginfo_in_path (mod, canon,
+ 				     debuglink_file, debuglink_crc,
+diff --git a/libdwfl/libdwfl_crc32_file.c b/libdwfl/libdwfl_crc32_file.c
+index 6b6b7d3..debc4a4 100644
+--- a/libdwfl/libdwfl_crc32_file.c
++++ b/libdwfl/libdwfl_crc32_file.c
+@@ -31,6 +31,16 @@
+ 
+ #define crc32_file attribute_hidden __libdwfl_crc32_file
+ #define crc32 __libdwfl_crc32
++
++#ifndef TEMP_FAILURE_RETRY
++#define TEMP_FAILURE_RETRY(expression) \
++  (__extension__							      \
++    ({ long int __result;						      \
++       do __result = (long int) (expression);				      \
++       while (__result == -1L && errno == EINTR);			      \
++       __result; }))
++#endif
++
+ #define LIB_SYSTEM_H	1
+ #include <libdwflP.h>
+ #include "../lib/crc32_file.c"
+diff --git a/libdwfl/linux-kernel-modules.c b/libdwfl/linux-kernel-modules.c
+index 9cd8ea9..4dbf4c5 100644
+--- a/libdwfl/linux-kernel-modules.c
++++ b/libdwfl/linux-kernel-modules.c
+@@ -36,6 +36,7 @@
+ #include <config.h>
+ 
+ #include "libdwflP.h"
++#include "system.h"
+ #include <inttypes.h>
+ #include <errno.h>
+ #include <stdio.h>
+diff --git a/libebl/eblopenbackend.c b/libebl/eblopenbackend.c
+index 34d439a..56d2345 100644
+--- a/libebl/eblopenbackend.c
++++ b/libebl/eblopenbackend.c
+@@ -32,7 +32,7 @@
+ 
+ #include <assert.h>
+ #include <dlfcn.h>
+-#include <error.h>
++#include <err.h>
+ #include <libelfP.h>
+ #include <dwarf.h>
+ #include <stdlib.h>
+diff --git a/libelf/elf.h b/libelf/elf.h
+index 74654d6..81eee8b 100644
+--- a/libelf/elf.h
++++ b/libelf/elf.h
+@@ -21,7 +21,9 @@
+ 
+ #include <features.h>
+ 
+-__BEGIN_DECLS
++#ifdef __cplusplus
++extern "C" {
++#endif
+ 
+ /* Standard ELF types.  */
+ 
+@@ -3704,6 +3706,8 @@ enum
+ #define R_BPF_NONE		0	/* No reloc */
+ #define R_BPF_MAP_FD		1	/* Map fd to pointer */
+ 
+-__END_DECLS
++#ifdef __cplusplus
++}
++#endif
+ 
+ #endif	/* elf.h */
+diff --git a/libelf/libelf.h b/libelf/libelf.h
+index c0d6389..38a68fd 100644
+--- a/libelf/libelf.h
++++ b/libelf/libelf.h
+@@ -29,6 +29,7 @@
+ #ifndef _LIBELF_H
+ #define _LIBELF_H 1
+ 
++#include <fcntl.h>
+ #include <stdint.h>
+ #include <sys/types.h>
+ 
+diff --git a/libelf/libelfP.h b/libelf/libelfP.h
+index 4459982..1296f20 100644
+--- a/libelf/libelfP.h
++++ b/libelf/libelfP.h
+@@ -36,6 +36,7 @@
+ 
+ #include <ar.h>
+ #include <gelf.h>
++#include <libelf.h>
+ 
+ #include <errno.h>
+ #include <stdbool.h>
+diff --git a/src/addr2line.c b/src/addr2line.c
+index 0222088..cd6a9a6 100644
+--- a/src/addr2line.c
++++ b/src/addr2line.c
+@@ -23,7 +23,7 @@
+ #include <argp.h>
+ #include <assert.h>
+ #include <errno.h>
+-#include <error.h>
++#include <err.h>
+ #include <fcntl.h>
+ #include <inttypes.h>
+ #include <libdwfl.h>
+diff --git a/src/ar.c b/src/ar.c
+index f2f322b..6e70031 100644
+--- a/src/ar.c
++++ b/src/ar.c
+@@ -22,7 +22,7 @@
+ 
+ #include <argp.h>
+ #include <assert.h>
+-#include <error.h>
++#include <err.h>
+ #include <fcntl.h>
+ #include <gelf.h>
+ #include <libintl.h>
+diff --git a/src/arlib.c b/src/arlib.c
+index e0839aa..1143658 100644
+--- a/src/arlib.c
++++ b/src/arlib.c
+@@ -21,7 +21,7 @@
+ #endif
+ 
+ #include <assert.h>
+-#include <error.h>
++#include <err.h>
+ #include <gelf.h>
+ #include <inttypes.h>
+ #include <libintl.h>
+diff --git a/src/arlib2.c b/src/arlib2.c
+index 553fc57..46443d0 100644
+--- a/src/arlib2.c
++++ b/src/arlib2.c
+@@ -20,7 +20,7 @@
+ # include <config.h>
+ #endif
+ 
+-#include <error.h>
++#include <err.h>
+ #include <libintl.h>
+ #include <limits.h>
+ #include <string.h>
+diff --git a/src/elfcmp.c b/src/elfcmp.c
+index 401ab31..873d253 100644
+--- a/src/elfcmp.c
++++ b/src/elfcmp.c
+@@ -23,7 +23,7 @@
+ #include <argp.h>
+ #include <assert.h>
+ #include <errno.h>
+-#include <error.h>
++#include <err.h>
+ #include <fcntl.h>
+ #include <locale.h>
+ #include <libintl.h>
+diff --git a/src/elflint.c b/src/elflint.c
+index 7d3f227..074d21c 100644
+--- a/src/elflint.c
++++ b/src/elflint.c
+@@ -24,7 +24,7 @@
+ #include <assert.h>
+ #include <byteswap.h>
+ #include <endian.h>
+-#include <error.h>
++#include <err.h>
+ #include <fcntl.h>
+ #include <gelf.h>
+ #include <inttypes.h>
+diff --git a/src/findtextrel.c b/src/findtextrel.c
+index dc41502..325888c 100644
+--- a/src/findtextrel.c
++++ b/src/findtextrel.c
+@@ -23,7 +23,7 @@
+ #include <argp.h>
+ #include <assert.h>
+ #include <errno.h>
+-#include <error.h>
++#include <err.h>
+ #include <fcntl.h>
+ #include <gelf.h>
+ #include <libdw.h>
+diff --git a/src/nm.c b/src/nm.c
+index c54e96f..9e031d9 100644
+--- a/src/nm.c
++++ b/src/nm.c
+@@ -26,7 +26,7 @@
+ #include <ctype.h>
+ #include <dwarf.h>
+ #include <errno.h>
+-#include <error.h>
++#include <err.h>
+ #include <fcntl.h>
+ #include <gelf.h>
+ #include <inttypes.h>
+diff --git a/src/objdump.c b/src/objdump.c
+index fff4b81..4b1f966 100644
+--- a/src/objdump.c
++++ b/src/objdump.c
+@@ -21,7 +21,7 @@
+ #endif
+ 
+ #include <argp.h>
+-#include <error.h>
++#include <err.h>
+ #include <fcntl.h>
+ #include <inttypes.h>
+ #include <libintl.h>
+diff --git a/src/ranlib.c b/src/ranlib.c
+index 41a3bcf..0c7da2c 100644
+--- a/src/ranlib.c
++++ b/src/ranlib.c
+@@ -24,7 +24,7 @@
+ #include <argp.h>
+ #include <assert.h>
+ #include <errno.h>
+-#include <error.h>
++#include <err.h>
+ #include <fcntl.h>
+ #include <gelf.h>
+ #include <libintl.h>
+diff --git a/src/readelf.c b/src/readelf.c
+index d18a4b7..a6cfb35 100644
+--- a/src/readelf.c
++++ b/src/readelf.c
+@@ -25,7 +25,7 @@
+ #include <ctype.h>
+ #include <dwarf.h>
+ #include <errno.h>
+-#include <error.h>
++#include <err.h>
+ #include <fcntl.h>
+ #include <gelf.h>
+ #include <inttypes.h>
+diff --git a/src/size.c b/src/size.c
+index de0d791..4639d42 100644
+--- a/src/size.c
++++ b/src/size.c
+@@ -21,7 +21,7 @@
+ #endif
+ 
+ #include <argp.h>
+-#include <error.h>
++#include <err.h>
+ #include <fcntl.h>
+ #include <gelf.h>
+ #include <inttypes.h>
+diff --git a/src/stack.c b/src/stack.c
+index a5a7beb..4c075bc 100644
+--- a/src/stack.c
++++ b/src/stack.c
+@@ -18,7 +18,7 @@
+ #include <config.h>
+ #include <assert.h>
+ #include <argp.h>
+-#include <error.h>
++#include <err.h>
+ #include <stdlib.h>
+ #include <inttypes.h>
+ #include <stdio.h>
+diff --git a/src/strings.c b/src/strings.c
+index 49aab8b..09d5b1c 100644
+--- a/src/strings.c
++++ b/src/strings.c
+@@ -25,7 +25,7 @@
+ #include <ctype.h>
+ #include <endian.h>
+ #include <errno.h>
+-#include <error.h>
++#include <err.h>
+ #include <fcntl.h>
+ #include <gelf.h>
+ #include <inttypes.h>
+diff --git a/src/strip.c b/src/strip.c
+index a875ddf..fd76f7f 100644
+--- a/src/strip.c
++++ b/src/strip.c
+@@ -24,7 +24,7 @@
+ #include <assert.h>
+ #include <byteswap.h>
+ #include <endian.h>
+-#include <error.h>
++#include <err.h>
+ #include <fcntl.h>
+ #include <gelf.h>
+ #include <libelf.h>
+diff --git a/src/unstrip.c b/src/unstrip.c
+index d838ae9..0108272 100644
+--- a/src/unstrip.c
++++ b/src/unstrip.c
+@@ -31,7 +31,7 @@
+ #include <argp.h>
+ #include <assert.h>
+ #include <errno.h>
+-#include <error.h>
++#include <err.h>
+ #include <fcntl.h>
+ #include <fnmatch.h>
+ #include <libintl.h>
+diff --git a/tests/addrscopes.c b/tests/addrscopes.c
+index 791569f..54f4311 100644
+--- a/tests/addrscopes.c
++++ b/tests/addrscopes.c
+@@ -25,7 +25,7 @@
+ #include <stdio_ext.h>
+ #include <locale.h>
+ #include <stdlib.h>
+-#include <error.h>
++#include <err.h>
+ #include <string.h>
+ 
+ 
+diff --git a/tests/allregs.c b/tests/allregs.c
+index 286f7e3..c9de089 100644
+--- a/tests/allregs.c
++++ b/tests/allregs.c
+@@ -21,7 +21,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+-#include <error.h>
++#include <err.h>
+ #include <locale.h>
+ #include <argp.h>
+ #include <assert.h>
+diff --git a/tests/backtrace-data.c b/tests/backtrace-data.c
+index b7158da..354fa6a 100644
+--- a/tests/backtrace-data.c
++++ b/tests/backtrace-data.c
+@@ -27,7 +27,7 @@
+ #include <dirent.h>
+ #include <stdlib.h>
+ #include <errno.h>
+-#include <error.h>
++#include <err.h>
+ #include <unistd.h>
+ #include <dwarf.h>
+ #if defined(__x86_64__) && defined(__linux__)
+diff --git a/tests/backtrace-dwarf.c b/tests/backtrace-dwarf.c
+index a644c8a..b8cbe27 100644
+--- a/tests/backtrace-dwarf.c
++++ b/tests/backtrace-dwarf.c
+@@ -22,7 +22,7 @@
+ #include <stdio_ext.h>
+ #include <locale.h>
+ #include <errno.h>
+-#include <error.h>
++#include <err.h>
+ #include <unistd.h>
+ #include <sys/ptrace.h>
+ #include <sys/types.h>
+diff --git a/tests/backtrace.c b/tests/backtrace.c
+index 1ff6353..47e3f7b 100644
+--- a/tests/backtrace.c
++++ b/tests/backtrace.c
+@@ -24,7 +24,7 @@
+ #include <dirent.h>
+ #include <stdlib.h>
+ #include <errno.h>
+-#include <error.h>
++#include <err.h>
+ #include <unistd.h>
+ #include <dwarf.h>
+ #ifdef __linux__
+diff --git a/tests/buildid.c b/tests/buildid.c
+index 87c1877..2953e6b 100644
+--- a/tests/buildid.c
++++ b/tests/buildid.c
+@@ -23,7 +23,7 @@
+ #include ELFUTILS_HEADER(elf)
+ #include ELFUTILS_HEADER(dwelf)
+ #include <stdio.h>
+-#include <error.h>
++#include <err.h>
+ #include <string.h>
+ #include <stdlib.h>
+ #include <sys/types.h>
+diff --git a/tests/debugaltlink.c b/tests/debugaltlink.c
+index 6d97d50..ee7e559 100644
+--- a/tests/debugaltlink.c
++++ b/tests/debugaltlink.c
+@@ -23,7 +23,7 @@
+ #include ELFUTILS_HEADER(dw)
+ #include ELFUTILS_HEADER(dwelf)
+ #include <stdio.h>
+-#include <error.h>
++#include <err.h>
+ #include <string.h>
+ #include <stdlib.h>
+ #include <sys/types.h>
+diff --git a/tests/debuglink.c b/tests/debuglink.c
+index 935d102..741cb81 100644
+--- a/tests/debuglink.c
++++ b/tests/debuglink.c
+@@ -21,7 +21,7 @@
+ #include <errno.h>
+ #include ELFUTILS_HEADER(dwelf)
+ #include <stdio.h>
+-#include <error.h>
++#include <err.h>
+ #include <string.h>
+ #include <stdlib.h>
+ #include <sys/types.h>
+diff --git a/tests/deleted.c b/tests/deleted.c
+index 6be35bc..0190711 100644
+--- a/tests/deleted.c
++++ b/tests/deleted.c
+@@ -21,7 +21,7 @@
+ #include <unistd.h>
+ #include <assert.h>
+ #include <stdio.h>
+-#include <error.h>
++#include <err.h>
+ #include <errno.h>
+ #ifdef __linux__
+ #include <sys/prctl.h>
+diff --git a/tests/dwfl-addr-sect.c b/tests/dwfl-addr-sect.c
+index 21e470a..1ea1e3b 100644
+--- a/tests/dwfl-addr-sect.c
++++ b/tests/dwfl-addr-sect.c
+@@ -23,7 +23,7 @@
+ #include <stdio_ext.h>
+ #include <stdlib.h>
+ #include <string.h>
+-#include <error.h>
++#include <err.h>
+ #include <locale.h>
+ #include <argp.h>
+ #include ELFUTILS_HEADER(dwfl)
+diff --git a/tests/dwfl-bug-addr-overflow.c b/tests/dwfl-bug-addr-overflow.c
+index aa8030e..02c8bef 100644
+--- a/tests/dwfl-bug-addr-overflow.c
++++ b/tests/dwfl-bug-addr-overflow.c
+@@ -20,7 +20,7 @@
+ #include <inttypes.h>
+ #include <stdio.h>
+ #include <stdio_ext.h>
+-#include <error.h>
++#include <err.h>
+ #include <locale.h>
+ #include ELFUTILS_HEADER(dwfl)
+ 
+diff --git a/tests/dwfl-bug-fd-leak.c b/tests/dwfl-bug-fd-leak.c
+index 689cdd7..5973da3 100644
+--- a/tests/dwfl-bug-fd-leak.c
++++ b/tests/dwfl-bug-fd-leak.c
+@@ -24,7 +24,7 @@
+ #include <dirent.h>
+ #include <stdlib.h>
+ #include <errno.h>
+-#include <error.h>
++#include <err.h>
+ #include <unistd.h>
+ #include <dwarf.h>
+ 
+diff --git a/tests/dwfl-bug-getmodules.c b/tests/dwfl-bug-getmodules.c
+index 1ee989f..fd62e65 100644
+--- a/tests/dwfl-bug-getmodules.c
++++ b/tests/dwfl-bug-getmodules.c
+@@ -18,7 +18,7 @@
+ #include <config.h>
+ #include ELFUTILS_HEADER(dwfl)
+ 
+-#include <error.h>
++#include <err.h>
+ 
+ static const Dwfl_Callbacks callbacks =
+   {
+diff --git a/tests/dwfl-report-elf-align.c b/tests/dwfl-report-elf-align.c
+index a4e97d3..f471587 100644
+--- a/tests/dwfl-report-elf-align.c
++++ b/tests/dwfl-report-elf-align.c
+@@ -20,7 +20,7 @@
+ #include <inttypes.h>
+ #include <stdio.h>
+ #include <stdio_ext.h>
+-#include <error.h>
++#include <err.h>
+ #include <locale.h>
+ #include <string.h>
+ #include <stdlib.h>
+diff --git a/tests/dwfllines.c b/tests/dwfllines.c
+index 90379dd..cbdf6c4 100644
+--- a/tests/dwfllines.c
++++ b/tests/dwfllines.c
+@@ -27,7 +27,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+-#include <error.h>
++#include <err.h>
+ 
+ int
+ main (int argc, char *argv[])
+diff --git a/tests/dwflmodtest.c b/tests/dwflmodtest.c
+index 0027f96..e68d3bc 100644
+--- a/tests/dwflmodtest.c
++++ b/tests/dwflmodtest.c
+@@ -23,7 +23,7 @@
+ #include <stdio_ext.h>
+ #include <stdlib.h>
+ #include <string.h>
+-#include <error.h>
++#include <err.h>
+ #include <locale.h>
+ #include <argp.h>
+ #include ELFUTILS_HEADER(dwfl)
+diff --git a/tests/dwflsyms.c b/tests/dwflsyms.c
+index 49ac334..cf07830 100644
+--- a/tests/dwflsyms.c
++++ b/tests/dwflsyms.c
+@@ -25,7 +25,7 @@
+ #include <stdio.h>
+ #include <stdio_ext.h>
+ #include <stdlib.h>
+-#include <error.h>
++#include <err.h>
+ #include <string.h>
+ 
+ static const char *
+diff --git a/tests/early-offscn.c b/tests/early-offscn.c
+index 924cb9e..6f60d5a 100644
+--- a/tests/early-offscn.c
++++ b/tests/early-offscn.c
+@@ -19,7 +19,7 @@
+ #endif
+ 
+ #include <errno.h>
+-#include <error.h>
++#include <err.h>
+ #include <fcntl.h>
+ #include <gelf.h>
+ #include <stdio.h>
+diff --git a/tests/ecp.c b/tests/ecp.c
+index 38a6859..743cea5 100644
+--- a/tests/ecp.c
++++ b/tests/ecp.c
+@@ -20,7 +20,7 @@
+ #endif
+ 
+ #include <errno.h>
+-#include <error.h>
++#include <err.h>
+ #include <fcntl.h>
+ #include <gelf.h>
+ #include <stdlib.h>
+diff --git a/tests/find-prologues.c b/tests/find-prologues.c
+index ba8ae37..76f5f04 100644
+--- a/tests/find-prologues.c
++++ b/tests/find-prologues.c
+@@ -25,7 +25,7 @@
+ #include <stdio_ext.h>
+ #include <locale.h>
+ #include <stdlib.h>
+-#include <error.h>
++#include <err.h>
+ #include <string.h>
+ #include <fnmatch.h>
+ 
+diff --git a/tests/funcretval.c b/tests/funcretval.c
+index 8d19d11..c8aaa93 100644
+--- a/tests/funcretval.c
++++ b/tests/funcretval.c
+@@ -25,7 +25,7 @@
+ #include <stdio_ext.h>
+ #include <locale.h>
+ #include <stdlib.h>
+-#include <error.h>
++#include <err.h>
+ #include <string.h>
+ #include <fnmatch.h>
+ 
+diff --git a/tests/funcscopes.c b/tests/funcscopes.c
+index 9c90185..dbccb89 100644
+--- a/tests/funcscopes.c
++++ b/tests/funcscopes.c
+@@ -25,7 +25,7 @@
+ #include <stdio_ext.h>
+ #include <locale.h>
+ #include <stdlib.h>
+-#include <error.h>
++#include <err.h>
+ #include <string.h>
+ #include <fnmatch.h>
+ 
+diff --git a/tests/getsrc_die.c b/tests/getsrc_die.c
+index 055aede..9c394dd 100644
+--- a/tests/getsrc_die.c
++++ b/tests/getsrc_die.c
+@@ -19,7 +19,7 @@
+ #endif
+ 
+ #include <errno.h>
+-#include <error.h>
++#include <err.h>
+ #include <fcntl.h>
+ #include <inttypes.h>
+ #include <libelf.h>
+diff --git a/tests/line2addr.c b/tests/line2addr.c
+index e0d65d3..9bf0023 100644
+--- a/tests/line2addr.c
++++ b/tests/line2addr.c
+@@ -26,7 +26,7 @@
+ #include <locale.h>
+ #include <stdlib.h>
+ #include <string.h>
+-#include <error.h>
++#include <err.h>
+ 
+ 
+ static void
+diff --git a/tests/low_high_pc.c b/tests/low_high_pc.c
+index d0f4302..8da4fbd 100644
+--- a/tests/low_high_pc.c
++++ b/tests/low_high_pc.c
+@@ -25,7 +25,7 @@
+ #include <stdio_ext.h>
+ #include <locale.h>
+ #include <stdlib.h>
+-#include <error.h>
++#include <err.h>
+ #include <string.h>
+ #include <fnmatch.h>
+ 
+diff --git a/tests/md5-sha1-test.c b/tests/md5-sha1-test.c
+index d50355e..3c41f40 100644
+--- a/tests/md5-sha1-test.c
++++ b/tests/md5-sha1-test.c
+@@ -19,7 +19,7 @@
+ #endif
+ 
+ #include <string.h>
+-#include <error.h>
++#include <err.h>
+ 
+ #include "md5.h"
+ #include "sha1.h"
+diff --git a/tests/rdwrmmap.c b/tests/rdwrmmap.c
+index 6f027df..1ce5e6e 100644
+--- a/tests/rdwrmmap.c
++++ b/tests/rdwrmmap.c
+@@ -19,7 +19,7 @@
+ #endif
+ 
+ #include <errno.h>
+-#include <error.h>
++#include <err.h>
+ #include <stdio.h>
+ #include <fcntl.h>
+ #include <unistd.h>
+diff --git a/tests/saridx.c b/tests/saridx.c
+index 8a450d8..b387801 100644
+--- a/tests/saridx.c
++++ b/tests/saridx.c
+@@ -17,7 +17,7 @@
+ 
+ #include <config.h>
+ 
+-#include <error.h>
++#include <err.h>
+ #include <fcntl.h>
+ #include <gelf.h>
+ #include <stdio.h>
+diff --git a/tests/sectiondump.c b/tests/sectiondump.c
+index 3033fed..8e888db 100644
+--- a/tests/sectiondump.c
++++ b/tests/sectiondump.c
+@@ -18,7 +18,7 @@
+ #include <config.h>
+ 
+ #include <errno.h>
+-#include <error.h>
++#include <err.h>
+ #include <fcntl.h>
+ #include <gelf.h>
+ #include <inttypes.h>
+diff --git a/tests/varlocs.c b/tests/varlocs.c
+index c3fba89..e043ea2 100644
+--- a/tests/varlocs.c
++++ b/tests/varlocs.c
+@@ -25,7 +25,7 @@
+ #include <dwarf.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+-#include <error.h>
++#include <err.h>
+ #include <string.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
+diff --git a/tests/vdsosyms.c b/tests/vdsosyms.c
+index b876c10..afb2823 100644
+--- a/tests/vdsosyms.c
++++ b/tests/vdsosyms.c
+@@ -18,7 +18,7 @@
+ #include <config.h>
+ #include <assert.h>
+ #include <errno.h>
+-#include <error.h>
++#include <err.h>
+ #include <inttypes.h>
+ #include <stdio.h>
+ #include <string.h>
+-- 
+2.8.1
+

--- a/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/0001-elf_getarsym-Silence-Werror-maybe-uninitialized-fals.patch
+++ b/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/0001-elf_getarsym-Silence-Werror-maybe-uninitialized-fals.patch
@@ -1,0 +1,35 @@
+From 668accf322fd7185e273bfd50b84320e71d9de5a Mon Sep 17 00:00:00 2001
+From: Martin Jansa <Martin.Jansa@gmail.com>
+Date: Fri, 10 Apr 2015 00:29:18 +0200
+Subject: [PATCH] elf_getarsym: Silence -Werror=maybe-uninitialized false
+ positive
+
+Upstream-Status: Pending
+Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
+---
+ libelf/elf_getarsym.c | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/libelf/elf_getarsym.c b/libelf/elf_getarsym.c
+index d0bb28a..08954d2 100644
+--- a/libelf/elf_getarsym.c
++++ b/libelf/elf_getarsym.c
+@@ -165,8 +165,13 @@ elf_getarsym (elf, ptr)
+       int w = index64_p ? 8 : 4;
+ 
+       /* We have an archive.  The first word in there is the number of
+-	 entries in the table.  */
+-      uint64_t n;
++	 entries in the table.
++	 Set to SIZE_MAX just to silence -Werror=maybe-uninitialized
++	 elf_getarsym.c:290:9: error: 'n' may be used uninitialized in this function
++	 The read_number_entries function doesn't initialize n only when returning
++	 -1 which in turn ensures to jump over usage of this uninitialized variable.
++	 */
++      uint64_t n = SIZE_MAX;
+       size_t off = elf->start_offset + SARMAG + sizeof (struct ar_hdr);
+       if (read_number_entries (&n, elf, &off, index64_p) < 0)
+ 	{
+-- 
+2.3.5
+

--- a/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/0001-fix-a-stack-usage-warning.patch
+++ b/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/0001-fix-a-stack-usage-warning.patch
@@ -1,0 +1,28 @@
+[PATCH] fix a stack-usage warning
+
+Upstream-Status: Pending
+
+not use a variable to as a array size, otherwise the warning to error that
+stack usage might be unbounded [-Werror=stack-usage=] will happen
+
+Signed-off-by: Roy Li <rongqing.li@windriver.com>
+---
+ backends/ppc_initreg.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/backends/ppc_initreg.c b/backends/ppc_initreg.c
+index 64f5379..52dde3e 100644
+--- a/backends/ppc_initreg.c
++++ b/backends/ppc_initreg.c
+@@ -93,7 +93,7 @@ ppc_set_initial_registers_tid (pid_t tid __attribute__ ((unused)),
+ 	return false;
+     }
+   const size_t gprs = sizeof (user_regs.r.gpr) / sizeof (*user_regs.r.gpr);
+-  Dwarf_Word dwarf_regs[gprs];
++  Dwarf_Word dwarf_regs[sizeof (user_regs.r.gpr) / sizeof (*user_regs.r.gpr)];
+   for (unsigned gpr = 0; gpr < gprs; gpr++)
+     dwarf_regs[gpr] = user_regs.r.gpr[gpr];
+   if (! setfunc (0, gprs, dwarf_regs, arg))
+-- 
+1.9.1
+

--- a/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/0001-remove-the-unneed-checking.patch
+++ b/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/0001-remove-the-unneed-checking.patch
@@ -1,0 +1,38 @@
+Disable the test to convert euc-jp
+
+Remove the test "Test against HP-UX 11.11 bug:
+No converter from EUC-JP to UTF-8 is provided"
+since we don't support HP-UX and if the euc-jp is not
+installed on the host, the dependence will be built without
+iconv support and will cause guild-native building fail.
+
+Upstream-Status: Inappropriate [OE specific]
+
+Signed-off-by: Roy Li <rongqing.li@windriver.com>
+---
+ m4/iconv.m4 | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/m4/iconv.m4 b/m4/iconv.m4
+index a503646..299f1eb 100644
+--- a/m4/iconv.m4
++++ b/m4/iconv.m4
+@@ -159,6 +159,7 @@ int main ()
+       }
+   }
+ #endif
++#if 0
+   /* Test against HP-UX 11.11 bug: No converter from EUC-JP to UTF-8 is
+      provided.  */
+   if (/* Try standardized names.  */
+@@ -170,6 +171,7 @@ int main ()
+       /* Try HP-UX names.  */
+       && iconv_open ("utf8", "eucJP") == (iconv_t)(-1))
+     result |= 16;
++#endif
+   return result;
+ }]])],
+         [am_cv_func_iconv_works=yes],
+-- 
+2.0.1
+

--- a/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/Fix_one_GCC7_warning.patch
+++ b/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/Fix_one_GCC7_warning.patch
@@ -1,0 +1,44 @@
+From 93c51144c3f664d4e9709da75a1d0fa00ea0fe95 Mon Sep 17 00:00:00 2001
+From: Mark Wielaard <mark@klomp.org>
+Date: Sun, 12 Feb 2017 21:51:34 +0100
+Subject: [PATCH] libasm: Fix one GCC7 -Wformat-truncation=2 warning.
+
+Make sure that if we have really lots of labels the tempsym doesn't get
+truncated because it is too small to hold the whole name.
+
+This doesn't enable -Wformat-truncation=2 or fix other "issues" pointed
+out by enabling this warning because there are currently some issues
+with it. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=79448
+
+Signed-off-by: Mark Wielaard <mark@klomp.org>
+
+Upstream-Status: Backport (https://sourceware.org/git/?p=elfutils.git;a=commit;h=93c51144c3f664d4e9709da75a1d0fa00ea0fe95)
+Signed-off-by: Joshua Lock <joshua.g.lock@intel.com>
+
+---
+ libasm/ChangeLog    | 6 +++++-
+ libasm/asm_newsym.c | 6 ++++--
+ 2 files changed, 9 insertions(+), 3 deletions(-)
+
+Index: elfutils-0.168/libasm/asm_newsym.c
+===================================================================
+--- elfutils-0.168.orig/libasm/asm_newsym.c
++++ elfutils-0.168/libasm/asm_newsym.c
+@@ -1,5 +1,5 @@
+ /* Define new symbol for current position in given section.
+-   Copyright (C) 2002, 2005, 2016 Red Hat, Inc.
++   Copyright (C) 2002, 2005, 2016, 2017 Red Hat, Inc.
+    This file is part of elfutils.
+    Written by Ulrich Drepper <drepper@redhat.com>, 2002.
+ 
+@@ -44,7 +44,9 @@ AsmSym_t *
+ asm_newsym (AsmScn_t *asmscn, const char *name, GElf_Xword size,
+ 	    int type, int binding)
+ {
+-#define TEMPSYMLEN 10
++/* We don't really expect labels with many digits, but in theory it could
++   be 10 digits (plus ".L" and a zero terminator).  */
++#define TEMPSYMLEN 13
+   char tempsym[TEMPSYMLEN];
+   AsmSym_t *result;
+ 

--- a/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/aarch64_uio.patch
+++ b/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/aarch64_uio.patch
@@ -1,0 +1,47 @@
+Fix build on aarch64/musl
+
+Errors
+
+invalid operands to binary & (have 'long double' and 'unsigned int')
+
+error: redefinition
+ of 'struct iovec'
+ struct iovec { void *iov_base; size_t iov_len; };
+        ^
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Index: elfutils-0.163/backends/aarch64_initreg.c
+===================================================================
+--- elfutils-0.163.orig/backends/aarch64_initreg.c
++++ elfutils-0.163/backends/aarch64_initreg.c
+@@ -33,7 +33,7 @@
+ #include "system.h"
+ #include <assert.h>
+ #ifdef __aarch64__
+-# include <linux/uio.h>
++# include <sys/uio.h>
+ # include <sys/user.h>
+ # include <sys/ptrace.h>
+ /* Deal with old glibc defining user_pt_regs instead of user_regs_struct.  */
+@@ -82,7 +82,7 @@ aarch64_set_initial_registers_tid (pid_t
+ 
+   Dwarf_Word dwarf_fregs[32];
+   for (int r = 0; r < 32; r++)
+-    dwarf_fregs[r] = fregs.vregs[r] & 0xFFFFFFFF;
++    dwarf_fregs[r] = (unsigned int)fregs.vregs[r] & 0xFFFFFFFF;
+ 
+   if (! setfunc (64, 32, dwarf_fregs, arg))
+     return false;
+Index: elfutils-0.163/backends/arm_initreg.c
+===================================================================
+--- elfutils-0.163.orig/backends/arm_initreg.c
++++ elfutils-0.163/backends/arm_initreg.c
+@@ -37,7 +37,7 @@
+ #endif
+ 
+ #ifdef __aarch64__
+-# include <linux/uio.h>
++# include <sys/uio.h>
+ # include <sys/user.h>
+ # include <sys/ptrace.h>
+ /* Deal with old glibc defining user_pt_regs instead of user_regs_struct.  */

--- a/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/debian/0001-Ignore-differences-between-mips-machine-identifiers.patch
+++ b/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/debian/0001-Ignore-differences-between-mips-machine-identifiers.patch
@@ -1,0 +1,35 @@
+From 77cb4a53c270d5854d3af24f19547bc3de825233 Mon Sep 17 00:00:00 2001
+From: James Cowgill <james410@cowgill.org.uk>
+Date: Mon, 5 Jan 2015 15:16:58 +0000
+Subject: [PATCH 1/3] Ignore differences between mips machine identifiers
+
+Little endian binaries actually use EM_MIPS so you can't tell the endianness
+from the elf machine id. Also, the EM_MIPS_RS3_LE machine is dead anyway (the
+kernel will not load binaries containing it).
+
+Signed-off-by: James Cowgill <james410@cowgill.org.uk>
+
+Upstream-Status: Backport [from debian]
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+
+---
+ backends/mips_init.c | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
+Index: b/backends/mips_init.c
+===================================================================
+--- a/backends/mips_init.c
++++ b/backends/mips_init.c
+@@ -45,11 +45,7 @@ mips_init (Elf *elf __attribute__ ((unus
+     return NULL;
+ 
+   /* We handle it.  */
+-  if (machine == EM_MIPS)
+-    eh->name = "MIPS R3000 big-endian";
+-  else if (machine == EM_MIPS_RS3_LE)
+-    eh->name = "MIPS R3000 little-endian";
+-
++  eh->name = "MIPS";
+   mips_init_reloc (eh);
+   HOOK (eh, reloc_simple_type);
+   HOOK (eh, return_value_location);

--- a/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/debian/0002-Add-support-for-mips64-abis-in-mips_retval.c.patch
+++ b/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/debian/0002-Add-support-for-mips64-abis-in-mips_retval.c.patch
@@ -1,0 +1,171 @@
+From fdaab18a65ed2529656baa64cb6169f34d7e507b Mon Sep 17 00:00:00 2001
+From: James Cowgill <james410@cowgill.org.uk>
+Date: Mon, 5 Jan 2015 15:17:01 +0000
+Subject: [PATCH 2/3] Add support for mips64 abis in mips_retval.c
+
+Signed-off-by: James Cowgill <james410@cowgill.org.uk>
+
+Upstream-Status: Backport [from debian]
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+---
+ backends/mips_retval.c | 104 ++++++++++++++++++++++++++++++++++++++++++++-----
+ 1 file changed, 94 insertions(+), 10 deletions(-)
+
+diff --git a/backends/mips_retval.c b/backends/mips_retval.c
+index 33f12a7..d5c6ef0 100644
+--- a/backends/mips_retval.c
++++ b/backends/mips_retval.c
+@@ -91,6 +91,8 @@ enum mips_abi find_mips_abi(Elf *elf)
+     default:
+       if ((elf_flags & EF_MIPS_ABI2))
+ 	return MIPS_ABI_N32;
++      else if ((ehdr->e_ident[EI_CLASS] == ELFCLASS64))
++	return MIPS_ABI_N64;
+     }
+ 
+   /* GCC creates a pseudo-section whose name describes the ABI.  */
+@@ -195,6 +197,57 @@ static const Dwarf_Op loc_aggregate[] =
+   };
+ #define nloc_aggregate 1
+ 
++/* Test if a struct member is a float */
++static int is_float_child(Dwarf_Die *childdie)
++{
++  /* Test if this is actually a struct member */
++  if (dwarf_tag(childdie) != DW_TAG_member)
++    return 0;
++
++  /* Get type of member */
++  Dwarf_Attribute attr_mem;
++  Dwarf_Die child_type_mem;
++  Dwarf_Die *child_typedie =
++    dwarf_formref_die(dwarf_attr_integrate(childdie,
++                                           DW_AT_type,
++                                           &attr_mem), &child_type_mem);
++
++  if (dwarf_tag(child_typedie) != DW_TAG_base_type)
++    return 0;
++
++  /* Get base subtype */
++  Dwarf_Word encoding;
++  if (dwarf_formudata (dwarf_attr_integrate (child_typedie,
++                                             DW_AT_encoding,
++                                             &attr_mem), &encoding) != 0)
++    return 0;
++
++  return encoding == DW_ATE_float;
++}
++
++/* Returns the number of fpregs which can be returned in the given struct */
++static int get_struct_fpregs(Dwarf_Die *structtypedie)
++{
++  Dwarf_Die child_mem;
++  int fpregs = 0;
++
++  /* Get first structure member */
++  if (dwarf_child(structtypedie, &child_mem) != 0)
++    return 0;
++
++  do
++    {
++      /* Ensure this register is a float */
++      if (!is_float_child(&child_mem))
++        return 0;
++
++      fpregs++;
++    }
++  while (dwarf_siblingof (&child_mem, &child_mem) == 0);
++
++  return fpregs;
++}
++
+ int
+ mips_return_value_location (Dwarf_Die *functypedie, const Dwarf_Op **locp)
+ {
+@@ -240,6 +293,7 @@ mips_return_value_location (Dwarf_Die *functypedie, const Dwarf_Op **locp)
+       tag = dwarf_tag (typedie);
+     }
+ 
++  Dwarf_Word size;
+   switch (tag)
+     {
+     case -1:
+@@ -258,8 +312,6 @@ mips_return_value_location (Dwarf_Die *functypedie, const Dwarf_Op **locp)
+     case DW_TAG_enumeration_type:
+     case DW_TAG_pointer_type:
+     case DW_TAG_ptr_to_member_type:
+-      {
+-        Dwarf_Word size;
+ 	if (dwarf_formudata (dwarf_attr_integrate (typedie, DW_AT_byte_size,
+ 					 &attr_mem), &size) != 0)
+ 	  {
+@@ -289,7 +341,7 @@ mips_return_value_location (Dwarf_Die *functypedie, const Dwarf_Op **locp)
+ 		if (size <= 4*regsize && abi == MIPS_ABI_O32)
+                   return nloc_fpregquad;
+ 
+-		goto aggregate;
++		goto large;
+ 	      }
+ 	  }
+ 	*locp = ABI_LOC(loc_intreg, regsize);
+@@ -298,18 +350,50 @@ mips_return_value_location (Dwarf_Die *functypedie, const Dwarf_Op **locp)
+ 	if (size <= 2*regsize)
+ 	  return nloc_intregpair;
+ 
+-	/* Else fall through. Shouldn't happen though (at least with gcc) */
+-      }
++	/* Else pass in memory. Shouldn't happen though (at least with gcc) */
++	goto large;
+ 
+     case DW_TAG_structure_type:
+     case DW_TAG_class_type:
+     case DW_TAG_union_type:
+-    case DW_TAG_array_type:
+-    aggregate:
+-      /* XXX TODO: Can't handle structure return with other ABI's yet :-/ */
+-      if ((abi != MIPS_ABI_O32) && (abi != MIPS_ABI_O64))
+-        return -2;
++      /* Handle special cases for structures <= 128 bytes in newer ABIs */
++      if (abi == MIPS_ABI_EABI32 || abi == MIPS_ABI_EABI64 ||
++          abi == MIPS_ABI_N32 || abi == MIPS_ABI_N64)
++        {
++          if (dwarf_aggregate_size (typedie, &size) == 0 && size <= 16)
++            {
++              /*
++               * Special case in N64 / N32 -
++               * structures containing only floats are returned in fp regs.
++               * Everything else is returned in integer regs.
++               */
++              if (tag != DW_TAG_union_type &&
++                  (abi == MIPS_ABI_N32 || abi == MIPS_ABI_N64))
++                {
++                  int num_fpregs = get_struct_fpregs(typedie);
++                  if (num_fpregs == 1 || num_fpregs == 2)
++                    {
++                      *locp = loc_fpreg;
++                      if (num_fpregs == 1)
++                        return nloc_fpreg;
++                      else
++                        return nloc_fpregpair;
++                    }
++                }
++
++              *locp = loc_intreg;
++              if (size <= 8)
++                return nloc_intreg;
++              else
++                return nloc_intregpair;
++            }
++        }
++
++      /* Fallthrough to handle large types */
+ 
++    case DW_TAG_array_type:
++    large:
++      /* Return large structures in memory */
+       *locp = loc_aggregate;
+       return nloc_aggregate;
+     }
+-- 
+2.1.4
+

--- a/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/debian/0003-Add-mips-n64-relocation-format-hack.patch
+++ b/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/debian/0003-Add-mips-n64-relocation-format-hack.patch
@@ -1,0 +1,229 @@
+From 59d4b8c48e5040af7e02b34eb26ea602ec82a38e Mon Sep 17 00:00:00 2001
+From: James Cowgill <james410@cowgill.org.uk>
+Date: Mon, 5 Jan 2015 15:17:02 +0000
+Subject: [PATCH 3/3] Add mips n64 relocation format hack
+
+MIPSEL N64 ELF files use a slightly different format for storing relocation
+entries which is incompatible with the normal R_SYM / R_INFO macros.
+To workaround this, we rearrange the bytes in the relocation's r_info field
+when reading and writing the relocations.
+
+This patch also ensures that strip.c sets the correct value of e_machine
+before manipulating relocations so that these changes take effect.
+
+Signed-off-by: James Cowgill <james410@cowgill.org.uk>
+
+Upstream-Status: Backport [from debian]
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+---
+ libelf/gelf_getrel.c      | 25 +++++++++++++++++++++++--
+ libelf/gelf_getrela.c     | 25 +++++++++++++++++++++++--
+ libelf/gelf_update_rel.c  | 20 +++++++++++++++++++-
+ libelf/gelf_update_rela.c | 20 +++++++++++++++++++-
+ src/strip.c               | 17 +++++++++++++++++
+ 5 files changed, 101 insertions(+), 6 deletions(-)
+
+Index: b/libelf/gelf_getrel.c
+===================================================================
+--- a/libelf/gelf_getrel.c
++++ b/libelf/gelf_getrel.c
+@@ -36,6 +36,7 @@
+ 
+ #include "libelfP.h"
+ 
++#define EF_MIPS_ABI	0x0000F000
+ 
+ GElf_Rel *
+ gelf_getrel (Elf_Data *data, int ndx, GElf_Rel *dst)
+@@ -89,8 +90,28 @@ gelf_getrel (Elf_Data *data, int ndx, GE
+ 	  result = NULL;
+ 	}
+       else
+-	result = memcpy (dst, &((Elf64_Rel *) data_scn->d.d_buf)[ndx],
+-			 sizeof (Elf64_Rel));
++        {
++          GElf_Ehdr hdr;
++          result = memcpy (dst, &((Elf64_Rel *) data_scn->d.d_buf)[ndx],
++                           sizeof (Elf64_Rel));
++
++          if (gelf_getehdr(scn->elf, &hdr) != NULL &&
++              hdr.e_ident[EI_DATA] == ELFDATA2LSB &&
++              hdr.e_machine == EM_MIPS &&
++              (hdr.e_flags & EF_MIPS_ABI) == 0)
++            {
++              /*
++               * The relocation format is mangled on MIPSEL N64
++               *  We'll adjust it so at least R_SYM will work on it
++               */
++              GElf_Xword r_info = dst->r_info;
++              dst->r_info = (r_info << 32) |
++                            ((r_info >> 8) & 0xFF000000) |
++                            ((r_info >> 24) & 0x00FF0000) |
++                            ((r_info >> 40) & 0x0000FF00) |
++                            ((r_info >> 56) & 0x000000FF);
++            }
++        }
+     }
+ 
+   rwlock_unlock (scn->elf->lock);
+Index: b/libelf/gelf_getrela.c
+===================================================================
+--- a/libelf/gelf_getrela.c
++++ b/libelf/gelf_getrela.c
+@@ -36,6 +36,7 @@
+ 
+ #include "libelfP.h"
+ 
++#define EF_MIPS_ABI	0x0000F000
+ 
+ GElf_Rela *
+ gelf_getrela (Elf_Data *data, int ndx, GElf_Rela *dst)
+@@ -90,8 +91,28 @@ gelf_getrela (Elf_Data *data, int ndx, G
+ 	  result = NULL;
+ 	}
+       else
+-	result = memcpy (dst, &((Elf64_Rela *) data_scn->d.d_buf)[ndx],
+-			 sizeof (Elf64_Rela));
++        {
++          GElf_Ehdr hdr;
++          result = memcpy (dst, &((Elf64_Rela *) data_scn->d.d_buf)[ndx],
++                           sizeof (Elf64_Rela));
++
++          if (gelf_getehdr(scn->elf, &hdr) != NULL &&
++              hdr.e_ident[EI_DATA] == ELFDATA2LSB &&
++              hdr.e_machine == EM_MIPS &&
++              (hdr.e_flags & EF_MIPS_ABI) == 0)
++            {
++              /*
++               * The relocation format is mangled on MIPSEL N64
++               *  We'll adjust it so at least R_SYM will work on it
++               */
++              GElf_Xword r_info = dst->r_info;
++              dst->r_info = (r_info << 32) |
++                            ((r_info >> 8) & 0xFF000000) |
++                            ((r_info >> 24) & 0x00FF0000) |
++                            ((r_info >> 40) & 0x0000FF00) |
++                            ((r_info >> 56) & 0x000000FF);
++            }
++        }
+     }
+ 
+   rwlock_unlock (scn->elf->lock);
+Index: b/libelf/gelf_update_rel.c
+===================================================================
+--- a/libelf/gelf_update_rel.c
++++ b/libelf/gelf_update_rel.c
+@@ -36,6 +36,7 @@
+ 
+ #include "libelfP.h"
+ 
++#define EF_MIPS_ABI	0x0000F000
+ 
+ int
+ gelf_update_rel (Elf_Data *dst, int ndx, GElf_Rel *src)
+@@ -86,6 +87,9 @@ gelf_update_rel (Elf_Data *dst, int ndx,
+     }
+   else
+     {
++      GElf_Ehdr hdr;
++      GElf_Rel value = *src;
++
+       /* Check whether we have to resize the data buffer.  */
+       if (INVALID_NDX (ndx, Elf64_Rel, &data_scn->d))
+ 	{
+@@ -93,7 +97,21 @@ gelf_update_rel (Elf_Data *dst, int ndx,
+ 	  goto out;
+ 	}
+ 
+-      ((Elf64_Rel *) data_scn->d.d_buf)[ndx] = *src;
++      if (gelf_getehdr(scn->elf, &hdr) != NULL &&
++          hdr.e_ident[EI_DATA] == ELFDATA2LSB &&
++          hdr.e_machine == EM_MIPS &&
++          (hdr.e_flags & EF_MIPS_ABI) == 0)
++        {
++          /* Undo the MIPSEL N64 hack from gelf_getrel */
++          GElf_Xword r_info = value.r_info;
++          value.r_info = (r_info >> 32) |
++                         ((r_info << 8) &  0x000000FF00000000) |
++                         ((r_info << 24) & 0x0000FF0000000000) |
++                         ((r_info << 40) & 0x00FF000000000000) |
++                         ((r_info << 56) & 0xFF00000000000000);
++        }
++
++      ((Elf64_Rel *) data_scn->d.d_buf)[ndx] = value;
+     }
+ 
+   result = 1;
+Index: b/libelf/gelf_update_rela.c
+===================================================================
+--- a/libelf/gelf_update_rela.c
++++ b/libelf/gelf_update_rela.c
+@@ -36,6 +36,7 @@
+ 
+ #include "libelfP.h"
+ 
++#define EF_MIPS_ABI	0x0000F000
+ 
+ int
+ gelf_update_rela (Elf_Data *dst, int ndx, GElf_Rela *src)
+@@ -89,6 +90,9 @@ gelf_update_rela (Elf_Data *dst, int ndx
+     }
+   else
+     {
++      GElf_Ehdr hdr;
++      GElf_Rela value = *src;
++
+       /* Check whether we have to resize the data buffer.  */
+       if (INVALID_NDX (ndx, Elf64_Rela, &data_scn->d))
+ 	{
+@@ -96,7 +100,21 @@ gelf_update_rela (Elf_Data *dst, int ndx
+ 	  goto out;
+ 	}
+ 
+-      ((Elf64_Rela *) data_scn->d.d_buf)[ndx] = *src;
++      if (gelf_getehdr(scn->elf, &hdr) != NULL &&
++          hdr.e_ident[EI_DATA] == ELFDATA2LSB &&
++          hdr.e_machine == EM_MIPS &&
++          (hdr.e_flags & EF_MIPS_ABI) == 0)
++        {
++          /* Undo the MIPSEL N64 hack from gelf_getrel */
++          GElf_Xword r_info = value.r_info;
++          value.r_info = (r_info >> 32) |
++                         ((r_info << 8) &  0x000000FF00000000) |
++                         ((r_info << 24) & 0x0000FF0000000000) |
++                         ((r_info << 40) & 0x00FF000000000000) |
++                         ((r_info << 56) & 0xFF00000000000000);
++        }
++
++      ((Elf64_Rela *) data_scn->d.d_buf)[ndx] = value;
+     }
+ 
+   result = 1;
+Index: b/src/strip.c
+===================================================================
+--- a/src/strip.c
++++ b/src/strip.c
+@@ -532,6 +532,23 @@ handle_elf (int fd, Elf *elf, const char
+       goto fail;
+     }
+ 
++  /* Copy identity part of the ELF header now */
++  newehdr = gelf_getehdr (newelf, &newehdr_mem);
++  if (newehdr == NULL)
++    INTERNAL_ERROR (fname);
++
++  memcpy (newehdr->e_ident, ehdr->e_ident, EI_NIDENT);
++  newehdr->e_type = ehdr->e_type;
++  newehdr->e_machine = ehdr->e_machine;
++  newehdr->e_version = ehdr->e_version;
++
++  if (gelf_update_ehdr (newelf, newehdr) == 0)
++    {
++      error (0, 0, gettext ("%s: error while creating ELF header: %s"),
++	     fname, elf_errmsg (-1));
++      return 1;
++    }
++
+   /* Copy over the old program header if needed.  */
+   if (ehdr->e_type != ET_REL)
+     for (cnt = 0; cnt < phnum; ++cnt)

--- a/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/debian/arm_backend.diff
+++ b/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/debian/arm_backend.diff
@@ -1,0 +1,603 @@
+Upstream-Status: Backport [from debian]
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+
+Index: b/backends/arm_init.c
+===================================================================
+--- a/backends/arm_init.c
++++ b/backends/arm_init.c
+@@ -35,20 +35,31 @@
+ #define RELOC_PREFIX	R_ARM_
+ #include "libebl_CPU.h"
+ 
++#include "libebl_arm.h"
++
+ /* This defines the common reloc hooks based on arm_reloc.def.  */
+ #include "common-reloc.c"
+ 
+ 
+ const char *
+-arm_init (Elf *elf __attribute__ ((unused)),
++arm_init (Elf *elf,
+ 	  GElf_Half machine __attribute__ ((unused)),
+ 	  Ebl *eh,
+ 	  size_t ehlen)
+ {
++  int soft_float = 0;
++
+   /* Check whether the Elf_BH object has a sufficent size.  */
+   if (ehlen < sizeof (Ebl))
+     return NULL;
+ 
++  if (elf) {
++    GElf_Ehdr ehdr_mem;
++    GElf_Ehdr *ehdr = gelf_getehdr (elf, &ehdr_mem);
++    if (ehdr && (ehdr->e_flags & EF_ARM_SOFT_FLOAT))
++      soft_float = 1;
++  }
++
+   /* We handle it.  */
+   eh->name = "ARM";
+   arm_init_reloc (eh);
+@@ -60,7 +71,10 @@ arm_init (Elf *elf __attribute__ ((unuse
+   HOOK (eh, core_note);
+   HOOK (eh, auxv_info);
+   HOOK (eh, check_object_attribute);
+-  HOOK (eh, return_value_location);
++  if (soft_float)
++    eh->return_value_location = arm_return_value_location_soft;
++  else
++    eh->return_value_location = arm_return_value_location_hard;
+   HOOK (eh, abi_cfi);
+   HOOK (eh, check_reloc_target_type);
+   HOOK (eh, symbol_type_name);
+Index: b/backends/arm_regs.c
+===================================================================
+--- a/backends/arm_regs.c
++++ b/backends/arm_regs.c
+@@ -31,6 +31,7 @@
+ #endif
+ 
+ #include <string.h>
++#include <stdio.h>
+ #include <dwarf.h>
+ 
+ #define BACKEND arm_
+@@ -76,6 +77,9 @@ arm_register_info (Ebl *ebl __attribute_
+       break;
+ 
+     case 16 + 0 ... 16 + 7:
++      /* AADWARF says that there are no registers in that range,
++       * but gcc maps FPA registers here
++       */
+       regno += 96 - 16;
+       /* Fall through.  */
+     case 96 + 0 ... 96 + 7:
+@@ -87,11 +91,139 @@ arm_register_info (Ebl *ebl __attribute_
+       namelen = 2;
+       break;
+ 
++    case 64 + 0 ... 64 + 9:
++      *setname = "VFP";
++      *bits = 32;
++      *type = DW_ATE_float;
++      name[0] = 's';
++      name[1] = regno - 64 + '0';
++      namelen = 2;
++      break;
++
++    case 64 + 10 ... 64 + 31:
++      *setname = "VFP";
++      *bits = 32;
++      *type = DW_ATE_float;
++      name[0] = 's';
++      name[1] = (regno - 64) / 10 + '0';
++      name[2] = (regno - 64) % 10 + '0';
++      namelen = 3;
++      break;
++
++    case 104 + 0 ... 104 + 7:
++      /* XXX TODO:
++       * This can be either intel wireless MMX general purpose/control
++       * registers or xscale accumulator, which have different usage.
++       * We only have the intel wireless MMX here now.
++       * The name needs to be changed for the xscale accumulator too. */
++      *setname = "MMX";
++      *type = DW_ATE_unsigned;
++      *bits = 32;
++      memcpy(name, "wcgr", 4);
++      name[4] = regno - 104 + '0';
++      namelen = 5;
++      break;
++
++    case 112 + 0 ... 112 + 9:
++      *setname = "MMX";
++      *type = DW_ATE_unsigned;
++      *bits = 64;
++      name[0] = 'w';
++      name[1] = 'r';
++      name[2] = regno - 112 + '0';
++      namelen = 3;
++      break;
++
++    case 112 + 10 ... 112 + 15:
++      *setname = "MMX";
++      *type = DW_ATE_unsigned;
++      *bits = 64;
++      name[0] = 'w';
++      name[1] = 'r';
++      name[2] = '1';
++      name[3] = regno - 112 - 10 + '0';
++      namelen = 4;
++      break;
++
+     case 128:
++      *setname = "state";
+       *type = DW_ATE_unsigned;
+       return stpcpy (name, "spsr") + 1 - name;
+ 
++    case 129:
++      *setname = "state";
++      *type = DW_ATE_unsigned;
++      return stpcpy(name, "spsr_fiq") + 1 - name;
++
++    case 130:
++      *setname = "state";
++      *type = DW_ATE_unsigned;
++      return stpcpy(name, "spsr_irq") + 1 - name;
++
++    case 131:
++      *setname = "state";
++      *type = DW_ATE_unsigned;
++      return stpcpy(name, "spsr_abt") + 1 - name;
++
++    case 132:
++      *setname = "state";
++      *type = DW_ATE_unsigned;
++      return stpcpy(name, "spsr_und") + 1 - name;
++
++    case 133:
++      *setname = "state";
++      *type = DW_ATE_unsigned;
++      return stpcpy(name, "spsr_svc") + 1 - name;
++
++    case 144 ... 150:
++      *setname = "integer";
++      *type = DW_ATE_signed;
++      *bits = 32;
++      return sprintf(name, "r%d_usr", regno - 144 + 8) + 1;
++
++    case 151 ... 157:
++      *setname = "integer";
++      *type = DW_ATE_signed;
++      *bits = 32;
++      return sprintf(name, "r%d_fiq", regno - 151 + 8) + 1;
++
++    case 158 ... 159:
++      *setname = "integer";
++      *type = DW_ATE_signed;
++      *bits = 32;
++      return sprintf(name, "r%d_irq", regno - 158 + 13) + 1;
++
++    case 160 ... 161:
++      *setname = "integer";
++      *type = DW_ATE_signed;
++      *bits = 32;
++      return sprintf(name, "r%d_abt", regno - 160 + 13) + 1;
++
++    case 162 ... 163:
++      *setname = "integer";
++      *type = DW_ATE_signed;
++      *bits = 32;
++      return sprintf(name, "r%d_und", regno - 162 + 13) + 1;
++
++    case 164 ... 165:
++      *setname = "integer";
++      *type = DW_ATE_signed;
++      *bits = 32;
++      return sprintf(name, "r%d_svc", regno - 164 + 13) + 1;
++
++    case 192 ... 199:
++     *setname = "MMX";
++      *bits = 32;
++      *type = DW_ATE_unsigned;
++      name[0] = 'w';
++      name[1] = 'c';
++      name[2] = regno - 192 + '0';
++      namelen = 3;
++      break;
++
+     case 256 + 0 ... 256 + 9:
++      /* XXX TODO: Neon also uses those registers and can contain
++       * both float and integers */
+       *setname = "VFP";
+       *type = DW_ATE_float;
+       *bits = 64;
+Index: b/backends/arm_retval.c
+===================================================================
+--- a/backends/arm_retval.c
++++ b/backends/arm_retval.c
+@@ -48,6 +48,13 @@ static const Dwarf_Op loc_intreg[] =
+ #define nloc_intreg	1
+ #define nloc_intregs(n)	(2 * (n))
+ 
++/* f1  */ /* XXX TODO: f0 can also have number 96 if program was compiled with -mabi=aapcs */
++static const Dwarf_Op loc_fpreg[] =
++  {
++    { .atom = DW_OP_reg16 },
++  };
++#define nloc_fpreg  1
++
+ /* The return value is a structure and is actually stored in stack space
+    passed in a hidden argument by the caller.  But, the compiler
+    helpfully returns the address of that space in r0.  */
+@@ -58,8 +65,9 @@ static const Dwarf_Op loc_aggregate[] =
+ #define nloc_aggregate 1
+ 
+ 
+-int
+-arm_return_value_location (Dwarf_Die *functypedie, const Dwarf_Op **locp)
++static int
++arm_return_value_location_ (Dwarf_Die *functypedie, const Dwarf_Op **locp,
++		            int soft_float)
+ {
+   /* Start with the function's type, and get the DW_AT_type attribute,
+      which is the type of the return value.  */
+@@ -98,6 +106,21 @@ arm_return_value_location (Dwarf_Die *fu
+ 	    else
+ 	      return -1;
+ 	  }
++	if (tag == DW_TAG_base_type)
++	  {
++	    Dwarf_Word encoding;
++	    if (dwarf_formudata (dwarf_attr_integrate (typedie, DW_AT_encoding,
++				 &attr_mem), &encoding) != 0)
++	      return -1;
++
++	    if ((encoding == DW_ATE_float) && !soft_float)
++	      {
++		*locp = loc_fpreg;
++		if (size <= 8)
++		  return nloc_fpreg;
++		goto aggregate;
++	      }
++	  }
+ 	if (size <= 16)
+ 	  {
+ 	  intreg:
+@@ -106,6 +129,7 @@ arm_return_value_location (Dwarf_Die *fu
+ 	  }
+ 
+       aggregate:
++	/* XXX TODO sometimes aggregates are returned in r0 (-mabi=aapcs) */
+ 	*locp = loc_aggregate;
+ 	return nloc_aggregate;
+       }
+@@ -125,3 +149,18 @@ arm_return_value_location (Dwarf_Die *fu
+      DWARF and might be valid.  */
+   return -2;
+ }
++
++/* return location for -mabi=apcs-gnu -msoft-float */
++int
++arm_return_value_location_soft (Dwarf_Die *functypedie, const Dwarf_Op **locp)
++{
++   return arm_return_value_location_ (functypedie, locp, 1);
++}
++
++/* return location for -mabi=apcs-gnu -mhard-float (current default) */
++int
++arm_return_value_location_hard (Dwarf_Die *functypedie, const Dwarf_Op **locp)
++{
++   return arm_return_value_location_ (functypedie, locp, 0);
++}
++
+Index: b/libelf/elf.h
+===================================================================
+--- a/libelf/elf.h
++++ b/libelf/elf.h
+@@ -2593,6 +2593,9 @@ enum
+ #define EF_ARM_EABI_VER4	0x04000000
+ #define EF_ARM_EABI_VER5	0x05000000
+ 
++/* EI_OSABI values */
++#define ELFOSABI_ARM_AEABI    64      /* Contains symbol versioning. */
++
+ /* Additional symbol types for Thumb.  */
+ #define STT_ARM_TFUNC		STT_LOPROC /* A Thumb function.  */
+ #define STT_ARM_16BIT		STT_HIPROC /* A Thumb label.  */
+@@ -2610,12 +2613,19 @@ enum
+ 
+ /* Processor specific values for the Phdr p_type field.  */
+ #define PT_ARM_EXIDX		(PT_LOPROC + 1)	/* ARM unwind segment.  */
++#define PT_ARM_UNWIND		PT_ARM_EXIDX
+ 
+ /* Processor specific values for the Shdr sh_type field.  */
+ #define SHT_ARM_EXIDX		(SHT_LOPROC + 1) /* ARM unwind section.  */
+ #define SHT_ARM_PREEMPTMAP	(SHT_LOPROC + 2) /* Preemption details.  */
+ #define SHT_ARM_ATTRIBUTES	(SHT_LOPROC + 3) /* ARM attributes section.  */
+ 
++/* Processor specific values for the Dyn d_tag field.  */
++#define DT_ARM_RESERVED1	(DT_LOPROC + 0)
++#define DT_ARM_SYMTABSZ		(DT_LOPROC + 1)
++#define DT_ARM_PREEMTMAB	(DT_LOPROC + 2)
++#define DT_ARM_RESERVED2	(DT_LOPROC + 3)
++#define DT_ARM_NUM		4
+ 
+ /* AArch64 relocs.  */
+ 
+@@ -2908,6 +2918,7 @@ enum
+ 					   TLS block (LDR, STR).  */
+ #define R_ARM_TLS_IE12GP	111	/* 12 bit GOT entry relative
+ 					   to GOT origin (LDR).  */
++/* 112 - 127 private range */
+ #define R_ARM_ME_TOO		128	/* Obsolete.  */
+ #define R_ARM_THM_TLS_DESCSEQ	129
+ #define R_ARM_THM_TLS_DESCSEQ16	129
+Index: b/backends/libebl_arm.h
+===================================================================
+--- /dev/null
++++ b/backends/libebl_arm.h
+@@ -0,0 +1,9 @@
++#ifndef _LIBEBL_ARM_H
++#define _LIBEBL_ARM_H 1
++
++#include <libdw.h>
++
++extern int arm_return_value_location_soft(Dwarf_Die *, const Dwarf_Op **locp);
++extern int arm_return_value_location_hard(Dwarf_Die *, const Dwarf_Op **locp);
++
++#endif
+Index: b/tests/run-allregs.sh
+===================================================================
+--- a/tests/run-allregs.sh
++++ b/tests/run-allregs.sh
+@@ -2672,7 +2672,28 @@ integer registers:
+ 	 13: sp (sp), address 32 bits
+ 	 14: lr (lr), address 32 bits
+ 	 15: pc (pc), address 32 bits
+-	128: spsr (spsr), unsigned 32 bits
++	144: r8_usr (r8_usr), signed 32 bits
++	145: r9_usr (r9_usr), signed 32 bits
++	146: r10_usr (r10_usr), signed 32 bits
++	147: r11_usr (r11_usr), signed 32 bits
++	148: r12_usr (r12_usr), signed 32 bits
++	149: r13_usr (r13_usr), signed 32 bits
++	150: r14_usr (r14_usr), signed 32 bits
++	151: r8_fiq (r8_fiq), signed 32 bits
++	152: r9_fiq (r9_fiq), signed 32 bits
++	153: r10_fiq (r10_fiq), signed 32 bits
++	154: r11_fiq (r11_fiq), signed 32 bits
++	155: r12_fiq (r12_fiq), signed 32 bits
++	156: r13_fiq (r13_fiq), signed 32 bits
++	157: r14_fiq (r14_fiq), signed 32 bits
++	158: r13_irq (r13_irq), signed 32 bits
++	159: r14_irq (r14_irq), signed 32 bits
++	160: r13_abt (r13_abt), signed 32 bits
++	161: r14_abt (r14_abt), signed 32 bits
++	162: r13_und (r13_und), signed 32 bits
++	163: r14_und (r14_und), signed 32 bits
++	164: r13_svc (r13_svc), signed 32 bits
++	165: r14_svc (r14_svc), signed 32 bits
+ FPA registers:
+ 	 16: f0 (f0), float 96 bits
+ 	 17: f1 (f1), float 96 bits
+@@ -2690,7 +2711,72 @@ FPA registers:
+ 	101: f5 (f5), float 96 bits
+ 	102: f6 (f6), float 96 bits
+ 	103: f7 (f7), float 96 bits
++MMX registers:
++	104: wcgr0 (wcgr0), unsigned 32 bits
++	105: wcgr1 (wcgr1), unsigned 32 bits
++	106: wcgr2 (wcgr2), unsigned 32 bits
++	107: wcgr3 (wcgr3), unsigned 32 bits
++	108: wcgr4 (wcgr4), unsigned 32 bits
++	109: wcgr5 (wcgr5), unsigned 32 bits
++	110: wcgr6 (wcgr6), unsigned 32 bits
++	111: wcgr7 (wcgr7), unsigned 32 bits
++	112: wr0 (wr0), unsigned 64 bits
++	113: wr1 (wr1), unsigned 64 bits
++	114: wr2 (wr2), unsigned 64 bits
++	115: wr3 (wr3), unsigned 64 bits
++	116: wr4 (wr4), unsigned 64 bits
++	117: wr5 (wr5), unsigned 64 bits
++	118: wr6 (wr6), unsigned 64 bits
++	119: wr7 (wr7), unsigned 64 bits
++	120: wr8 (wr8), unsigned 64 bits
++	121: wr9 (wr9), unsigned 64 bits
++	122: wr10 (wr10), unsigned 64 bits
++	123: wr11 (wr11), unsigned 64 bits
++	124: wr12 (wr12), unsigned 64 bits
++	125: wr13 (wr13), unsigned 64 bits
++	126: wr14 (wr14), unsigned 64 bits
++	127: wr15 (wr15), unsigned 64 bits
++	192: wc0 (wc0), unsigned 32 bits
++	193: wc1 (wc1), unsigned 32 bits
++	194: wc2 (wc2), unsigned 32 bits
++	195: wc3 (wc3), unsigned 32 bits
++	196: wc4 (wc4), unsigned 32 bits
++	197: wc5 (wc5), unsigned 32 bits
++	198: wc6 (wc6), unsigned 32 bits
++	199: wc7 (wc7), unsigned 32 bits
+ VFP registers:
++	 64: s0 (s0), float 32 bits
++	 65: s1 (s1), float 32 bits
++	 66: s2 (s2), float 32 bits
++	 67: s3 (s3), float 32 bits
++	 68: s4 (s4), float 32 bits
++	 69: s5 (s5), float 32 bits
++	 70: s6 (s6), float 32 bits
++	 71: s7 (s7), float 32 bits
++	 72: s8 (s8), float 32 bits
++	 73: s9 (s9), float 32 bits
++	 74: s10 (s10), float 32 bits
++	 75: s11 (s11), float 32 bits
++	 76: s12 (s12), float 32 bits
++	 77: s13 (s13), float 32 bits
++	 78: s14 (s14), float 32 bits
++	 79: s15 (s15), float 32 bits
++	 80: s16 (s16), float 32 bits
++	 81: s17 (s17), float 32 bits
++	 82: s18 (s18), float 32 bits
++	 83: s19 (s19), float 32 bits
++	 84: s20 (s20), float 32 bits
++	 85: s21 (s21), float 32 bits
++	 86: s22 (s22), float 32 bits
++	 87: s23 (s23), float 32 bits
++	 88: s24 (s24), float 32 bits
++	 89: s25 (s25), float 32 bits
++	 90: s26 (s26), float 32 bits
++	 91: s27 (s27), float 32 bits
++	 92: s28 (s28), float 32 bits
++	 93: s29 (s29), float 32 bits
++	 94: s30 (s30), float 32 bits
++	 95: s31 (s31), float 32 bits
+ 	256: d0 (d0), float 64 bits
+ 	257: d1 (d1), float 64 bits
+ 	258: d2 (d2), float 64 bits
+@@ -2723,6 +2809,13 @@ VFP registers:
+ 	285: d29 (d29), float 64 bits
+ 	286: d30 (d30), float 64 bits
+ 	287: d31 (d31), float 64 bits
++state registers:
++	128: spsr (spsr), unsigned 32 bits
++	129: spsr_fiq (spsr_fiq), unsigned 32 bits
++	130: spsr_irq (spsr_irq), unsigned 32 bits
++	131: spsr_abt (spsr_abt), unsigned 32 bits
++	132: spsr_und (spsr_und), unsigned 32 bits
++	133: spsr_svc (spsr_svc), unsigned 32 bits
+ EOF
+ 
+ # See run-readelf-mixed-corenote.sh for instructions to regenerate
+Index: b/tests/run-readelf-mixed-corenote.sh
+===================================================================
+--- a/tests/run-readelf-mixed-corenote.sh
++++ b/tests/run-readelf-mixed-corenote.sh
+@@ -31,12 +31,11 @@ Note segment of 892 bytes at offset 0x27
+     pid: 11087, ppid: 11063, pgrp: 11087, sid: 11063
+     utime: 0.000000, stime: 0.010000, cutime: 0.000000, cstime: 0.000000
+     orig_r0: -1, fpvalid: 1
+-    r0:             1  r1:   -1091672508  r2:   -1091672500
+-    r3:             0  r4:             0  r5:             0
+-    r6:         33728  r7:             0  r8:             0
+-    r9:             0  r10:  -1225703496  r11:  -1091672844
+-    r12:            0  sp:    0xbeee64f4  lr:    0xb6dc3f48
+-    pc:    0x00008500  spsr:  0x60000010
++    r0:            1  r1:  -1091672508  r2:  -1091672500  r3:            0
++    r4:            0  r5:            0  r6:        33728  r7:            0
++    r8:            0  r9:            0  r10: -1225703496  r11: -1091672844
++    r12:           0  sp:   0xbeee64f4  lr:   0xb6dc3f48  pc:   0x00008500
++    spsr:  0x60000010
+   CORE                 124  PRPSINFO
+     state: 0, sname: R, zomb: 0, nice: 0, flag: 0x00400500
+     uid: 0, gid: 0, pid: 11087, ppid: 11063, pgrp: 11087, sid: 11063
+Index: b/tests/run-addrcfi.sh
+===================================================================
+--- a/tests/run-addrcfi.sh
++++ b/tests/run-addrcfi.sh
+@@ -3554,6 +3554,38 @@ dwarf_cfi_addrframe (.eh_frame): no matc
+ 	FPA reg21 (f5): undefined
+ 	FPA reg22 (f6): undefined
+ 	FPA reg23 (f7): undefined
++	VFP reg64 (s0): undefined
++	VFP reg65 (s1): undefined
++	VFP reg66 (s2): undefined
++	VFP reg67 (s3): undefined
++	VFP reg68 (s4): undefined
++	VFP reg69 (s5): undefined
++	VFP reg70 (s6): undefined
++	VFP reg71 (s7): undefined
++	VFP reg72 (s8): undefined
++	VFP reg73 (s9): undefined
++	VFP reg74 (s10): undefined
++	VFP reg75 (s11): undefined
++	VFP reg76 (s12): undefined
++	VFP reg77 (s13): undefined
++	VFP reg78 (s14): undefined
++	VFP reg79 (s15): undefined
++	VFP reg80 (s16): undefined
++	VFP reg81 (s17): undefined
++	VFP reg82 (s18): undefined
++	VFP reg83 (s19): undefined
++	VFP reg84 (s20): undefined
++	VFP reg85 (s21): undefined
++	VFP reg86 (s22): undefined
++	VFP reg87 (s23): undefined
++	VFP reg88 (s24): undefined
++	VFP reg89 (s25): undefined
++	VFP reg90 (s26): undefined
++	VFP reg91 (s27): undefined
++	VFP reg92 (s28): undefined
++	VFP reg93 (s29): undefined
++	VFP reg94 (s30): undefined
++	VFP reg95 (s31): undefined
+ 	FPA reg96 (f0): undefined
+ 	FPA reg97 (f1): undefined
+ 	FPA reg98 (f2): undefined
+@@ -3562,7 +3594,66 @@ dwarf_cfi_addrframe (.eh_frame): no matc
+ 	FPA reg101 (f5): undefined
+ 	FPA reg102 (f6): undefined
+ 	FPA reg103 (f7): undefined
+-	integer reg128 (spsr): undefined
++	MMX reg104 (wcgr0): undefined
++	MMX reg105 (wcgr1): undefined
++	MMX reg106 (wcgr2): undefined
++	MMX reg107 (wcgr3): undefined
++	MMX reg108 (wcgr4): undefined
++	MMX reg109 (wcgr5): undefined
++	MMX reg110 (wcgr6): undefined
++	MMX reg111 (wcgr7): undefined
++	MMX reg112 (wr0): undefined
++	MMX reg113 (wr1): undefined
++	MMX reg114 (wr2): undefined
++	MMX reg115 (wr3): undefined
++	MMX reg116 (wr4): undefined
++	MMX reg117 (wr5): undefined
++	MMX reg118 (wr6): undefined
++	MMX reg119 (wr7): undefined
++	MMX reg120 (wr8): undefined
++	MMX reg121 (wr9): undefined
++	MMX reg122 (wr10): undefined
++	MMX reg123 (wr11): undefined
++	MMX reg124 (wr12): undefined
++	MMX reg125 (wr13): undefined
++	MMX reg126 (wr14): undefined
++	MMX reg127 (wr15): undefined
++	state reg128 (spsr): undefined
++	state reg129 (spsr_fiq): undefined
++	state reg130 (spsr_irq): undefined
++	state reg131 (spsr_abt): undefined
++	state reg132 (spsr_und): undefined
++	state reg133 (spsr_svc): undefined
++	integer reg144 (r8_usr): undefined
++	integer reg145 (r9_usr): undefined
++	integer reg146 (r10_usr): undefined
++	integer reg147 (r11_usr): undefined
++	integer reg148 (r12_usr): undefined
++	integer reg149 (r13_usr): undefined
++	integer reg150 (r14_usr): undefined
++	integer reg151 (r8_fiq): undefined
++	integer reg152 (r9_fiq): undefined
++	integer reg153 (r10_fiq): undefined
++	integer reg154 (r11_fiq): undefined
++	integer reg155 (r12_fiq): undefined
++	integer reg156 (r13_fiq): undefined
++	integer reg157 (r14_fiq): undefined
++	integer reg158 (r13_irq): undefined
++	integer reg159 (r14_irq): undefined
++	integer reg160 (r13_abt): undefined
++	integer reg161 (r14_abt): undefined
++	integer reg162 (r13_und): undefined
++	integer reg163 (r14_und): undefined
++	integer reg164 (r13_svc): undefined
++	integer reg165 (r14_svc): undefined
++	MMX reg192 (wc0): undefined
++	MMX reg193 (wc1): undefined
++	MMX reg194 (wc2): undefined
++	MMX reg195 (wc3): undefined
++	MMX reg196 (wc4): undefined
++	MMX reg197 (wc5): undefined
++	MMX reg198 (wc6): undefined
++	MMX reg199 (wc7): undefined
+ 	VFP reg256 (d0): undefined
+ 	VFP reg257 (d1): undefined
+ 	VFP reg258 (d2): undefined

--- a/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/debian/hppa_backend.diff
+++ b/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/debian/hppa_backend.diff
@@ -1,0 +1,802 @@
+Upstream-Status: Backport [from debian]
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+
+Index: b/backends/parisc_init.c
+===================================================================
+--- /dev/null
++++ b/backends/parisc_init.c
+@@ -0,0 +1,73 @@
++/* Initialization of PA-RISC specific backend library.
++   Copyright (C) 2002, 2005, 2006 Red Hat, Inc.
++   This file is part of Red Hat elfutils.
++   Written by Ulrich Drepper <drepper@redhat.com>, 2002.
++
++   Red Hat elfutils is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by the
++   Free Software Foundation; version 2 of the License.
++
++   Red Hat elfutils is distributed in the hope that it will be useful, but
++   WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   General Public License for more details.
++
++   You should have received a copy of the GNU General Public License along
++   with Red Hat elfutils; if not, write to the Free Software Foundation,
++   Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301 USA.
++
++   Red Hat elfutils is an included package of the Open Invention Network.
++   An included package of the Open Invention Network is a package for which
++   Open Invention Network licensees cross-license their patents.  No patent
++   license is granted, either expressly or impliedly, by designation as an
++   included package.  Should you wish to participate in the Open Invention
++   Network licensing program, please visit www.openinventionnetwork.com
++   <http://www.openinventionnetwork.com>.  */
++
++#ifdef HAVE_CONFIG_H
++# include <config.h>
++#endif
++
++#define BACKEND		parisc_
++#define RELOC_PREFIX	R_PARISC_
++#include "libebl_CPU.h"
++#include "libebl_parisc.h"
++
++/* This defines the common reloc hooks based on parisc_reloc.def.  */
++#include "common-reloc.c"
++
++
++const char *
++parisc_init (Elf *elf __attribute__ ((unused)),
++     GElf_Half machine __attribute__ ((unused)),
++     Ebl *eh,
++     size_t ehlen)
++{
++  int pa64 = 0;
++
++  /* Check whether the Elf_BH object has a sufficent size.  */
++  if (ehlen < sizeof (Ebl))
++    return NULL;
++
++  if (elf) {
++    GElf_Ehdr ehdr_mem;
++    GElf_Ehdr *ehdr = gelf_getehdr (elf, &ehdr_mem);
++    if (ehdr && (ehdr->e_flags & EF_PARISC_WIDE))
++      pa64 = 1;
++  }
++  /* We handle it.  */
++  eh->name = "PA-RISC";
++  parisc_init_reloc (eh);
++  HOOK (eh, reloc_simple_type);
++  HOOK (eh, machine_flag_check);
++  HOOK (eh, symbol_type_name);
++  HOOK (eh, segment_type_name);
++  HOOK (eh, section_type_name);
++  HOOK (eh, register_info);
++  if (pa64)
++    eh->return_value_location = parisc_return_value_location_64;
++  else
++    eh->return_value_location = parisc_return_value_location_32;
++
++  return MODVERSION;
++}
+Index: b/backends/parisc_regs.c
+===================================================================
+--- /dev/null
++++ b/backends/parisc_regs.c
+@@ -0,0 +1,159 @@
++/* Register names and numbers for PA-RISC DWARF.
++   Copyright (C) 2005, 2006 Red Hat, Inc.
++   This file is part of Red Hat elfutils.
++
++   Red Hat elfutils is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by the
++   Free Software Foundation; version 2 of the License.
++
++   Red Hat elfutils is distributed in the hope that it will be useful, but
++   WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   General Public License for more details.
++
++   You should have received a copy of the GNU General Public License along
++   with Red Hat elfutils; if not, write to the Free Software Foundation,
++   Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301 USA.
++
++   Red Hat elfutils is an included package of the Open Invention Network.
++   An included package of the Open Invention Network is a package for which
++   Open Invention Network licensees cross-license their patents.  No patent
++   license is granted, either expressly or impliedly, by designation as an
++   included package.  Should you wish to participate in the Open Invention
++   Network licensing program, please visit www.openinventionnetwork.com
++   <http://www.openinventionnetwork.com>.  */
++
++#ifdef HAVE_CONFIG_H
++# include <config.h>
++#endif
++
++#include <string.h>
++#include <dwarf.h>
++
++#define BACKEND parisc_
++#include "libebl_CPU.h"
++
++ssize_t
++parisc_register_info (Ebl *ebl, int regno, char *name, size_t namelen,
++		     const char **prefix, const char **setname,
++		     int *bits, int *type)
++{
++  int pa64 = 0;
++
++  if (ebl->elf) {
++    GElf_Ehdr ehdr_mem;
++    GElf_Ehdr *ehdr = gelf_getehdr (ebl->elf, &ehdr_mem);
++    if (ehdr->e_flags & EF_PARISC_WIDE)
++      pa64 = 1;
++  }
++
++  int nregs = pa64 ? 127 : 128;
++
++  if (name == NULL)
++    return nregs;
++
++  if (regno < 0 || regno >= nregs || namelen < 6)
++    return -1;
++
++  *prefix = "%";
++
++  if (regno < 32)
++  {
++    *setname = "integer";
++    *type = DW_ATE_signed;
++    if (pa64)
++    {
++	*bits = 64;
++    }
++    else
++    {
++    	*bits = 32;
++    }
++  }
++  else if (regno == 32)
++  {
++    *setname = "special";
++    if (pa64)
++    {
++	*bits = 6;
++    }
++    else
++    {
++    	*bits = 5;
++    }
++    *type = DW_ATE_unsigned;
++  }
++  else
++  {
++    *setname = "FPU";
++    *type = DW_ATE_float;
++    if (pa64)
++    {
++	*bits = 64;
++    }
++    else
++    {
++    	*bits = 32;
++    }
++  }
++
++  if (regno < 33) {
++    switch (regno)
++      {
++      case 0 ... 9:
++        name[0] = 'r';
++        name[1] = regno + '0';
++        namelen = 2;
++        break;
++      case 10 ... 31:
++        name[0] = 'r';
++        name[1] = regno / 10 + '0';
++        name[2] = regno % 10 + '0';
++        namelen = 3;
++        break;
++      case 32:
++	*prefix = NULL;
++	name[0] = 'S';
++	name[1] = 'A';
++	name[2] = 'R';
++	namelen = 3;
++	break;
++      }
++  }
++  else {
++    if (pa64 && ((regno - 72) % 2)) {
++      *setname = NULL;
++      return 0;
++    }
++
++    switch (regno)
++      {
++      case 72 + 0 ... 72 + 11:
++        name[0] = 'f';
++	name[1] = 'r';
++        name[2] = (regno + 8 - 72) / 2 + '0';
++        namelen = 3;
++        if ((regno + 8 - 72) % 2) {
++	  name[3] = 'R';
++	  namelen++;
++        }
++        break;
++      case 72 + 12 ... 72 + 55:
++        name[0] = 'f';
++	name[1] = 'r';
++        name[2] = (regno + 8 - 72) / 2 / 10 + '0';
++        name[3] = (regno + 8 - 72) / 2 % 10 + '0';
++        namelen = 4;
++        if ((regno + 8 - 72) % 2) {
++	  name[4] = 'R';
++	  namelen++;
++        }
++        break;
++      default:
++        *setname = NULL;
++        return 0;
++      }
++  }
++  name[namelen++] = '\0';
++  return namelen;
++}
+Index: b/backends/parisc_reloc.def
+===================================================================
+--- /dev/null
++++ b/backends/parisc_reloc.def
+@@ -0,0 +1,128 @@
++/* List the relocation types for PA-RISC.  -*- C -*-
++   Copyright (C) 2005 Red Hat, Inc.
++   This file is part of Red Hat elfutils.
++
++   Red Hat elfutils is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by the
++   Free Software Foundation; version 2 of the License.
++
++   Red Hat elfutils is distributed in the hope that it will be useful, but
++   WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   General Public License for more details.
++
++   You should have received a copy of the GNU General Public License along
++   with Red Hat elfutils; if not, write to the Free Software Foundation,
++   Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301 USA.
++
++   Red Hat elfutils is an included package of the Open Invention Network.
++   An included package of the Open Invention Network is a package for which
++   Open Invention Network licensees cross-license their patents.  No patent
++   license is granted, either expressly or impliedly, by designation as an
++   included package.  Should you wish to participate in the Open Invention
++   Network licensing program, please visit www.openinventionnetwork.com
++   <http://www.openinventionnetwork.com>.  */
++
++/*	    NAME,		REL|EXEC|DYN	*/
++
++RELOC_TYPE (NONE,		EXEC|DYN)
++RELOC_TYPE (DIR32,		REL|EXEC|DYN)
++RELOC_TYPE (DIR21L,		REL|EXEC|DYN)
++RELOC_TYPE (DIR17R,		REL)
++RELOC_TYPE (DIR17F,		REL)
++RELOC_TYPE (DIR14R,		REL|DYN)
++RELOC_TYPE (PCREL32,		REL)
++RELOC_TYPE (PCREL21L,		REL)
++RELOC_TYPE (PCREL17R,		REL)
++RELOC_TYPE (PCREL17F,		REL)
++RELOC_TYPE (PCREL14R,		REL|EXEC)
++RELOC_TYPE (DPREL21L,		REL)
++RELOC_TYPE (DPREL14WR,		REL)
++RELOC_TYPE (DPREL14DR,          REL)
++RELOC_TYPE (DPREL14R,		REL)
++RELOC_TYPE (GPREL21L,		0)
++RELOC_TYPE (GPREL14R,		0)
++RELOC_TYPE (LTOFF21L,		REL)
++RELOC_TYPE (LTOFF14R,		REL)
++RELOC_TYPE (DLTIND14F,		0)
++RELOC_TYPE (SETBASE,		0)
++RELOC_TYPE (SECREL32,		REL)
++RELOC_TYPE (BASEREL21L,		0)
++RELOC_TYPE (BASEREL17R,		0)
++RELOC_TYPE (BASEREL14R,		0)
++RELOC_TYPE (SEGBASE,		0)
++RELOC_TYPE (SEGREL32,		REL)
++RELOC_TYPE (PLTOFF21L,		0)
++RELOC_TYPE (PLTOFF14R,		0)
++RELOC_TYPE (PLTOFF14F,		0)
++RELOC_TYPE (LTOFF_FPTR32,	0)
++RELOC_TYPE (LTOFF_FPTR21L,	0)
++RELOC_TYPE (LTOFF_FPTR14R,	0)
++RELOC_TYPE (FPTR64,		0)
++RELOC_TYPE (PLABEL32,		REL|DYN)
++RELOC_TYPE (PCREL64,		0)
++RELOC_TYPE (PCREL22C,		0)
++RELOC_TYPE (PCREL22F,		0)
++RELOC_TYPE (PCREL14WR,		0)
++RELOC_TYPE (PCREL14DR,		0)
++RELOC_TYPE (PCREL16F,		0)
++RELOC_TYPE (PCREL16WF,		0)
++RELOC_TYPE (PCREL16DF,		0)
++RELOC_TYPE (DIR64,		REL|DYN)
++RELOC_TYPE (DIR14WR,		REL)
++RELOC_TYPE (DIR14DR,		REL)
++RELOC_TYPE (DIR16F,		REL)
++RELOC_TYPE (DIR16WF,		REL)
++RELOC_TYPE (DIR16DF,		REL)
++RELOC_TYPE (GPREL64,		0)
++RELOC_TYPE (GPREL14WR,		0)
++RELOC_TYPE (GPREL14DR,		0)
++RELOC_TYPE (GPREL16F,		0)
++RELOC_TYPE (GPREL16WF,		0)
++RELOC_TYPE (GPREL16DF,		0)
++RELOC_TYPE (LTOFF64,		0)
++RELOC_TYPE (LTOFF14WR,		0)
++RELOC_TYPE (LTOFF14DR,		0)
++RELOC_TYPE (LTOFF16F,		0)
++RELOC_TYPE (LTOFF16WF,		0)
++RELOC_TYPE (LTOFF16DF,		0)
++RELOC_TYPE (SECREL64,		0)
++RELOC_TYPE (BASEREL14WR,	0)
++RELOC_TYPE (BASEREL14DR,	0)
++RELOC_TYPE (SEGREL64,		0)
++RELOC_TYPE (PLTOFF14WR,		0)
++RELOC_TYPE (PLTOFF14DR,		0)
++RELOC_TYPE (PLTOFF16F,		0)
++RELOC_TYPE (PLTOFF16WF,		0)
++RELOC_TYPE (PLTOFF16DF,		0)
++RELOC_TYPE (LTOFF_FPTR64,	0)
++RELOC_TYPE (LTOFF_FPTR14WR,	0)
++RELOC_TYPE (LTOFF_FPTR14DR,	0)
++RELOC_TYPE (LTOFF_FPTR16F,	0)
++RELOC_TYPE (LTOFF_FPTR16WF,	0)
++RELOC_TYPE (LTOFF_FPTR16DF,	0)
++RELOC_TYPE (COPY,		EXEC)
++RELOC_TYPE (IPLT,		EXEC|DYN)
++RELOC_TYPE (EPLT,		0)
++RELOC_TYPE (TPREL32,		DYN)
++RELOC_TYPE (TPREL21L,		0)
++RELOC_TYPE (TPREL14R,		0)
++RELOC_TYPE (LTOFF_TP21L,	0)
++RELOC_TYPE (LTOFF_TP14R,	0)
++RELOC_TYPE (LTOFF_TP14F,	0)
++RELOC_TYPE (TPREL64,		0)
++RELOC_TYPE (TPREL14WR,		0)
++RELOC_TYPE (TPREL14DR,		0)
++RELOC_TYPE (TPREL16F,		0)
++RELOC_TYPE (TPREL16WF,		0)
++RELOC_TYPE (TPREL16DF,		0)
++RELOC_TYPE (LTOFF_TP64,		0)
++RELOC_TYPE (LTOFF_TP14WR,	0)
++RELOC_TYPE (LTOFF_TP14DR,	0)
++RELOC_TYPE (LTOFF_TP16F,	0)
++RELOC_TYPE (LTOFF_TP16WF,	0)
++RELOC_TYPE (LTOFF_TP16DF,	0)
++RELOC_TYPE (TLS_DTPMOD32,	DYN)
++RELOC_TYPE (TLS_DTPMOD64,	DYN)
++
++#define NO_RELATIVE_RELOC       1
+Index: b/backends/parisc_retval.c
+===================================================================
+--- /dev/null
++++ b/backends/parisc_retval.c
+@@ -0,0 +1,213 @@
++/* Function return value location for Linux/PA-RISC ABI.
++   Copyright (C) 2005 Red Hat, Inc.
++   This file is part of Red Hat elfutils.
++
++   Red Hat elfutils is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by the
++   Free Software Foundation; version 2 of the License.
++
++   Red Hat elfutils is distributed in the hope that it will be useful, but
++   WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   General Public License for more details.
++
++   You should have received a copy of the GNU General Public License along
++   with Red Hat elfutils; if not, write to the Free Software Foundation,
++   Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301 USA.
++
++   Red Hat elfutils is an included package of the Open Invention Network.
++   An included package of the Open Invention Network is a package for which
++   Open Invention Network licensees cross-license their patents.  No patent
++   license is granted, either expressly or impliedly, by designation as an
++   included package.  Should you wish to participate in the Open Invention
++   Network licensing program, please visit www.openinventionnetwork.com
++   <http://www.openinventionnetwork.com>.  */
++
++#ifdef HAVE_CONFIG_H
++# include <config.h>
++#endif
++
++#include <assert.h>
++#include <dwarf.h>
++
++#define BACKEND parisc_
++#include "libebl_CPU.h"
++#include "libebl_parisc.h"
++
++/* %r28, or pair %r28, %r29.  */
++static const Dwarf_Op loc_intreg32[] =
++  {
++    { .atom = DW_OP_reg28 }, { .atom = DW_OP_piece, .number = 4 },
++    { .atom = DW_OP_reg29 }, { .atom = DW_OP_piece, .number = 4 },
++  };
++
++static const Dwarf_Op loc_intreg[] =
++  {
++    { .atom = DW_OP_reg28 }, { .atom = DW_OP_piece, .number = 8 },
++    { .atom = DW_OP_reg29 }, { .atom = DW_OP_piece, .number = 8 },
++  };
++#define nloc_intreg	1
++#define nloc_intregpair	4
++
++/* %fr4L, or pair %fr4L, %fr4R on pa-32 */
++static const Dwarf_Op loc_fpreg32[] =
++  {
++    { .atom = DW_OP_regx, .number = 72 }, { .atom = DW_OP_piece, .number = 4 },
++    { .atom = DW_OP_regx, .number = 73 }, { .atom = DW_OP_piece, .number = 4 },
++  };
++#define nloc_fpreg32 2
++#define nloc_fpregpair32 4
++
++/* $fr4 */
++static const Dwarf_Op loc_fpreg[] =
++  {
++    { .atom = DW_OP_regx, .number = 72 },
++  };
++#define nloc_fpreg  1
++
++#if 0
++/* The return value is a structure and is actually stored in stack space
++   passed in a hidden argument by the caller. Address of the location is stored
++   in %r28 before function call, but it may be changed by function. */
++static const Dwarf_Op loc_aggregate[] =
++  {
++    { .atom = DW_OP_breg28 },
++  };
++#define nloc_aggregate 1
++#endif
++
++static int
++parisc_return_value_location_ (Dwarf_Die *functypedie, const Dwarf_Op **locp, int pa64)
++{
++  Dwarf_Word regsize = pa64 ? 8 : 4;
++
++  /* Start with the function's type, and get the DW_AT_type attribute,
++     which is the type of the return value.  */
++
++  Dwarf_Attribute attr_mem;
++  Dwarf_Attribute *attr = dwarf_attr_integrate (functypedie, DW_AT_type, &attr_mem);
++  if (attr == NULL)
++    /* The function has no return value, like a `void' function in C.  */
++    return 0;
++
++  Dwarf_Die die_mem;
++  Dwarf_Die *typedie = dwarf_formref_die (attr, &die_mem);
++  int tag = dwarf_tag (typedie);
++
++  /* Follow typedefs and qualifiers to get to the actual type.  */
++  while (tag == DW_TAG_typedef
++	 || tag == DW_TAG_const_type || tag == DW_TAG_volatile_type
++	 || tag == DW_TAG_restrict_type)
++    {
++      attr = dwarf_attr_integrate (typedie, DW_AT_type, &attr_mem);
++      typedie = dwarf_formref_die (attr, &die_mem);
++      tag = dwarf_tag (typedie);
++    }
++
++  switch (tag)
++    {
++    case -1:
++      return -1;
++
++    case DW_TAG_subrange_type:
++      if (! dwarf_hasattr_integrate (typedie, DW_AT_byte_size))
++	{
++	  attr = dwarf_attr_integrate (typedie, DW_AT_type, &attr_mem);
++	  typedie = dwarf_formref_die (attr, &die_mem);
++	  tag = dwarf_tag (typedie);
++	}
++      /* Fall through.  */
++
++    case DW_TAG_base_type:
++    case DW_TAG_enumeration_type:
++    case DW_TAG_pointer_type:
++    case DW_TAG_ptr_to_member_type:
++      {
++        Dwarf_Word size;
++	if (dwarf_formudata (dwarf_attr_integrate (typedie, DW_AT_byte_size,
++					 &attr_mem), &size) != 0)
++	  {
++	    if (tag == DW_TAG_pointer_type || tag == DW_TAG_ptr_to_member_type)
++	      size = 4;
++	    else
++	      return -1;
++	  }
++	if (tag == DW_TAG_base_type)
++	  {
++	    Dwarf_Word encoding;
++	    if (dwarf_formudata (dwarf_attr_integrate (typedie, DW_AT_encoding,
++					     &attr_mem), &encoding) != 0)
++	      return -1;
++
++	    if (encoding == DW_ATE_float)
++	      {
++		if (pa64) {
++		  *locp = loc_fpreg;
++		  if (size <= 8)
++		      return nloc_fpreg;
++		}
++		else {
++		  *locp = loc_fpreg32;
++		  if (size <= 4)
++		    return nloc_fpreg32;
++		  else if (size <= 8)
++		    return nloc_fpregpair32;
++		}
++		goto aggregate;
++	      }
++	  }
++	if (pa64)
++	  *locp = loc_intreg;
++	else
++	  *locp = loc_intreg32;
++	if (size <= regsize)
++	  return nloc_intreg;
++	if (size <= 2 * regsize)
++	  return nloc_intregpair;
++
++	/* Else fall through.  */
++      }
++
++    case DW_TAG_structure_type:
++    case DW_TAG_class_type:
++    case DW_TAG_union_type:
++    case DW_TAG_array_type:
++    aggregate: {
++        Dwarf_Word size;
++	if (dwarf_aggregate_size (typedie, &size) != 0)
++	  return -1;
++	if (pa64)
++          *locp = loc_intreg;
++	else
++	  *locp = loc_intreg32;
++        if (size <= regsize)
++	  return nloc_intreg;
++        if (size <= 2 * regsize)
++	  return nloc_intregpair;
++#if 0
++	/* there should be some way to know this location... But I do not see it. */
++        *locp = loc_aggregate;
++        return nloc_aggregate;
++#endif
++	/* fall through.  */
++      }
++    }
++
++  /* XXX We don't have a good way to return specific errors from ebl calls.
++     This value means we do not understand the type, but it is well-formed
++     DWARF and might be valid.  */
++  return -2;
++}
++
++int
++parisc_return_value_location_32 (Dwarf_Die *functypedie, const Dwarf_Op **locp)
++{
++  return parisc_return_value_location_ (functypedie, locp, 0);
++}
++
++int
++parisc_return_value_location_64 (Dwarf_Die *functypedie, const Dwarf_Op **locp)
++{
++  return parisc_return_value_location_ (functypedie, locp, 1);
++}
++
+Index: b/backends/parisc_symbol.c
+===================================================================
+--- /dev/null
++++ b/backends/parisc_symbol.c
+@@ -0,0 +1,112 @@
++/* PA-RISC specific symbolic name handling.
++   Copyright (C) 2002, 2005 Red Hat, Inc.
++   This file is part of Red Hat elfutils.
++   Written by Ulrich Drepper <drepper@redhat.com>, 2002.
++
++   Red Hat elfutils is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by the
++   Free Software Foundation; version 2 of the License.
++
++   Red Hat elfutils is distributed in the hope that it will be useful, but
++   WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   General Public License for more details.
++
++   You should have received a copy of the GNU General Public License along
++   with Red Hat elfutils; if not, write to the Free Software Foundation,
++   Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301 USA.
++
++   Red Hat elfutils is an included package of the Open Invention Network.
++   An included package of the Open Invention Network is a package for which
++   Open Invention Network licensees cross-license their patents.  No patent
++   license is granted, either expressly or impliedly, by designation as an
++   included package.  Should you wish to participate in the Open Invention
++   Network licensing program, please visit www.openinventionnetwork.com
++   <http://www.openinventionnetwork.com>.  */
++
++#ifdef HAVE_CONFIG_H
++# include <config.h>
++#endif
++
++#include <elf.h>
++#include <stddef.h>
++
++#define BACKEND		parisc_
++#include "libebl_CPU.h"
++
++const char *
++parisc_segment_type_name (int segment, char *buf __attribute__ ((unused)),
++			size_t len __attribute__ ((unused)))
++{
++  switch (segment)
++    {
++    case PT_PARISC_ARCHEXT:
++      return "PARISC_ARCHEXT";
++    case PT_PARISC_UNWIND:
++      return "PARISC_UNWIND";
++    default:
++      break;
++    }
++  return NULL;
++}
++
++/* Return symbolic representation of symbol type.  */
++const char *
++parisc_symbol_type_name(int symbol, char *buf __attribute__ ((unused)),
++    size_t len __attribute__ ((unused)))
++{
++	if (symbol == STT_PARISC_MILLICODE)
++	  return "PARISC_MILLI";
++	return NULL;
++}
++
++/* Return symbolic representation of section type.  */
++const char *
++parisc_section_type_name (int type,
++			char *buf __attribute__ ((unused)),
++			size_t len __attribute__ ((unused)))
++{
++  switch (type)
++    {
++    case SHT_PARISC_EXT:
++      return "PARISC_EXT";
++    case SHT_PARISC_UNWIND:
++      return "PARISC_UNWIND";
++    case SHT_PARISC_DOC:
++      return "PARISC_DOC";
++    }
++
++  return NULL;
++}
++
++/* Check whether machine flags are valid.  */
++bool
++parisc_machine_flag_check (GElf_Word flags)
++{
++  if (flags &~ (EF_PARISC_TRAPNIL | EF_PARISC_EXT | EF_PARISC_LSB |
++	EF_PARISC_WIDE | EF_PARISC_NO_KABP |
++	EF_PARISC_LAZYSWAP | EF_PARISC_ARCH))
++    return 0;
++
++  GElf_Word arch = flags & EF_PARISC_ARCH;
++
++  return ((arch == EFA_PARISC_1_0) || (arch == EFA_PARISC_1_1) ||
++      (arch == EFA_PARISC_2_0));
++}
++
++/* Check for the simple reloc types.  */
++Elf_Type
++parisc_reloc_simple_type (Ebl *ebl __attribute__ ((unused)), int type)
++{
++  switch (type)
++    {
++    case R_PARISC_DIR64:
++    case R_PARISC_SECREL64:
++      return ELF_T_XWORD;
++    case R_PARISC_DIR32:
++    case R_PARISC_SECREL32:
++      return ELF_T_WORD;
++    default:
++      return ELF_T_NUM;
++    }
++}
+Index: b/backends/libebl_parisc.h
+===================================================================
+--- /dev/null
++++ b/backends/libebl_parisc.h
+@@ -0,0 +1,9 @@
++#ifndef _LIBEBL_HPPA_H
++#define _LIBEBL_HPPA_H 1
++
++#include <libdw.h>
++
++extern int parisc_return_value_location_32(Dwarf_Die *, const Dwarf_Op **locp);
++extern int parisc_return_value_location_64(Dwarf_Die *, const Dwarf_Op **locp);
++
++#endif
+Index: b/backends/Makefile.am
+===================================================================
+--- a/backends/Makefile.am
++++ b/backends/Makefile.am
+@@ -33,12 +33,12 @@ AM_CPPFLAGS += -I$(top_srcdir)/libebl -I
+ 
+ 
+ modules = i386 sh x86_64 ia64 alpha arm aarch64 sparc ppc ppc64 s390 \
+-	  tilegx m68k bpf
++	  tilegx m68k bpf parisc
+ libebl_pic = libebl_i386_pic.a libebl_sh_pic.a libebl_x86_64_pic.a    \
+ 	     libebl_ia64_pic.a libebl_alpha_pic.a libebl_arm_pic.a    \
+ 	     libebl_aarch64_pic.a libebl_sparc_pic.a libebl_ppc_pic.a \
+ 	     libebl_ppc64_pic.a libebl_s390_pic.a libebl_tilegx_pic.a \
+-	     libebl_m68k_pic.a libebl_bpf_pic.a
++	     libebl_m68k_pic.a libebl_bpf_pic.a libebl_parisc_pic.a
+ noinst_LIBRARIES = $(libebl_pic)
+ noinst_DATA = $(libebl_pic:_pic.a=.so)
+ 
+@@ -128,6 +128,9 @@ endif
+ libebl_bpf_pic_a_SOURCES = $(bpf_SRCS)
+ am_libebl_bpf_pic_a_OBJECTS = $(bpf_SRCS:.c=.os)
+ 
++parisc_SRCS = parisc_init.c parisc_symbol.c parisc_regs.c parisc_retval.c
++libebl_parisc_pic_a_SOURCES = $(parisc_SRCS)
++am_libebl_parisc_pic_a_OBJECTS = $(parisc_SRCS:.c=.os)
+ 
+ libebl_%.so libebl_%.map: libebl_%_pic.a $(libelf) $(libdw)
+ 	@rm -f $(@:.so=.map)
+Index: b/libelf/elf.h
+===================================================================
+--- a/libelf/elf.h
++++ b/libelf/elf.h
+@@ -2055,16 +2055,24 @@ enum
+ #define R_PARISC_PCREL17F	12	/* 17 bits of rel. address.  */
+ #define R_PARISC_PCREL14R	14	/* Right 14 bits of rel. address.  */
+ #define R_PARISC_DPREL21L	18	/* Left 21 bits of rel. address.  */
++#define R_PARISC_DPREL14WR	19
++#define R_PARISC_DPREL14DR	20
+ #define R_PARISC_DPREL14R	22	/* Right 14 bits of rel. address.  */
+ #define R_PARISC_GPREL21L	26	/* GP-relative, left 21 bits.  */
+ #define R_PARISC_GPREL14R	30	/* GP-relative, right 14 bits.  */
+ #define R_PARISC_LTOFF21L	34	/* LT-relative, left 21 bits.  */
+ #define R_PARISC_LTOFF14R	38	/* LT-relative, right 14 bits.  */
++#define R_PARISC_DLTIND14F	39
++#define R_PARISC_SETBASE	40
+ #define R_PARISC_SECREL32	41	/* 32 bits section rel. address.  */
++#define R_PARISC_BASEREL21L	42
++#define R_PARISC_BASEREL17R	43
++#define R_PARISC_BASEREL14R	46
+ #define R_PARISC_SEGBASE	48	/* No relocation, set segment base.  */
+ #define R_PARISC_SEGREL32	49	/* 32 bits segment rel. address.  */
+ #define R_PARISC_PLTOFF21L	50	/* PLT rel. address, left 21 bits.  */
+ #define R_PARISC_PLTOFF14R	54	/* PLT rel. address, right 14 bits.  */
++#define R_PARISC_PLTOFF14F	55
+ #define R_PARISC_LTOFF_FPTR32	57	/* 32 bits LT-rel. function pointer. */
+ #define R_PARISC_LTOFF_FPTR21L	58	/* LT-rel. fct ptr, left 21 bits. */
+ #define R_PARISC_LTOFF_FPTR14R	62	/* LT-rel. fct ptr, right 14 bits. */
+@@ -2073,6 +2081,7 @@ enum
+ #define R_PARISC_PLABEL21L	66	/* Left 21 bits of fdesc address.  */
+ #define R_PARISC_PLABEL14R	70	/* Right 14 bits of fdesc address.  */
+ #define R_PARISC_PCREL64	72	/* 64 bits PC-rel. address.  */
++#define R_PARISC_PCREL22C	73
+ #define R_PARISC_PCREL22F	74	/* 22 bits PC-rel. address.  */
+ #define R_PARISC_PCREL14WR	75	/* PC-rel. address, right 14 bits.  */
+ #define R_PARISC_PCREL14DR	76	/* PC rel. address, right 14 bits.  */
+@@ -2098,6 +2107,8 @@ enum
+ #define R_PARISC_LTOFF16WF	102	/* 16 bits LT-rel. address.  */
+ #define R_PARISC_LTOFF16DF	103	/* 16 bits LT-rel. address.  */
+ #define R_PARISC_SECREL64	104	/* 64 bits section rel. address.  */
++#define R_PARISC_BASEREL14WR	107
++#define R_PARISC_BASEREL14DR	108
+ #define R_PARISC_SEGREL64	112	/* 64 bits segment rel. address.  */
+ #define R_PARISC_PLTOFF14WR	115	/* PLT-rel. address, right 14 bits.  */
+ #define R_PARISC_PLTOFF14DR	116	/* PLT-rel. address, right 14 bits.  */

--- a/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/debian/hurd_path.patch
+++ b/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/debian/hurd_path.patch
@@ -1,0 +1,17 @@
+Upstream-Status: Backport [from debian]
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+
+Index: elfutils-0.165/tests/run-native-test.sh
+===================================================================
+--- elfutils-0.165.orig/tests/run-native-test.sh
++++ elfutils-0.165/tests/run-native-test.sh
+@@ -83,6 +83,9 @@ native_test()
+ # "cannot attach to process: Function not implemented".
+ [ "$(uname)" = "GNU/kFreeBSD" ] && exit 77
+ 
++# hurd's /proc/$PID/maps does not give paths yet.
++[ "$(uname)" = "GNU" ] && exit 77
++
+ native_test ${abs_builddir}/allregs
+ native_test ${abs_builddir}/funcretval
+ 

--- a/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/debian/ignore_strmerge.diff
+++ b/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/debian/ignore_strmerge.diff
@@ -1,0 +1,14 @@
+Upstream-Status: Backport [from debian]
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+
+--- elfutils-0.165.orig/tests/run-strip-strmerge.sh
++++ elfutils-0.165/tests/run-strip-strmerge.sh
+@@ -30,7 +30,7 @@ remerged=remerged.elf
+ tempfiles $merged $stripped $debugfile $remerged
+ 
+ echo elflint $input
+-testrun ${abs_top_builddir}/src/elflint --gnu $input
++testrun_on_self_skip ${abs_top_builddir}/src/elflint --gnu $input
+ echo elfstrmerge
+ testrun ${abs_top_builddir}/tests/elfstrmerge -o $merged $input
+ echo elflint $merged

--- a/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/debian/kfreebsd_path.patch
+++ b/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/debian/kfreebsd_path.patch
@@ -1,0 +1,20 @@
+Upstream-Status: Backport [from debian]
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+
+Index: b/tests/run-native-test.sh
+===================================================================
+--- a/tests/run-native-test.sh
++++ b/tests/run-native-test.sh
+@@ -77,6 +77,12 @@ native_test()
+   test $native -eq 0 || testrun "$@" -p $native > /dev/null
+ }
+ 
++# On the Debian buildds, GNU/kFreeBSD linprocfs /proc/$PID/maps does
++# not give absolute paths due to sbuild's bind mounts (bug #570805)
++# therefore the next two test programs are expected to fail with
++# "cannot attach to process: Function not implemented".
++[ "$(uname)" = "GNU/kFreeBSD" ] && exit 77
++
+ native_test ${abs_builddir}/allregs
+ native_test ${abs_builddir}/funcretval
+ 

--- a/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/debian/mips_backend.diff
+++ b/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/debian/mips_backend.diff
@@ -1,0 +1,686 @@
+Upstream-Status: Backport [from debian]
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+
+Index: b/backends/mips_init.c
+===================================================================
+--- /dev/null
++++ b/backends/mips_init.c
+@@ -0,0 +1,59 @@
++/* Initialization of mips specific backend library.
++   Copyright (C) 2006 Red Hat, Inc.
++   This file is part of Red Hat elfutils.
++
++   Red Hat elfutils is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by the
++   Free Software Foundation; version 2 of the License.
++
++   Red Hat elfutils is distributed in the hope that it will be useful, but
++   WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   General Public License for more details.
++
++   You should have received a copy of the GNU General Public License along
++   with Red Hat elfutils; if not, write to the Free Software Foundation,
++   Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301 USA.
++
++   Red Hat elfutils is an included package of the Open Invention Network.
++   An included package of the Open Invention Network is a package for which
++   Open Invention Network licensees cross-license their patents.  No patent
++   license is granted, either expressly or impliedly, by designation as an
++   included package.  Should you wish to participate in the Open Invention
++   Network licensing program, please visit www.openinventionnetwork.com
++   <http://www.openinventionnetwork.com>.  */
++
++#ifdef HAVE_CONFIG_H
++# include <config.h>
++#endif
++
++#define BACKEND		mips_
++#define RELOC_PREFIX	R_MIPS_
++#include "libebl_CPU.h"
++
++/* This defines the common reloc hooks based on mips_reloc.def.  */
++#include "common-reloc.c"
++
++const char *
++mips_init (Elf *elf __attribute__ ((unused)),
++     GElf_Half machine __attribute__ ((unused)),
++     Ebl *eh,
++     size_t ehlen)
++{
++  /* Check whether the Elf_BH object has a sufficent size.  */
++  if (ehlen < sizeof (Ebl))
++    return NULL;
++
++  /* We handle it.  */
++  if (machine == EM_MIPS)
++    eh->name = "MIPS R3000 big-endian";
++  else if (machine == EM_MIPS_RS3_LE)
++    eh->name = "MIPS R3000 little-endian";
++
++  mips_init_reloc (eh);
++  HOOK (eh, reloc_simple_type);
++  HOOK (eh, return_value_location);
++  HOOK (eh, register_info);
++
++  return MODVERSION;
++}
+Index: b/backends/mips_regs.c
+===================================================================
+--- /dev/null
++++ b/backends/mips_regs.c
+@@ -0,0 +1,104 @@
++/* Register names and numbers for MIPS DWARF.
++   Copyright (C) 2006 Red Hat, Inc.
++   This file is part of Red Hat elfutils.
++
++   Red Hat elfutils is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by the
++   Free Software Foundation; version 2 of the License.
++
++   Red Hat elfutils is distributed in the hope that it will be useful, but
++   WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   General Public License for more details.
++
++   You should have received a copy of the GNU General Public License along
++   with Red Hat elfutils; if not, write to the Free Software Foundation,
++   Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301 USA.
++
++   Red Hat elfutils is an included package of the Open Invention Network.
++   An included package of the Open Invention Network is a package for which
++   Open Invention Network licensees cross-license their patents.  No patent
++   license is granted, either expressly or impliedly, by designation as an
++   included package.  Should you wish to participate in the Open Invention
++   Network licensing program, please visit www.openinventionnetwork.com
++   <http://www.openinventionnetwork.com>.  */
++
++#ifdef HAVE_CONFIG_H
++# include <config.h>
++#endif
++
++#include <string.h>
++#include <dwarf.h>
++
++#define BACKEND mips_
++#include "libebl_CPU.h"
++
++ssize_t
++mips_register_info (Ebl *ebl __attribute__((unused)),
++		    int regno, char *name, size_t namelen,
++		    const char **prefix, const char **setname,
++		    int *bits, int *type)
++{
++  if (name == NULL)
++    return 66;
++
++  if (regno < 0 || regno > 65 || namelen < 4)
++    return -1;
++
++  *prefix = "$";
++
++  if (regno < 32)
++    {
++      *setname = "integer";
++      *type = DW_ATE_signed;
++      *bits = 32;
++      if (regno < 32 + 10)
++        {
++          name[0] = regno + '0';
++          namelen = 1;
++        }
++      else
++        {
++          name[0] = (regno / 10) + '0';
++          name[1] = (regno % 10) + '0';
++          namelen = 2;
++        }
++    }
++  else if (regno < 64)
++    {
++      *setname = "FPU";
++      *type = DW_ATE_float;
++      *bits = 32;
++      name[0] = 'f';
++      if (regno < 32 + 10)
++	{
++	  name[1] = (regno - 32) + '0';
++	  namelen = 2;
++	}
++      else
++	{
++	  name[1] = (regno - 32) / 10 + '0';
++	  name[2] = (regno - 32) % 10 + '0';
++	  namelen = 3;
++	}
++    }
++  else if (regno == 64)
++    {
++      *type = DW_ATE_signed;
++      *bits = 32;
++      name[0] = 'h';
++      name[1] = 'i';
++      namelen = 2;
++    }
++  else
++    {
++      *type = DW_ATE_signed;
++      *bits = 32;
++      name[0] = 'l';
++      name[1] = 'o';
++      namelen = 2;
++    }
++
++  name[namelen++] = '\0';
++  return namelen;
++}
+Index: b/backends/mips_reloc.def
+===================================================================
+--- /dev/null
++++ b/backends/mips_reloc.def
+@@ -0,0 +1,79 @@
++/* List the relocation types for mips.  -*- C -*-
++   Copyright (C) 2006 Red Hat, Inc.
++   This file is part of Red Hat elfutils.
++
++   Red Hat elfutils is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by the
++   Free Software Foundation; version 2 of the License.
++
++   Red Hat elfutils is distributed in the hope that it will be useful, but
++   WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   General Public License for more details.
++
++   You should have received a copy of the GNU General Public License along
++   with Red Hat elfutils; if not, write to the Free Software Foundation,
++   Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301 USA.
++
++   Red Hat elfutils is an included package of the Open Invention Network.
++   An included package of the Open Invention Network is a package for which
++   Open Invention Network licensees cross-license their patents.  No patent
++   license is granted, either expressly or impliedly, by designation as an
++   included package.  Should you wish to participate in the Open Invention
++   Network licensing program, please visit www.openinventionnetwork.com
++   <http://www.openinventionnetwork.com>.  */
++
++/* 	    NAME,		REL|EXEC|DYN	*/
++
++RELOC_TYPE (NONE,               0)
++RELOC_TYPE (16,                 0)
++RELOC_TYPE (32,                 0)
++RELOC_TYPE (REL32,              0)
++RELOC_TYPE (26,                 0)
++RELOC_TYPE (HI16,               0)
++RELOC_TYPE (LO16,               0)
++RELOC_TYPE (GPREL16,            0)
++RELOC_TYPE (LITERAL,            0)
++RELOC_TYPE (GOT16,              0)
++RELOC_TYPE (PC16,               0)
++RELOC_TYPE (CALL16,             0)
++RELOC_TYPE (GPREL32,            0)
++
++RELOC_TYPE (SHIFT5,             0)
++RELOC_TYPE (SHIFT6,             0)
++RELOC_TYPE (64,                 0)
++RELOC_TYPE (GOT_DISP,           0)
++RELOC_TYPE (GOT_PAGE,           0)
++RELOC_TYPE (GOT_OFST,           0)
++RELOC_TYPE (GOT_HI16,           0)
++RELOC_TYPE (GOT_LO16,           0)
++RELOC_TYPE (SUB,                0)
++RELOC_TYPE (INSERT_A,           0)
++RELOC_TYPE (INSERT_B,           0)
++RELOC_TYPE (DELETE,             0)
++RELOC_TYPE (HIGHER,             0)
++RELOC_TYPE (HIGHEST,            0)
++RELOC_TYPE (CALL_HI16,          0)
++RELOC_TYPE (CALL_LO16,          0)
++RELOC_TYPE (SCN_DISP,           0)
++RELOC_TYPE (REL16,              0)
++RELOC_TYPE (ADD_IMMEDIATE,      0)
++RELOC_TYPE (PJUMP,              0)
++RELOC_TYPE (RELGOT,             0)
++RELOC_TYPE (JALR,               0)
++RELOC_TYPE (TLS_DTPMOD32,       0)
++RELOC_TYPE (TLS_DTPREL32,       0)
++RELOC_TYPE (TLS_DTPMOD64,       0)
++RELOC_TYPE (TLS_DTPREL64,       0)
++RELOC_TYPE (TLS_GD,             0)
++RELOC_TYPE (TLS_LDM,            0)
++RELOC_TYPE (TLS_DTPREL_HI16,    0)
++RELOC_TYPE (TLS_DTPREL_LO16,    0)
++RELOC_TYPE (TLS_GOTTPREL,       0)
++RELOC_TYPE (TLS_TPREL32,        0)
++RELOC_TYPE (TLS_TPREL64,        0)
++RELOC_TYPE (TLS_TPREL_HI16,     0)
++RELOC_TYPE (TLS_TPREL_LO16,     0)
++
++#define NO_COPY_RELOC 1
++#define NO_RELATIVE_RELOC 1
+Index: b/backends/mips_retval.c
+===================================================================
+--- /dev/null
++++ b/backends/mips_retval.c
+@@ -0,0 +1,321 @@
++/* Function return value location for Linux/mips ABI.
++   Copyright (C) 2005 Red Hat, Inc.
++   This file is part of Red Hat elfutils.
++
++   Red Hat elfutils is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by the
++   Free Software Foundation; version 2 of the License.
++
++   Red Hat elfutils is distributed in the hope that it will be useful, but
++   WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   General Public License for more details.
++
++   You should have received a copy of the GNU General Public License along
++   with Red Hat elfutils; if not, write to the Free Software Foundation,
++   Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301 USA.
++
++   Red Hat elfutils is an included package of the Open Invention Network.
++   An included package of the Open Invention Network is a package for which
++   Open Invention Network licensees cross-license their patents.  No patent
++   license is granted, either expressly or impliedly, by designation as an
++   included package.  Should you wish to participate in the Open Invention
++   Network licensing program, please visit www.openinventionnetwork.com
++   <http://www.openinventionnetwork.com>.  */
++
++#ifdef HAVE_CONFIG_H
++# include <config.h>
++#endif
++
++#include <string.h>
++#include <assert.h>
++#include <dwarf.h>
++#include <elf.h>
++
++#include "../libebl/libeblP.h"
++#include "../libdw/libdwP.h"
++
++#define BACKEND mips_
++#include "libebl_CPU.h"
++
++/* The ABI of the file.  Also see EF_MIPS_ABI2 above. */
++#define EF_MIPS_ABI		0x0000F000
++
++/* The original o32 abi. */
++#define E_MIPS_ABI_O32          0x00001000
++
++/* O32 extended to work on 64 bit architectures */
++#define E_MIPS_ABI_O64          0x00002000
++
++/* EABI in 32 bit mode */
++#define E_MIPS_ABI_EABI32       0x00003000
++
++/* EABI in 64 bit mode */
++#define E_MIPS_ABI_EABI64       0x00004000
++
++/* All the possible MIPS ABIs. */
++enum mips_abi
++  {
++    MIPS_ABI_UNKNOWN = 0,
++    MIPS_ABI_N32,
++    MIPS_ABI_O32,
++    MIPS_ABI_N64,
++    MIPS_ABI_O64,
++    MIPS_ABI_EABI32,
++    MIPS_ABI_EABI64,
++    MIPS_ABI_LAST
++  };
++
++/* Find the mips ABI of the current file */
++enum mips_abi find_mips_abi(Elf *elf)
++{
++  GElf_Ehdr ehdr_mem;
++  GElf_Ehdr *ehdr = gelf_getehdr (elf, &ehdr_mem);
++
++  if (ehdr == NULL)
++    return MIPS_ABI_LAST;
++
++  GElf_Word elf_flags = ehdr->e_flags;
++
++  /* Check elf_flags to see if it specifies the ABI being used.  */
++  switch ((elf_flags & EF_MIPS_ABI))
++    {
++    case E_MIPS_ABI_O32:
++      return MIPS_ABI_O32;
++    case E_MIPS_ABI_O64:
++      return MIPS_ABI_O64;
++    case E_MIPS_ABI_EABI32:
++      return MIPS_ABI_EABI32;
++    case E_MIPS_ABI_EABI64:
++      return MIPS_ABI_EABI64;
++    default:
++      if ((elf_flags & EF_MIPS_ABI2))
++	return MIPS_ABI_N32;
++    }
++
++  /* GCC creates a pseudo-section whose name describes the ABI.  */
++  size_t shstrndx;
++  if (elf_getshdrstrndx (elf, &shstrndx) < 0)
++    return MIPS_ABI_LAST;
++
++  const char *name;
++  Elf_Scn *scn = NULL;
++  while ((scn = elf_nextscn (elf, scn)) != NULL)
++    {
++      GElf_Shdr shdr_mem;
++      GElf_Shdr *shdr = gelf_getshdr (scn, &shdr_mem);
++      if (shdr == NULL)
++        return MIPS_ABI_LAST;
++
++      name = elf_strptr (elf, shstrndx, shdr->sh_name) ?: "";
++      if (strncmp (name, ".mdebug.", 8) != 0)
++        continue;
++
++      if (strcmp (name, ".mdebug.abi32") == 0)
++        return MIPS_ABI_O32;
++      else if (strcmp (name, ".mdebug.abiN32") == 0)
++        return MIPS_ABI_N32;
++      else if (strcmp (name, ".mdebug.abi64") == 0)
++        return MIPS_ABI_N64;
++      else if (strcmp (name, ".mdebug.abiO64") == 0)
++        return MIPS_ABI_O64;
++      else if (strcmp (name, ".mdebug.eabi32") == 0)
++        return MIPS_ABI_EABI32;
++      else if (strcmp (name, ".mdebug.eabi64") == 0)
++        return MIPS_ABI_EABI64;
++      else
++        return MIPS_ABI_UNKNOWN;
++    }
++
++  return MIPS_ABI_UNKNOWN;
++}
++
++unsigned int
++mips_abi_regsize (enum mips_abi abi)
++{
++  switch (abi)
++    {
++    case MIPS_ABI_EABI32:
++    case MIPS_ABI_O32:
++      return 4;
++    case MIPS_ABI_N32:
++    case MIPS_ABI_N64:
++    case MIPS_ABI_O64:
++    case MIPS_ABI_EABI64:
++      return 8;
++    case MIPS_ABI_UNKNOWN:
++    case MIPS_ABI_LAST:
++    default:
++      return 0;
++    }
++}
++
++
++/* $v0 or pair $v0, $v1 */
++static const Dwarf_Op loc_intreg_o32[] =
++  {
++    { .atom = DW_OP_reg2 }, { .atom = DW_OP_piece, .number = 4 },
++    { .atom = DW_OP_reg3 }, { .atom = DW_OP_piece, .number = 4 },
++  };
++
++static const Dwarf_Op loc_intreg[] =
++  {
++    { .atom = DW_OP_reg2 }, { .atom = DW_OP_piece, .number = 8 },
++    { .atom = DW_OP_reg3 }, { .atom = DW_OP_piece, .number = 8 },
++  };
++#define nloc_intreg	1
++#define nloc_intregpair	4
++
++/* $f0 (float), or pair $f0, $f1 (double).
++ * f2/f3 are used for COMPLEX (= 2 doubles) returns in Fortran */
++static const Dwarf_Op loc_fpreg_o32[] =
++  {
++    { .atom = DW_OP_regx, .number = 32 }, { .atom = DW_OP_piece, .number = 4 },
++    { .atom = DW_OP_regx, .number = 33 }, { .atom = DW_OP_piece, .number = 4 },
++    { .atom = DW_OP_regx, .number = 34 }, { .atom = DW_OP_piece, .number = 4 },
++    { .atom = DW_OP_regx, .number = 35 }, { .atom = DW_OP_piece, .number = 4 },
++  };
++
++/* $f0, or pair $f0, $f2.  */
++static const Dwarf_Op loc_fpreg[] =
++  {
++    { .atom = DW_OP_regx, .number = 32 }, { .atom = DW_OP_piece, .number = 8 },
++    { .atom = DW_OP_regx, .number = 34 }, { .atom = DW_OP_piece, .number = 8 },
++  };
++#define nloc_fpreg  1
++#define nloc_fpregpair 4
++#define nloc_fpregquad 8
++
++/* The return value is a structure and is actually stored in stack space
++   passed in a hidden argument by the caller.  But, the compiler
++   helpfully returns the address of that space in $v0.  */
++static const Dwarf_Op loc_aggregate[] =
++  {
++    { .atom = DW_OP_breg2, .number = 0 }
++  };
++#define nloc_aggregate 1
++
++int
++mips_return_value_location (Dwarf_Die *functypedie, const Dwarf_Op **locp)
++{
++  /* First find the ABI used by the elf object */
++  enum mips_abi abi = find_mips_abi(functypedie->cu->dbg->elf);
++
++  /* Something went seriously wrong while trying to figure out the ABI */
++  if (abi == MIPS_ABI_LAST)
++    return -1;
++
++  /* We couldn't identify the ABI, but the file seems valid */
++  if (abi == MIPS_ABI_UNKNOWN)
++    return -2;
++
++  /* Can't handle EABI variants */
++  if ((abi == MIPS_ABI_EABI32) || (abi == MIPS_ABI_EABI64))
++    return -2;
++
++  unsigned int regsize = mips_abi_regsize (abi);
++  if (!regsize)
++    return -2;
++
++  /* Start with the function's type, and get the DW_AT_type attribute,
++     which is the type of the return value.  */
++
++  Dwarf_Attribute attr_mem;
++  Dwarf_Attribute *attr = dwarf_attr_integrate (functypedie, DW_AT_type, &attr_mem);
++  if (attr == NULL)
++    /* The function has no return value, like a `void' function in C.  */
++    return 0;
++
++  Dwarf_Die die_mem;
++  Dwarf_Die *typedie = dwarf_formref_die (attr, &die_mem);
++  int tag = dwarf_tag (typedie);
++
++  /* Follow typedefs and qualifiers to get to the actual type.  */
++  while (tag == DW_TAG_typedef
++	 || tag == DW_TAG_const_type || tag == DW_TAG_volatile_type
++	 || tag == DW_TAG_restrict_type)
++    {
++      attr = dwarf_attr_integrate (typedie, DW_AT_type, &attr_mem);
++      typedie = dwarf_formref_die (attr, &die_mem);
++      tag = dwarf_tag (typedie);
++    }
++
++  switch (tag)
++    {
++    case -1:
++      return -1;
++
++    case DW_TAG_subrange_type:
++      if (! dwarf_hasattr_integrate (typedie, DW_AT_byte_size))
++	{
++	  attr = dwarf_attr_integrate (typedie, DW_AT_type, &attr_mem);
++	  typedie = dwarf_formref_die (attr, &die_mem);
++	  tag = dwarf_tag (typedie);
++	}
++      /* Fall through.  */
++
++    case DW_TAG_base_type:
++    case DW_TAG_enumeration_type:
++    case DW_TAG_pointer_type:
++    case DW_TAG_ptr_to_member_type:
++      {
++        Dwarf_Word size;
++	if (dwarf_formudata (dwarf_attr_integrate (typedie, DW_AT_byte_size,
++					 &attr_mem), &size) != 0)
++	  {
++	    if (tag == DW_TAG_pointer_type || tag == DW_TAG_ptr_to_member_type)
++	      size = regsize;
++	    else
++	      return -1;
++	  }
++	if (tag == DW_TAG_base_type)
++	  {
++	    Dwarf_Word encoding;
++	    if (dwarf_formudata (dwarf_attr_integrate (typedie, DW_AT_encoding,
++					     &attr_mem), &encoding) != 0)
++	      return -1;
++
++#define ABI_LOC(loc, regsize) ((regsize) == 4 ? (loc ## _o32) : (loc))
++
++	    if (encoding == DW_ATE_float)
++	      {
++		*locp = ABI_LOC(loc_fpreg, regsize);
++		if (size <= regsize)
++		    return nloc_fpreg;
++
++		if (size <= 2*regsize)
++                  return nloc_fpregpair;
++
++		if (size <= 4*regsize && abi == MIPS_ABI_O32)
++                  return nloc_fpregquad;
++
++		goto aggregate;
++	      }
++	  }
++	*locp = ABI_LOC(loc_intreg, regsize);
++	if (size <= regsize)
++	  return nloc_intreg;
++	if (size <= 2*regsize)
++	  return nloc_intregpair;
++
++	/* Else fall through. Shouldn't happen though (at least with gcc) */
++      }
++
++    case DW_TAG_structure_type:
++    case DW_TAG_class_type:
++    case DW_TAG_union_type:
++    case DW_TAG_array_type:
++    aggregate:
++      /* XXX TODO: Can't handle structure return with other ABI's yet :-/ */
++      if ((abi != MIPS_ABI_O32) && (abi != MIPS_ABI_O64))
++        return -2;
++
++      *locp = loc_aggregate;
++      return nloc_aggregate;
++    }
++
++  /* XXX We don't have a good way to return specific errors from ebl calls.
++     This value means we do not understand the type, but it is well-formed
++     DWARF and might be valid.  */
++  return -2;
++}
+Index: b/backends/mips_symbol.c
+===================================================================
+--- /dev/null
++++ b/backends/mips_symbol.c
+@@ -0,0 +1,52 @@
++/* MIPS specific symbolic name handling.
++   Copyright (C) 2002, 2003, 2005 Red Hat, Inc.
++   This file is part of Red Hat elfutils.
++   Written by Jakub Jelinek <jakub@redhat.com>, 2002.
++
++   Red Hat elfutils is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by the
++   Free Software Foundation; version 2 of the License.
++
++   Red Hat elfutils is distributed in the hope that it will be useful, but
++   WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   General Public License for more details.
++
++   You should have received a copy of the GNU General Public License along
++   with Red Hat elfutils; if not, write to the Free Software Foundation,
++   Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301 USA.
++
++   Red Hat elfutils is an included package of the Open Invention Network.
++   An included package of the Open Invention Network is a package for which
++   Open Invention Network licensees cross-license their patents.  No patent
++   license is granted, either expressly or impliedly, by designation as an
++   included package.  Should you wish to participate in the Open Invention
++   Network licensing program, please visit www.openinventionnetwork.com
++   <http://www.openinventionnetwork.com>.  */
++
++#ifdef HAVE_CONFIG_H
++# include <config.h>
++#endif
++
++#include <elf.h>
++#include <stddef.h>
++
++#define BACKEND		mips_
++#include "libebl_CPU.h"
++
++/* Check for the simple reloc types.  */
++Elf_Type
++mips_reloc_simple_type (Ebl *ebl __attribute__ ((unused)), int type)
++{
++  switch (type)
++    {
++    case R_MIPS_16:
++      return ELF_T_HALF;
++    case R_MIPS_32:
++      return ELF_T_WORD;
++    case R_MIPS_64:
++      return ELF_T_XWORD;
++    default:
++      return ELF_T_NUM;
++    }
++}
+Index: b/libebl/eblopenbackend.c
+===================================================================
+--- a/libebl/eblopenbackend.c
++++ b/libebl/eblopenbackend.c
+@@ -71,6 +71,8 @@ static const struct
+   { "sparc", "elf_sparc", "sparc", 5, EM_SPARC, 0, 0 },
+   { "sparc", "elf_sparcv8plus", "sparc", 5, EM_SPARC32PLUS, 0, 0 },
+   { "s390", "ebl_s390", "s390", 4, EM_S390, 0, 0 },
++  { "mips", "elf_mips", "mips", 4, EM_MIPS, 0, 0 },
++  { "mips", "elf_mipsel", "mipsel", 4, EM_MIPS_RS3_LE, 0, 0 },
+ 
+   { "m32", "elf_m32", "m32", 3, EM_M32, 0, 0 },
+   { "m68k", "elf_m68k", "m68k", 4, EM_68K, ELFCLASS32, ELFDATA2MSB },
+Index: b/backends/Makefile.am
+===================================================================
+--- a/backends/Makefile.am
++++ b/backends/Makefile.am
+@@ -33,12 +33,12 @@ AM_CPPFLAGS += -I$(top_srcdir)/libebl -I
+ 
+ 
+ modules = i386 sh x86_64 ia64 alpha arm aarch64 sparc ppc ppc64 s390 \
+-	  tilegx m68k bpf parisc
++	  tilegx m68k bpf parisc mips
+ libebl_pic = libebl_i386_pic.a libebl_sh_pic.a libebl_x86_64_pic.a    \
+ 	     libebl_ia64_pic.a libebl_alpha_pic.a libebl_arm_pic.a    \
+ 	     libebl_aarch64_pic.a libebl_sparc_pic.a libebl_ppc_pic.a \
+ 	     libebl_ppc64_pic.a libebl_s390_pic.a libebl_tilegx_pic.a \
+-	     libebl_m68k_pic.a libebl_bpf_pic.a libebl_parisc_pic.a
++	     libebl_m68k_pic.a libebl_bpf_pic.a libebl_parisc_pic.a libebl_mips_pic.a
+ noinst_LIBRARIES = $(libebl_pic)
+ noinst_DATA = $(libebl_pic:_pic.a=.so)
+ 
+@@ -132,6 +132,10 @@ parisc_SRCS = parisc_init.c parisc_symbo
+ libebl_parisc_pic_a_SOURCES = $(parisc_SRCS)
+ am_libebl_parisc_pic_a_OBJECTS = $(parisc_SRCS:.c=.os)
+ 
++mips_SRCS = mips_init.c mips_symbol.c mips_regs.c mips_retval.c
++libebl_mips_pic_a_SOURCES = $(mips_SRCS)
++am_libebl_mips_pic_a_OBJECTS = $(mips_SRCS:.c=.os)
++
+ libebl_%.so libebl_%.map: libebl_%_pic.a $(libelf) $(libdw)
+ 	@rm -f $(@:.so=.map)
+ 	$(AM_V_at)echo 'ELFUTILS_$(PACKAGE_VERSION) { global: $*_init; local: *; };' \

--- a/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/debian/mips_readelf_w.patch
+++ b/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/debian/mips_readelf_w.patch
@@ -1,0 +1,25 @@
+From: Kurt Roeckx <kurt@roeckx.be>
+Subject: Make readelf -w output debug information on mips
+Bug-Debian: http://bugs.debian.org/662041
+Forwarded: not-needed
+
+Upstreams wants a change where this is handled by a hook that needs
+to be filled in by the backend for the arch.
+
+Upstream-Status: Backport [from debian]
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+
+Index: b/src/readelf.c
+===================================================================
+--- a/src/readelf.c
++++ b/src/readelf.c
+@@ -8343,7 +8343,8 @@ print_debug (Dwfl_Module *dwflmod, Ebl *
+       GElf_Shdr shdr_mem;
+       GElf_Shdr *shdr = gelf_getshdr (scn, &shdr_mem);
+ 
+-      if (shdr != NULL && shdr->sh_type == SHT_PROGBITS)
++      if (shdr != NULL && (
++	 (shdr->sh_type == SHT_PROGBITS) || (shdr->sh_type == SHT_MIPS_DWARF)))
+ 	{
+ 	  static const struct
+ 	  {

--- a/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/debian/testsuite-ignore-elflint.diff
+++ b/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/debian/testsuite-ignore-elflint.diff
@@ -1,0 +1,42 @@
+On many architectures this test fails because binaries/libs produced by
+binutils don't pass elflint. However elfutils shouldn't FTBFS because of this.
+
+So we run the tests on all archs to see what breaks, but if it breaks we ignore
+the result (exitcode 77 means: this test was skipped).
+
+Upstream-Status: Backport [from debian]
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+
+Index: b/tests/run-elflint-self.sh
+===================================================================
+--- a/tests/run-elflint-self.sh
++++ b/tests/run-elflint-self.sh
+@@ -18,4 +18,4 @@
+ 
+ . $srcdir/test-subr.sh
+ 
+-testrun_on_self ${abs_top_builddir}/src/elflint --quiet --gnu-ld
++testrun_on_self_skip ${abs_top_builddir}/src/elflint --quiet --gnu-ld
+Index: b/tests/test-subr.sh
+===================================================================
+--- a/tests/test-subr.sh
++++ b/tests/test-subr.sh
+@@ -152,3 +152,18 @@ testrun_on_self_quiet()
+   # Only exit if something failed
+   if test $exit_status != 0; then exit $exit_status; fi
+ }
++
++# Same as testrun_on_self(), but skip on failure.
++testrun_on_self_skip()
++{
++  exit_status=0
++
++  for file in $self_test_files; do
++      testrun $* $file \
++	  || { echo "*** failure in $* $file"; exit_status=77; }
++  done
++
++  # Only exit if something failed
++  if test $exit_status != 0; then exit $exit_status; fi
++}
++

--- a/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/fallthrough.patch
+++ b/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/fallthrough.patch
@@ -1,0 +1,36 @@
+GCC7 adds -Wimplicit-fallthrough to warn when a switch case falls through,
+however this causes warnings (which are promoted to errors) with the elfutils
+patches from Debian for mips and parisc, which use fallthrough's by design.
+
+Explicitly mark the intentional fallthrough switch cases with a comment to
+disable the warnings where the fallthrough behaviour is desired.
+
+Upstream-Status: Pending [debian]
+Signed-off-by: Joshua Lock <joshua.g.lock@intel.com>
+
+Index: elfutils-0.168/backends/parisc_retval.c
+===================================================================
+--- elfutils-0.168.orig/backends/parisc_retval.c
++++ elfutils-0.168/backends/parisc_retval.c
+@@ -166,7 +166,7 @@ parisc_return_value_location_ (Dwarf_Die
+ 	  return nloc_intregpair;
+ 
+ 	/* Else fall through.  */
+-      }
++      } // fallthrough
+ 
+     case DW_TAG_structure_type:
+     case DW_TAG_class_type:
+Index: elfutils-0.168/backends/mips_retval.c
+===================================================================
+--- elfutils-0.168.orig/backends/mips_retval.c
++++ elfutils-0.168/backends/mips_retval.c
+@@ -387,7 +387,7 @@ mips_return_value_location (Dwarf_Die *f
+               else
+                 return nloc_intregpair;
+             }
+-        }
++        } // fallthrough
+ 
+       /* Fallthrough to handle large types */
+ 

--- a/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/fixheadercheck.patch
+++ b/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/fixheadercheck.patch
@@ -1,0 +1,23 @@
+For some binaries we can get a invalid section alignment, for example if 
+sh_align = 1 and sh_addralign is 0. In the case of a zero size section like 
+".note.GNU-stack", this is irrelavent as far as I can tell and we shouldn't
+error in this case.
+
+RP 2014/6/11
+
+Upstream-Status: Pending
+
+diff --git a/libelf/elf32_updatenull.c b/libelf/elf32_updatenull.c
+--- a/libelf/elf32_updatenull.c
++++ b/libelf/elf32_updatenull.c
+@@ -339,8 +339,8 @@ __elfw2(LIBELFBITS,updatenull_wrlock) (Elf *elf, int *change_bop, size_t shnum)
+ 		     we test for the alignment of the section being large
+ 		     enough for the largest alignment required by a data
+ 		     block.  */
+-		  if (unlikely (! powerof2 (shdr->sh_addralign))
+-		      || unlikely ((shdr->sh_addralign ?: 1) < sh_align))
++		  if (shdr->sh_size && (unlikely (! powerof2 (shdr->sh_addralign))
++		      || unlikely ((shdr->sh_addralign ?: 1) < sh_align)))
+ 		    {
+ 		      __libelf_seterrno (ELF_E_INVALID_ALIGN);
+ 		      return -1;

--- a/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/shadow.patch
+++ b/meta-openpli/recipes-devtools/elfutils/elfutils-0.168/shadow.patch
@@ -1,0 +1,23 @@
+Fix control path where we have str as uninitialized string
+
+| /home/ubuntu/work/oe/openembedded-core/build/tmp-musl/work/i586-oe-linux-musl/elfutils/0.164-r0/elfutils-0.164/libcpu/i386_disasm.c: In function 'i386_disasm':
+| /home/ubuntu/work/oe/openembedded-core/build/tmp-musl/work/i586-oe-linux-musl/elfutils/0.164-r0/elfutils-0.164/libcpu/i386_disasm.c:310:5: error: 'str' may be used uninitialized in this function [-Werror=maybe-uninitialized]
+|      memcpy (buf + bufcnt, _str, _len);           \
+|      ^
+| /home/ubuntu/work/oe/openembedded-core/build/tmp-musl/work/i586-oe-linux-musl/elfutils/0.164-r0/elfutils-0.164/libcpu/i386_disasm.c:709:17: note: 'str' was declared here
+|      const char *str;
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Upstream-Status: Pending
+Index: elfutils-0.164/libcpu/i386_disasm.c
+===================================================================
+--- elfutils-0.164.orig/libcpu/i386_disasm.c
++++ elfutils-0.164/libcpu/i386_disasm.c
+@@ -821,6 +821,7 @@ i386_disasm (const uint8_t **startp, con
+ 			    }
+ 
+ 			default:
++			  str = "";
+ 			  assert (! "INVALID not handled");
+ 			}
+ 		    }

--- a/meta-openpli/recipes-devtools/elfutils/elfutils/Fix_elf_cvt_gunhash.patch
+++ b/meta-openpli/recipes-devtools/elfutils/elfutils/Fix_elf_cvt_gunhash.patch
@@ -1,0 +1,29 @@
+Fix elf_cvt_gunhash if dest and src are same.
+
+Upstream-Status: Pending
+
+The 'dest' and 'src' can be same, we need to save the value of src32[2]
+before swaping it.
+
+Signed-off-by: Baoshan Pang <BaoShan.Pang@windriver.com>
+diff --git a/libelf/gnuhash_xlate.h b/libelf/gnuhash_xlate.h
+index 6faf113..04d9ca1 100644
+--- a/libelf/gnuhash_xlate.h
++++ b/libelf/gnuhash_xlate.h
+@@ -40,6 +40,7 @@ elf_cvt_gnuhash (void *dest, const void *src, size_t len, int encode)
+      words.  We must detangle them here.   */
+   Elf32_Word *dest32 = dest;
+   const Elf32_Word *src32 = src;
++  Elf32_Word save_src32_2 = src32[2]; // dest could be equal to src
+ 
+   /* First four control words, 32 bits.  */
+   for (unsigned int cnt = 0; cnt < 4; ++cnt)
+@@ -50,7 +51,7 @@ elf_cvt_gnuhash (void *dest, const void *src, size_t len, int encode)
+       len -= 4;
+     }
+ 
+-  Elf32_Word bitmask_words = encode ? src32[2] : dest32[2];
++  Elf32_Word bitmask_words = encode ? save_src32_2 : dest32[2];
+ 
+   /* Now the 64 bit words.  */
+   Elf64_Xword *dest64 = (Elf64_Xword *) &dest32[4];

--- a/meta-openpli/recipes-devtools/elfutils/elfutils/dso-link-change.patch
+++ b/meta-openpli/recipes-devtools/elfutils/elfutils/dso-link-change.patch
@@ -1,0 +1,32 @@
+Upstream-Status: Pending
+
+# This patch makes the link to the dependencies of libdw explicit, as recent
+# ld no longer implicitly links them. See
+# http://lists.fedoraproject.org/pipermail/devel/2010-March/133601.html as
+# a similar example of the error message you can encounter without this patch,
+# and https://fedoraproject.org/wiki/UnderstandingDSOLinkChange and
+# https://fedoraproject.org/wiki/Features/ChangeInImplicitDSOLinking for more
+# details.
+
+--- elfutils-0.148.orig/src/Makefile.am
++++ elfutils-0.148/src/Makefile.am
+@@ -86,7 +86,7 @@ libdw = ../libdw/libdw.a $(zip_LIBS) $(l
+ libelf = ../libelf/libelf.a
+ else
+ libasm = ../libasm/libasm.so
+-libdw = ../libdw/libdw.so
++libdw = ../libdw/libdw.so $(zip_LIBS) $(libelf) $(libebl) -ldl
+ libelf = ../libelf/libelf.so
+ endif
+ libebl = ../libebl/libebl.a
+--- elfutils-0.148.orig/tests/Makefile.am
++++ elfutils-0.148/tests/Makefile.am
+@@ -172,7 +172,7 @@ libdw = ../libdw/libdw.a $(zip_LIBS) $(l
+ libelf = ../libelf/libelf.a
+ libasm = ../libasm/libasm.a
+ else
+-libdw = ../libdw/libdw.so
++libdw = ../libdw/libdw.so $(zip_LIBS) $(libelf) $(libebl) -ldl
+ libelf = ../libelf/libelf.so
+ libasm = ../libasm/libasm.so
+ endif

--- a/meta-openpli/recipes-devtools/elfutils/elfutils_0.168.bb
+++ b/meta-openpli/recipes-devtools/elfutils/elfutils_0.168.bb
@@ -1,0 +1,84 @@
+SUMMARY = "Utilities and libraries for handling compiled object files"
+HOMEPAGE = "https://sourceware.org/elfutils"
+SECTION = "base"
+LICENSE = "(GPLv3 & Elfutils-Exception)"
+LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
+DEPENDS = "libtool bzip2 zlib virtual/libintl"
+DEPENDS_append_libc-musl = " argp-standalone fts "
+SRC_URI = "https://sourceware.org/elfutils/ftp/${PV}/${BP}.tar.bz2"
+SRC_URI[md5sum] = "52adfa40758d0d39e5d5c57689bf38d6"
+SRC_URI[sha256sum] = "b88d07893ba1373c7dd69a7855974706d05377766568a7d9002706d5de72c276"
+
+SRC_URI += "\
+        file://dso-link-change.patch \
+        file://Fix_elf_cvt_gunhash.patch \
+        file://fixheadercheck.patch \
+        file://0001-elf_getarsym-Silence-Werror-maybe-uninitialized-fals.patch \
+        file://0001-remove-the-unneed-checking.patch \
+        file://0001-fix-a-stack-usage-warning.patch \
+        file://aarch64_uio.patch \
+        file://Fix_one_GCC7_warning.patch \
+        file://shadow.patch \
+"
+
+# pick the patch from debian
+# http://ftp.de.debian.org/debian/pool/main/e/elfutils/elfutils_0.168-0.2.debian.tar.xz
+SRC_URI += "\
+        file://debian/hppa_backend.diff \
+        file://debian/arm_backend.diff \
+        file://debian/mips_backend.diff \
+        file://debian/testsuite-ignore-elflint.diff \
+        file://debian/mips_readelf_w.patch \
+        file://debian/kfreebsd_path.patch \
+        file://debian/0001-Ignore-differences-between-mips-machine-identifiers.patch \
+        file://debian/0002-Add-support-for-mips64-abis-in-mips_retval.c.patch \
+        file://debian/0003-Add-mips-n64-relocation-format-hack.patch \
+        file://debian/hurd_path.patch \
+        file://debian/ignore_strmerge.diff \
+"
+# Fix the patches from Debian with GCC7
+SRC_URI += "file://fallthrough.patch"
+SRC_URI_append_libc-musl = " file://0001-build-Provide-alternatives-for-glibc-assumptions-hel.patch "
+
+# The buildsystem wants to generate 2 .h files from source using a binary it just built,
+# which can not pass the cross compiling, so let's work around it by adding 2 .h files
+# along with the do_configure_prepend()
+
+inherit autotools gettext
+
+EXTRA_OECONF = "--program-prefix=eu- --without-lzma"
+EXTRA_OECONF_append_class-native = " --without-bzlib"
+
+do_install_append() {
+	if [ "${TARGET_ARCH}" != "x86_64" ] && [ -z `echo "${TARGET_ARCH}"|grep 'i.86'` ];then
+		rm -f ${D}${bindir}/eu-objdump
+	fi
+}
+
+EXTRA_OEMAKE_class-native = ""
+EXTRA_OEMAKE_class-nativesdk = ""
+
+ALLOW_EMPTY_${PN}_libc-musl = "1"
+
+BBCLASSEXTEND = "native nativesdk"
+
+# Package utilities separately
+PACKAGES =+ "${PN}-binutils libelf libasm libdw"
+FILES_${PN}-binutils = "\
+    ${bindir}/eu-addr2line \
+    ${bindir}/eu-ld \
+    ${bindir}/eu-nm \
+    ${bindir}/eu-readelf \
+    ${bindir}/eu-size \
+    ${bindir}/eu-strip"
+
+FILES_libelf = "${libdir}/libelf-${PV}.so ${libdir}/libelf.so.*"
+FILES_libasm = "${libdir}/libasm-${PV}.so ${libdir}/libasm.so.*"
+FILES_libdw  = "${libdir}/libdw-${PV}.so ${libdir}/libdw.so.* ${libdir}/elfutils/lib*"
+# Some packages have the version preceeding the .so instead properly
+# versioned .so.<version>, so we need to reorder and repackage.
+#FILES_${PN} += "${libdir}/*-${PV}.so ${base_libdir}/*-${PV}.so"
+#FILES_SOLIBSDEV = "${libdir}/libasm.so ${libdir}/libdw.so ${libdir}/libelf.so"
+
+# The package contains symlinks that trip up insane
+INSANE_SKIP_${MLPREFIX}libdw = "dev-so"

--- a/meta-openpli/recipes-devtools/gcc/files/ubsan-fix-check-empty-string.patch
+++ b/meta-openpli/recipes-devtools/gcc/files/ubsan-fix-check-empty-string.patch
@@ -1,0 +1,28 @@
+From 8db2cf6353c13f2a84cbe49b689654897906c499 Mon Sep 17 00:00:00 2001
+From: kyukhin <kyukhin@138bc75d-0d04-0410-961f-82ee72b054a4>
+Date: Sat, 3 Sep 2016 10:57:05 +0000
+Subject: [PATCH] gcc/ 	* ubsan.c (ubsan_use_new_style_p): Fix check for empty
+ string.
+
+git-svn-id: svn+ssh://gcc.gnu.org/svn/gcc/trunk@239971 138bc75d-0d04-0410-961f-82ee72b054a4
+
+Upstream-Status: Backport
+Signed-off-by: Joshua Lock <joshua.g.lock@intel.com>
+
+---
+ gcc/ubsan.c   | 2 +-
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+Index: gcc-6.3.0/gcc/ubsan.c
+===================================================================
+--- gcc-6.3.0.orig/gcc/ubsan.c
++++ gcc-6.3.0/gcc/ubsan.c
+@@ -1471,7 +1471,7 @@ ubsan_use_new_style_p (location_t loc)
+ 
+   expanded_location xloc = expand_location (loc);
+   if (xloc.file == NULL || strncmp (xloc.file, "\1", 2) == 0
+-      || xloc.file == '\0' || xloc.file[0] == '\xff'
++      || xloc.file[0] == '\0' || xloc.file[0] == '\xff'
+       || xloc.file[1] == '\xff')
+     return false;
+ 

--- a/meta-openpli/recipes-devtools/gcc/gcc-source_6.%.bbappend
+++ b/meta-openpli/recipes-devtools/gcc/gcc-source_6.%.bbappend
@@ -1,0 +1,5 @@
+SRC_URI =+ " \
+	file://ubsan-fix-check-empty-string.patch;patch=1 \
+	"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"


### PR DESCRIPTION
Tested on a clean installation of Fedora 26 using a clean build-directory
- Upgrade libelf from 0.166 to 0.168 (upstream OE)
- Backport upstream OE gcc patch
Tested from a clean state (no build directory) for zgemma h2h (mipsel) and the Mutant HD51 (arm)
Both images build without errors and work perfectly fine.