### PR TITLE
gcc-cross-initial: fix build

### DIFF
--- a/meta-openpli/recipes-devtools/gcc/gcc-cross-initial_6.%.bbappend
+++ b/meta-openpli/recipes-devtools/gcc/gcc-cross-initial_6.%.bbappend
@@ -1,0 +1,1 @@
+TARGET_CFLAGS=""


### PR DESCRIPTION
Introduced since commit:
http://git.openembedded.org/openembedded-core/commit/meta/classes/cross.bbclass?h=pyro&id=55c83cb239df5faf5e2143fffca47f2f16931cb3

checking for suffix of object files... configure: error: in `/home/hains/github/openpli-oe-core/
build/tmp/work/x86_64-linux/gcc-cross-initial-mipsel/6.3.0-r0/gcc-6.3.0/build.x86_64-linux.mipsel-oe-linux/mipsel-oe-linux/libgcc':
| configure: error: cannot compute suffix of object files: cannot compile
| See `config.log' for more details.
| Makefile:10709: recipe for target 'configure-target-libgcc' failed