### PR TITLE
glib-openssl: update to version 2.50.3

### DIFF
--- a/meta-openpli/recipes-core/glib-networking/glib-openssl_2.50.3.bb
+++ b/meta-openpli/recipes-core/glib-networking/glib-openssl_2.50.3.bb
@@ -9,8 +9,8 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=5f30f0716dfdd0d91eb439ebec522ec2"
 SECTION = "libs"
 DEPENDS = "glib-2.0 intltool-native openssl"
 
-SRC_URI[archive.md5sum] = "3331bc78aed330d993716fe636a939b6"
-SRC_URI[archive.sha256sum] = "1a381fce3a932f66ff3d6acab40b6153f8fe4db7371834fae182aec7cc8b62ae"
+SRC_URI[archive.md5sum] = "bd4746fcd00bf338af538bd765413a5b"
+SRC_URI[archive.sha256sum] = "0211c118b86aec228d2b7d2606bba9637d5bb5d60694cc7ccb6d2920f02866bc"
 
 inherit gnomebase gettext upstream-version-is-even gio-module-cache
 


### PR DESCRIPTION
Update to bugfix version 2.50.3 that includes a fix for verification of the certificate chain.
Related bug: https://bugzilla.gnome.org/show_bug.cgi?id=781854

Without this several https streams were failing with "Unacceptable TLS certificate".

$ gst-launch-1.0 souphttpsrc location=https://vodnowusohls.secure.footprint.net ! fakesink
Setting pipeline to PAUSED ...
Pipeline is PREROLLING ...
ERROR: from element /GstPipeline:pipeline0/GstSoupHTTPSrc:souphttpsrc0: Secure connection setup failed.
Additional debug info:
../../../git/ext/soup/gstsouphttpsrc.c(1279): gst_soup_http_src_parse_status (): /GstPipeline:pipeline0/GstSoupHTTPSrc:souphttpsrc0:
Unacceptable TLS certificate (6), URL: https://vodnowusohls.secure.footprint.net, Redirect to: (NULL)
ERROR: pipeline doesn't want to preroll.
Setting pipeline to NULL ...
Freeing pipeline ...

Thanks @atvcaptain for reporting the issue.