### PR TITLE
Revert "Set /etc/init.d/softcam softlink defaulty to oscam start/stop…

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-softcams/softcam-support.bb
+++ b/meta-openpli/recipes-openpli/enigma2-softcams/softcam-support.bb
@@ -27,6 +27,6 @@ do_compile_append() {
 pkg_postinst_${PN} () {
 	if [ ! -e "$D/etc/init.d/softcam" ]
 	then
-		ln -s softcam.oscam $D/etc/init.d/softcam
+		ln -s softcam.None $D/etc/init.d/softcam
 	fi
 }


### PR DESCRIPTION
… script"

This reverts commit 4d9d5ec0e2ba9c69b81ff3ef03c4dc6a95b14bbc.