### PR TITLE
Fix crash if you browser photos

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-dlnabrowser/enigma2-plugin-systemplugins-dlnabrowser_20130723.patch
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-dlnabrowser/enigma2-plugin-systemplugins-dlnabrowser_20130723.patch
@@ -2,6 +2,14 @@ diff --git a/lib/python/Plugins/Extensions/DLNABrowser/plugin.py b/lib/python/Pl
 index 884b5a0..3ffdfa7 100644
 --- a/lib/python/Plugins/Extensions/DLNABrowser/plugin.py
 +++ b/lib/python/Plugins/Extensions/DLNABrowser/plugin.py
+@@ -1,5 +1,7 @@
+ from Plugins.Plugin import PluginDescriptor
+
++from Plugins.Extensions.PicturePlayer.ui import *
++
+ import os
+ from enigma import gFont, eTimer, eConsoleAppContainer, ePicLoad, getDesktop, eServiceReference, iPlayableService, RT_HALIGN_LEFT, RT_HALIGN_RIGHT, RT_HALIGN_CENTER, RT_VALIGN_CENTER
+  
 @@ -903,6 +903,13 @@ class DLNADeviceBrowser(Screen):
  
  def main(session, **kwargs):


### PR DESCRIPTION
This is fixes crash on dlnabrowser plugin when browser photos.

`File "/usr/lib/enigma2/python/Plugins/Extensions/DLNABrowser/plugin.py", line 435, in layoutFinished
    self.setPictureLoadPara()
  File "/usr/lib/enigma2/python/Plugins/Extensions/DLNABrowser/plugin.py", line 477, in setPictureLoadPara
    int(config.pic.resize.value),
  File "/usr/lib/enigma2/python/Components/config.py", line 1644, in __getattr__
KeyError: 'pic'`