### PR TITLE
Add nodejs and python-pyexecjs to the feed

### DIFF
--- a/meta-openpli/recipes-devtools/nodejs/nodejs/fix_mips_build.patch
+++ b/meta-openpli/recipes-devtools/nodejs/nodejs/fix_mips_build.patch
@@ -1,0 +1,11 @@
+--- node-v4.4.3/configure	2017-04-13 23:46:06.407834520 +0200
++++ node-v4.4.3_neu/configure	2017-04-13 23:42:36.359333326 +0200
+@@ -235,7 +235,7 @@
+ parser.add_option('--with-mips-arch-variant',
+     action='store',
+     dest='mips_arch_variant',
+-    default='r2',
++    default='r1',
+     choices=valid_mips_arch,
+     help='MIPS arch variant ({0}) [default: %default]'.format(
+         ', '.join(valid_mips_arch)))

--- a/meta-openpli/recipes-devtools/nodejs/nodejs_%.bbappend
+++ b/meta-openpli/recipes-devtools/nodejs/nodejs_%.bbappend
@@ -1,0 +1,3 @@
+SRC_URI += "file://fix_mips_build.patch"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/nodejs:"

--- a/meta-openpli/recipes-devtools/python/python-flickrapi_1.4.2.bb
+++ b/meta-openpli/recipes-devtools/python/python-flickrapi_1.4.2.bb
@@ -15,7 +15,7 @@ RDEPENDS_${PN} = "\
   python-xml \
 "
 
-SRC_URI = "http://pypi.python.org/packages/source/f/flickrapi/flickrapi-${PV}.zip"
+SRC_URI = "https://pypi.python.org/packages/source/f/flickrapi/flickrapi-${PV}.zip"
 SRC_URI[md5sum] = "90dca08a45968b18da0894887f3e59b3"
 SRC_URI[sha256sum] = "ac9304f571175b8af4fc2ee17d3e110847b526640665ca53d97bbf9df98329bc"
 

--- a/meta-openpli/recipes-devtools/python/python-js2py_0.39.bb
+++ b/meta-openpli/recipes-devtools/python/python-js2py_0.39.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://PKG-INFO;md5=0e657c467f9c43e1e317b1ff5bef6c80"
 
 PR = "r0"
 
-SRC_URI = "http://pypi.python.org/packages/52/f8/e0d81d2a1db4025fa6dfa2e0a63f7234d958e11a0497e58c2ff15394c5cb/Js2Py-${PV}.tar.gz"
+SRC_URI = "https://pypi.python.org/packages/52/f8/e0d81d2a1db4025fa6dfa2e0a63f7234d958e11a0497e58c2ff15394c5cb/Js2Py-${PV}.tar.gz"
 
 S = "${WORKDIR}/Js2Py-${PV}"
 

--- a/meta-openpli/recipes-devtools/python/python-mechanize_0.2.5.bb
+++ b/meta-openpli/recipes-devtools/python/python-mechanize_0.2.5.bb
@@ -8,7 +8,7 @@ PR = "r2"
 
 RDEPENDS_${PN} = "python-core python-robotparser"
 
-SRC_URI = "http://pypi.python.org/packages/source/m/mechanize/mechanize-${PV}.tar.gz"
+SRC_URI = "https://pypi.python.org/packages/source/m/mechanize/mechanize-${PV}.tar.gz"
 
 SRC_URI[md5sum] = "32657f139fc2fb75bcf193b63b8c60b2"
 SRC_URI[sha256sum] = "2e67b20d107b30c00ad814891a095048c35d9d8cb9541801cebe85684cc84766"

--- a/meta-openpli/recipes-devtools/python/python-package-split.inc
+++ b/meta-openpli/recipes-devtools/python/python-package-split.inc
@@ -1,0 +1,65 @@
+inherit python-dir
+
+PACKAGES =+ " ${PN}-src ${PN}-test"
+RDEPENDS_{PN}-src = "${PN}"
+
+SSTATE_DUPWHITELIST += "${STAGING_LIBDIR}/python2.7/site-packages/tests/__init__.py ${STAGING_LIBDIR}/python2.7/site-packages/tests/__init__.pyo"
+
+FILES_${PN}-src = " \
+    ${PYTHON_SITEPACKAGES_DIR}/*.py \
+    ${PYTHON_SITEPACKAGES_DIR}/*/*.py \
+    ${PYTHON_SITEPACKAGES_DIR}/*/*/*.py \
+    ${PYTHON_SITEPACKAGES_DIR}/*/*/*/*.py \
+    ${PYTHON_SITEPACKAGES_DIR}/*/*/*/*/*.py \
+    ${PYTHON_SITEPACKAGES_DIR}/*/*/*/*/*/*.py \
+    ${PYTHON_SITEPACKAGES_DIR}/*.c \
+    ${PYTHON_SITEPACKAGES_DIR}/*/*.c \
+    ${PYTHON_SITEPACKAGES_DIR}/*/*/*.c \
+    ${PYTHON_SITEPACKAGES_DIR}/*/*/*/*.c \
+    ${PYTHON_SITEPACKAGES_DIR}/*/*/*/*/*.c \
+    ${PYTHON_SITEPACKAGES_DIR}/*.h \
+    ${PYTHON_SITEPACKAGES_DIR}/*/*.h \
+    ${PYTHON_SITEPACKAGES_DIR}/*/*/*.h \
+    ${PYTHON_SITEPACKAGES_DIR}/*/*/*/*.h \
+    ${PYTHON_SITEPACKAGES_DIR}/*/*/*/*/*.h \
+    "
+
+FILES_${PN}-test += " \
+    ${PYTHON_SITEPACKAGES_DIR}/test \
+    ${PYTHON_SITEPACKAGES_DIR}/tests \
+    ${PYTHON_SITEPACKAGES_DIR}/Test \
+    ${PYTHON_SITEPACKAGES_DIR}/Tests \
+    ${PYTHON_SITEPACKAGES_DIR}/*/test \
+    ${PYTHON_SITEPACKAGES_DIR}/*/tests \
+    ${PYTHON_SITEPACKAGES_DIR}/*/Test \
+    ${PYTHON_SITEPACKAGES_DIR}/*/Tests \
+    ${PYTHON_SITEPACKAGES_DIR}/*/*/test \
+    ${PYTHON_SITEPACKAGES_DIR}/*/*/tests \
+    ${PYTHON_SITEPACKAGES_DIR}/*/*/Test \
+    ${PYTHON_SITEPACKAGES_DIR}/*/*/Tests \
+"
+
+# some txt files which should go into -doc
+FILES_${PN}-doc += " \
+    ${PYTHON_SITEPACKAGES_DIR}/*-info \
+    ${PYTHON_SITEPACKAGES_DIR}/*/*-info \
+    ${PYTHON_SITEPACKAGES_DIR}/*-INFO \
+    ${PYTHON_SITEPACKAGES_DIR}/*/*-INFO \
+    ${PYTHON_SITEPACKAGES_DIR}/*-safe \
+    ${PYTHON_SITEPACKAGES_DIR}/*/*-safe \
+    ${PYTHON_SITEPACKAGES_DIR}/*.txt \
+    ${PYTHON_SITEPACKAGES_DIR}/*/*.txt \
+    ${PYTHON_SITEPACKAGES_DIR}/*/*/*.txt \
+    ${PYTHON_SITEPACKAGES_DIR}/doc \
+    ${PYTHON_SITEPACKAGES_DIR}/*/doc \
+    ${PYTHON_SITEPACKAGES_DIR}/LICENSE \
+    ${PYTHON_SITEPACKAGES_DIR}/README \
+    "
+
+FILES_${PN}-dbg += " \
+    ${PYTHON_SITEPACKAGES_DIR}/*/.debug \
+    ${PYTHON_SITEPACKAGES_DIR}/*/*/.debug \
+    ${PYTHON_SITEPACKAGES_DIR}/*/*/*/.debug \
+    ${PYTHON_SITEPACKAGES_DIR}/*/*/*/*/.debug \
+    ${PYTHON_SITEPACKAGES_DIR}/*.egg-info \
+    "

--- a/meta-openpli/recipes-devtools/python/python-pyexecjs_1.4.0.bb
+++ b/meta-openpli/recipes-devtools/python/python-pyexecjs_1.4.0.bb
@@ -1,0 +1,19 @@
+SUMMARY  = "JPyExecJS is a porting of ExecJS from Ruby. PyExecJS automatically picks the best runtime available to evaluate your JavaScript program."
+DESCRIPTION = "Run JavaScript code from Python"
+HOMEPAGE = "https://pypi.python.org/pypi/PyExecJS"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=70f9df77ea55ba7d1f19e18f62cf5bb6"
+
+PR = "r0"
+
+SRC_URI = "http://pypi.python.org/packages/b6/56/affb227598d7e42b28e7be24fe9240a84f3aa0cfd65a2abdbfdfd3d2f7c6/PyExecJS-${PV}.zip"
+
+S = "${WORKDIR}/PyExecJS-${PV}"
+
+inherit setuptools
+
+SRC_URI[md5sum] = "714edb64c8914e94eb45541e123c420b"
+SRC_URI[sha256sum] = "31346cdf19d1e64840f0104f8be1c1231cb9ce3de9919828419814567cc2e691"
+
+include python-package-split.inc

--- a/meta-openpli/recipes-devtools/python/python-pyexecjs_1.4.0.bb
+++ b/meta-openpli/recipes-devtools/python/python-pyexecjs_1.4.0.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=70f9df77ea55ba7d1f19e18f62cf5bb6"
 
 PR = "r0"
 
-SRC_URI = "http://pypi.python.org/packages/b6/56/affb227598d7e42b28e7be24fe9240a84f3aa0cfd65a2abdbfdfd3d2f7c6/PyExecJS-${PV}.zip"
+SRC_URI = "https://pypi.python.org/packages/b6/56/affb227598d7e42b28e7be24fe9240a84f3aa0cfd65a2abdbfdfd3d2f7c6/PyExecJS-${PV}.zip"
 
 S = "${WORKDIR}/PyExecJS-${PV}"
 

--- a/meta-openpli/recipes-openpli/images/openpli-enigma2-feed.bb
+++ b/meta-openpli/recipes-openpli/images/openpli-enigma2-feed.bb
@@ -53,6 +53,7 @@ OPTIONAL_PACKAGES += " \
 	mtools \
 	nano \
 	net-tools \
+	nodejs \
 	ntfs-3g \
 	ntp \
 	ofgwrite \
@@ -70,6 +71,7 @@ OPTIONAL_PACKAGES += " \
 	python-mechanize \
 	python-lxml \
 	python-js2py \
+	python-pyexecjs \
 	picocom \
 	ppp \
 	rsync \


### PR DESCRIPTION
It's a requirement for the MediaPortal plugin.
I can confirm it builds for both mips32el and both arm flavours (the one for Vu+ 4k and the one for hd51/vs1500).

See: https://forums.openpli.org/topic/55184-nodejs/