### PR TITLE
openpli.conf: add svn to hosttools

### DIFF
--- a/meta-openpli/conf/distro/openpli.conf
+++ b/meta-openpli/conf/distro/openpli.conf
@@ -92,5 +92,5 @@ PACKAGECONFIG_pn-curl = "${@bb.utils.contains("DISTRO_FEATURES", "ipv6", "ipv6",
 PACKAGECONFIG_pn-openldap = "openssl modules mdb ldap meta monitor null passwd shell proxycache dnssrv ${@bb.utils.contains('DISTRO_FEATURES', 'ipv6', 'ipv6', '', d)}"
 PACKAGECONFIG_pn-neon = "expat openssl libproxy webdav zlib"
 
-# Allow java and unzip executed on host
-HOSTTOOLS += "java unzip"
+# Allow java, svn and unzip executed on host
+HOSTTOOLS += "java svn unzip"


### PR DESCRIPTION
using host's subversion required on pyro, to fix ...failed with exit code 127, output:/usr/bin/env: 'svn': No such file or directory' error