### PR TITLE
inadyan-mt: update to version 2.24.44

### DIFF
--- a/meta-openpli/recipes-connectivity/inadyn-mt/inadyn-mt.bb
+++ b/meta-openpli/recipes-connectivity/inadyn-mt/inadyn-mt.bb
@@ -2,17 +2,19 @@ MAINTAINER = "Narcis Ilisei"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://COPYING;md5=3c34afdc3adf82d2448f12715a255122"
 
-SRCDATE = "20100519"
-PV = "v.02.18.24+cvs${SRCDATE}"
+PV = "v.02.24.44"
 PR = "r3"
 
-SRC_URI = "cvs://anonymous@inadyn-mt.cvs.sourceforge.net/cvsroot/inadyn-mt;module=${PN};tag=unicows;date=${SRCDATE} \
+SRC_URI = "https://sourceforge.net/projects/inadyn-mt/files/inadyn-mt/inadyn-mt.${PV}/inadyn-mt.${PV}.tar.gz \
 	file://inadyn-mt.sh \
 	file://inadyn.conf \
 	file://remove_host_include_paths.patch \
 	"
 
-S = "${WORKDIR}/${PN}"
+SRC_URI[md5sum] = "0652d99aab1249d6a3afe4d65861e77b"
+SRC_URI[sha256sum] = "f894b5ab92ed4ec4cae2eccc99efef1aa18c0f5f02de66025e50833cc9063c3c"
+
+S = "${WORKDIR}/inadyn-mt.${PV}"
 
 inherit autotools-brokensep update-rc.d
 


### PR DESCRIPTION
Get rid of cvs since it's down for a long time.