### PR TITLE
Backup Suite: Allow localization

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-backupsuite.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-backupsuite.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
 SRC_URI = "git://github.com/persianpros/BackupSuite.git;protocol=git"
 
-inherit gitpkgv
+inherit gitpkgv gettext
 
 S = "${WORKDIR}/git"
 SRC = "${S}/usr/lib/enigma2/python/Plugins/Extensions/BackupSuite"


### PR DESCRIPTION
We don't provide ".mo" files anymore, See: https://github.com/persianpros/BackupSuite/commit/aedad62e210aeb53d3723ebc11a46f558c85d8de