### PR TITLE
python-2.7: silence non staticdev package contains static.a library w…

### DIFF
--- a/meta-openpli/recipes-devtools/python/python_2.7.13.bbappend
+++ b/meta-openpli/recipes-devtools/python/python_2.7.13.bbappend
@@ -30,5 +30,9 @@ FILES_${PN}-src += "${libdir}/python${PYTHON_MAJMIN}/*/*.whl"
 FILES_${PN}-src += "${libdir}/python${PYTHON_MAJMIN}/*/*/*.whl"
 FILES_${PN}-src += "${libdir}/python${PYTHON_MAJMIN}/config/*"
 
+do_install_append () {
+	rm ${D}${libdir}/python${PYTHON_MAJMIN}/config/libpython${PYTHON_MAJMIN}.a
+}
+
 # some additional tests
 FILES_${PN}-tests += "${libdir}/python${PYTHON_MAJMIN}/*/test* ${libdir}/python${PYTHON_MAJMIN}/*/*/test*"


### PR DESCRIPTION
…arning

WARNING: python-2.7.13-r1 do_package_qa: QA Issue: non -staticdev package contains static .a library:
python-src path '/work/mips32el-oe-linux/python/2.7.13-r1/
packages-split/python-src/usr/lib/python2.7/config/libpython2.7.a' [staticdev]