### PR TITLE
Backup Suite: Make shell scripts executable

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-backupsuite.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-backupsuite.bb
@@ -13,4 +13,8 @@ S = "${WORKDIR}/git"
 PV = "22+git${SRCPV}"
 PKGV = "22+git${GITPKGV}"
 
+do_install_append() {
+	chmod a+x ${D}/usr/lib/enigma2/python/Plugins/*/*/*.sh
+}
+
 RDEPENDS_${PN} = "mtd-utils mtd-utils-ubifs ofgwrite"


### PR DESCRIPTION
Shell scripts are executable in our git but distutils won't make them executable so do something about it.