### PR TITLE
libupnp: update to version 1.6.22

### DIFF
--- a/meta-openpli/recipes-connectivity/libupnp/libupnp_1.6.22.bb
+++ b/meta-openpli/recipes-connectivity/libupnp/libupnp_1.6.22.bb
@@ -1,0 +1,15 @@
+DESCRIPTION = "The portable SDK for UPnP* Devices (libupnp) provides developers with an API and open source code for building control points, devices, and bridges that are compliant with Version 1.0 of the Universal Plug and Play Device Architecture Specification."
+HOMEPAGE = "http://pupnp.sourceforge.net/"
+LICENSE = "BSD"
+
+LIC_FILES_CHKSUM = "file://upnp/LICENSE;md5=b3190d5244e08e78e4c8ee78544f4863"
+
+PR = "r1"
+
+LEAD_SONAME = "libupnp"
+SRC_URI = "${SOURCEFORGE_MIRROR}/pupnp/${P}.tar.bz2"
+
+inherit autotools
+
+SRC_URI[md5sum] = "530e91e96119ee32a9523a73572b8d8f"
+SRC_URI[sha256sum] = "0bdfacb7fa8d99b78343b550800ff193264f92c66ef67852f87f042fd1a1ebbc"

--- a/meta-openpli/recipes-openpli/images/openpli-enigma2-feed.bb
+++ b/meta-openpli/recipes-openpli/images/openpli-enigma2-feed.bb
@@ -24,6 +24,7 @@ OPTIONAL_PACKAGES += " \
 	cups \
 	davfs2 \
 	diffutils \
+	djmount \
 	dosfstools \
 	dvblast \
 	dvbsnoop \
@@ -105,6 +106,7 @@ ENIGMA2_OPTIONAL = " \
 	enigma2-pliplugins \
 	enigma2-plugin-extensions-automatic-fullbackup \
 	enigma2-plugin-drivers-usbserial \
+	enigma2-plugin-extensions-dlnabrowser \
 	enigma2-plugin-extensions-dlnaserver \
 	enigma2-plugin-extensions-blurayplayer \
 	enigma2-plugin-extensions-epgimport \


### PR DESCRIPTION
To fix build djmount.
Restore djmount and dlnabrowser since they were disabled by commit:
https://github.com/OpenPLi/openpli-oe-core/commit/1eff7996bb026b7c094a0a1c4ae774fe55ebe6bd