### PR TITLE
meta-dream: replace IMAGE_DEPENDS with do_image_ubi[depends]

### DIFF
--- a/meta-dream/classes/image_types_nfi.bbclass
+++ b/meta-dream/classes/image_types_nfi.bbclass
@@ -41,6 +41,6 @@ IMAGE_CMD_ubinfi = " \
 
 EXTRA_IMAGECMD_ubinfi ?= "-e ${DREAMBOX_ERASE_BLOCK_SIZE} -n -l"
 
-IMAGE_DEPENDS_ubinfi = "${IMAGE_DEPENDS_ubi} ${IMAGE_DEPENDS_ubifs} dreambox-buildimage-native"
+do_image_ubi[depends] += "dreambox-buildimage-native:do_populate_sysroot"
 
-IMAGE_TYPES += "jffs2 ubifs"
+IMAGE_TYPES += "ubifs"

--- a/meta-dream/conf/machine/include/dreambox-ubi.inc
+++ b/meta-dream/conf/machine/include/dreambox-ubi.inc
@@ -1,6 +1,6 @@
 inherit image_types_nfi
 
-IMAGE_FSTYPES ?= "ubinfi"
+IMAGE_FSTYPES ?= "ubifs"
 UBI_VOLNAME = "rootfs"
 UBINIZE_VOLSIZE ?= "0"
 UBINIZE_DATAVOL ?= "0"

--- a/meta-dream/recipes-bsp/linux/linux-dreambox.inc
+++ b/meta-dream/recipes-bsp/linux/linux-dreambox.inc
@@ -99,7 +99,7 @@ pkg_postrm_kernel () {
 
 CMDLINE_JFFS2 = "root=/dev/mtdblock3 rootfstype=jffs2 rw ${CMDLINE_CONSOLE}"
 CMDLINE_UBI = "ubi.mtd=root root=ubi0:rootfs rootfstype=ubifs rw ${CMDLINE_CONSOLE}"
-CMDLINE = "${@bb.utils.contains('IMAGE_FSTYPES', 'ubinfi', '${CMDLINE_UBI}', '${CMDLINE_JFFS2}', d)}"
+CMDLINE = "${CMDLINE_UBI}"
 USB_CMDLINE = "root=${USB_ROOT} rootdelay=10 rw ${CMDLINE_CONSOLE}"
 
 LOCALVERSION = "-${MACHINE}"


### PR DESCRIPTION
Introduced with commit:
http://git.openembedded.org/openembedded-core/commit/?id=c5f33d466122e53be910fa448af60ef3937eb828
-Remove superfluous bb.utils.contains since we don't build for dm800se/dm500hd anymore.
-Small cleanup regarding jffs2.