### PR TITLE
Backup Suite revision update

### DIFF
--- a/meta-openpli/conf/distro/reporefs.conf
+++ b/meta-openpli/conf/distro/reporefs.conf
@@ -1,6 +1,6 @@
 SRCREV_pn-enigma2-plugin-extensions-automatic-fullbackup = "a252b4df4edbd299c41c814e840444b5ddb947e8"
 
-SRCREV_pn-enigma2-plugin-extensions-backupsuite = "1dbba937ee20716a8d172a760ed44a7889c38a38"
+SRCREV_pn-enigma2-plugin-extensions-backupsuite = "29c5c061abe0a3d4721280bd09fd69df6808c263"
 SRCREV_pn-enigma2-plugin-extensions-blurayplayer = "73be06bdee0b3dad40e485418546b3f1d9c6150a"
 
 SRCREV_pn-enigma2-plugin-extensions-dlnabrowser = "af72e53197ffe73c73b0af900f922d8237df8c32"


### PR DESCRIPTION
Git 251-272
- Bitbake recipe changed: Better mo compile and chmod, Thanks to Erik Slagter (eriksl)
Shell scripts are executable in our git but distutils won't make them executable so do something about it.
- SK language update, Thanks to Pr0metheus2
- Zgemma H9 support (It's experimental as it uses hi3798mv200 chip not broadcom)
- Edision OSninoplus support
- plugin.py update, Update "no_backup_files", Use "startswith" method and some improvements
- Cleanup: Useless and duplicate python imports removed.
- mphelp.xml update: Show https://github.com/persianpros/BackupSuite/issues
- Xtrend 13000 support
- Beyonwiz U4 support
- Version change from 22 to 23.