### PR TITLE
Create python-pycparser_2.%.bbappend

### DIFF
--- a/meta-openpli/recipes-devtools/python/python-pycparser_2.%.bbappend
+++ b/meta-openpli/recipes-devtools/python/python-pycparser_2.%.bbappend
@@ -1,0 +1,4 @@
+RDEPENDS_${PN}_class-target_remove = "\
+	cpp \
+	cpp-symlinks \
+"


### PR DESCRIPTION
No need to ship cpp and cpp-utils.
With this trick we will save so much on all STBs specially the ones with smaller flashes like 64MB/128MB.
Thanks to MastaG.