### PR TITLE
Backup Suite: add bzip2 to RDEPENDS

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-backupsuite.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-backupsuite.bb
@@ -9,7 +9,12 @@ SRC_URI = "git://github.com/PLi-metas/BackupSuite.git;protocol=git"
 # don't inherit allarch, it can't work with arch-dependent RDEPENDS
 inherit gitpkgv distutils-openplugins gettext
 
-RDEPENDS_${PN} = "mtd-utils mtd-utils-ubifs ofgwrite"
+RDEPENDS_${PN} = " \
+	mtd-utils \
+	mtd-utils-ubifs \
+	ofgwrite \
+	${@bb.utils.contains("IMAGE_FSTYPES", "tar.bz2", "bzip2" , "", d)} \
+	"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
We need "bzip2" for STBs with "tar.bz2" image extension so make sure about it.
I did test this with develop and I'm not sure that we can use "bb.utils.contains" like this for rc 6.1 or not.