### PR TITLE
python-wifi: change URL and update to version 0.6.1

### DIFF
--- a/meta-openpli/recipes-devtools/python/python-wifi_0.6.1.bb
+++ b/meta-openpli/recipes-devtools/python/python-wifi_0.6.1.bb
@@ -3,22 +3,24 @@ HOMEPAGE = "http://pythonwifi.wikispot.org/"
 SECTION = "devel/python"
 LICENSE = "LGPLv2+ & GPLv2+"
 LICENSE_${PN}-examples = "GPLv2+"
-LIC_FILES_CHKSUM = "file://README;beginline=56;endline=57;md5=31ebd3ff22b6f3c0160a143e0c4a98a3 \
-                    file://examples/iwconfig.py;beginline=1;endline=20;md5=60fd41501905b3e20e9065995edfc0cf \
-                    file://pythonwifi/iwlibs.py;beginline=1;endline=22;md5=679475d61cc083a24158bb8b473f0c6f"
+LIC_FILES_CHKSUM = "file://README;beginline=54;endline=55;md5=31ebd3ff22b6f3c0160a143e0c4a98a3 \
+					file://examples/iwconfig.py;beginline=1;endline=20;md5=d34accb82b4f998eccccfd4f4eb56f32 \
+					file://pythonwifi/iwlibs.py;beginline=1;endline=22;md5=aa48daae5660dfd2bb23b2cafe2789e1 \
+					"
+
 RDEPENDS_${PN} = "python-ctypes python-datetime"
 PR = "r1"
 
-SRC_URI = "http://pkgs.fedoraproject.org/repo/pkgs/${PN}/${P}.tar.bz2/8fe7fd0a4edce1f9bedaff4acb7fd500/${P}.tar.bz2"
-SRC_URI[md5sum] = "8fe7fd0a4edce1f9bedaff4acb7fd500"
-SRC_URI[sha256sum] = "3e3f645d37ab20450f60c785cec5f21b330f28a6c46c7c1b0898305dd7a34b26"
+SRC_URI = "https://pypi.python.org/packages/bc/ab/c49f97516f78c2b0cacb4f45873abc4ca9872942a9c4c19ded8052c8edda/python-wifi-0.6.1.tar.bz2"
+
+SRC_URI[md5sum] = "033227169230286a63b9c059e7465c77"
+SRC_URI[sha256sum] = "7bff6afbc03b1cb13f987e5cf3b597b8821a1b86e5b34182406d98657f1b2c91"
 
 inherit setuptools
 
 do_install_append() {
         install -d ${D}${docdir}/${PN}
         mv ${D}${datadir}/README ${D}${docdir}/${PN}
-        mv ${D}${datadir}/INSTALL ${D}${docdir}/${PN}
         mv ${D}${datadir}/docs/* ${D}${docdir}/${PN}
         rmdir ${D}${datadir}/docs
         install -d ${D}${sbindir}

--- a/meta-openpli/recipes-devtools/python/python-wifi_0.6.1.bb
+++ b/meta-openpli/recipes-devtools/python/python-wifi_0.6.1.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "file://README;beginline=54;endline=55;md5=31ebd3ff22b6f3c016
 RDEPENDS_${PN} = "python-ctypes python-datetime"
 PR = "r1"
 
-SRC_URI = "https://pypi.python.org/packages/bc/ab/c49f97516f78c2b0cacb4f45873abc4ca9872942a9c4c19ded8052c8edda/python-wifi-0.6.1.tar.bz2"
+SRC_URI = "https://pypi.python.org/packages/bc/ab/c49f97516f78c2b0cacb4f45873abc4ca9872942a9c4c19ded8052c8edda/python-wifi-${PV}.tar.bz2"
 
 SRC_URI[md5sum] = "033227169230286a63b9c059e7465c77"
 SRC_URI[sha256sum] = "7bff6afbc03b1cb13f987e5cf3b597b8821a1b86e5b34182406d98657f1b2c91"
@@ -19,13 +19,13 @@ SRC_URI[sha256sum] = "7bff6afbc03b1cb13f987e5cf3b597b8821a1b86e5b34182406d98657f
 inherit setuptools
 
 do_install_append() {
-        install -d ${D}${docdir}/${PN}
-        mv ${D}${datadir}/README ${D}${docdir}/${PN}
-        mv ${D}${datadir}/docs/* ${D}${docdir}/${PN}
-        rmdir ${D}${datadir}/docs
-        install -d ${D}${sbindir}
-        mv ${D}${datadir}/examples/* ${D}${sbindir}
-        rmdir ${D}${datadir}/examples
+		install -d ${D}${docdir}/${PN}
+		mv ${D}${datadir}/README ${D}${docdir}/${PN}
+		mv ${D}${datadir}/docs/* ${D}${docdir}/${PN}
+		rmdir ${D}${datadir}/docs
+		install -d ${D}${sbindir}
+		mv ${D}${datadir}/examples/* ${D}${sbindir}
+		rmdir ${D}${datadir}/examples
 }
 
 PACKAGES =+ "${PN}-examples"


### PR DESCRIPTION
Old URL with version 0.5.0 is offline.
Remove obsolete INSTALL file from install.
Replace spaces with tabs.