### PR TITLE
samba: disable python building

### DIFF
--- a/meta-openpli/recipes-connectivity/samba/samba/0001-waf-disable-python-add-option-globally-to-build-syst.patch
+++ b/meta-openpli/recipes-connectivity/samba/samba/0001-waf-disable-python-add-option-globally-to-build-syst.patch
@@ -1,0 +1,147 @@
+From 240528505c9c9fb3d8a244708ce5b69f99737138 Mon Sep 17 00:00:00 2001
+From: Ian Stakenvicius <axs@gentoo.org>
+Date: Fri, 27 Jan 2017 13:28:01 -0500
+Subject: [PATCH 01/14] waf: disable-python - add option globally to build
+ system
+
+This commit adds --disable-python as an option to the build system.
+It adds PYTHON_BUILD_IS_ENABLED() to bld, to be used with enabled=
+on other modules, and adjusts SAMBA_PYTHON() to set enabled=False
+if PYTHON_BUILD_IS_ENABLED() is false.
+
+Signed-off-by: Ian Stakenvicius <axs@gentoo.org>
+---
+ buildtools/wafsamba/samba_python.py | 37 +++++++++++++++++++++++++++++++++----
+ buildtools/wafsamba/wscript         | 10 ++++++++++
+ 2 files changed, 43 insertions(+), 4 deletions(-)
+
+diff --git a/buildtools/wafsamba/samba_python.py b/buildtools/wafsamba/samba_python.py
+index 057a017..56cef21 100644
+--- a/buildtools/wafsamba/samba_python.py
++++ b/buildtools/wafsamba/samba_python.py
+@@ -4,8 +4,9 @@ import os
+ import Build, Logs, Utils, Configure
+ from Configure import conf
+ 
++
+ @conf
+-def SAMBA_CHECK_PYTHON(conf, mandatory=True, version=(2,4,2)):
++def SAMBA_CHECK_PYTHON(conf, mandatory=True, version=(2, 4, 2)):
+     # enable tool to build python extensions
+     if conf.env.HAVE_PYTHON_H:
+         conf.check_python_version(version)
+@@ -40,6 +41,18 @@ def SAMBA_CHECK_PYTHON(conf, mandatory=True, version=(2,4,2)):
+ 
+ @conf
+ def SAMBA_CHECK_PYTHON_HEADERS(conf, mandatory=True):
++    if conf.env.disable_python:
++        if mandatory:
++            raise Utils.WafError("Cannot check for python headers when "
++                                 "--disable-python specified")
++
++        conf.msg("python headers", "Check disabled due to --disable-python")
++        # we don't want PYTHONDIR in config.h, as otherwise changing
++        # --prefix causes a complete rebuild
++        del(conf.env.defines['PYTHONDIR'])
++        del(conf.env.defines['PYTHONARCHDIR'])
++        return
++
+     if conf.env["python_headers_checked"] == []:
+         if conf.env['EXTRA_PYTHON']:
+             conf.setenv('extrapython')
+@@ -54,21 +67,23 @@ def SAMBA_CHECK_PYTHON_HEADERS(conf, mandatory=True):
+             if extraversion == conf.env['PYTHON_VERSION']:
+                 raise Utils.WafError("extrapython %s is same as main python %s" % (
+                     extraversion, conf.env['PYTHON_VERSION']))
++
+     else:
+-        conf.msg("python headers", "using cache")
++            conf.msg("python headers", "using cache")
+ 
+     # we don't want PYTHONDIR in config.h, as otherwise changing
+     # --prefix causes a complete rebuild
+     del(conf.env.defines['PYTHONDIR'])
+     del(conf.env.defines['PYTHONARCHDIR'])
+ 
++
+ def _check_python_headers(conf, mandatory):
+     try:
+         Configure.ConfigurationError
+         conf.check_python_headers(mandatory=mandatory)
+     except Configure.ConfigurationError:
+         if mandatory:
+-             raise
++            raise
+ 
+     if conf.env['PYTHON_VERSION'] > '3':
+         abi_pattern = os.path.splitext(conf.env['pyext_PATTERN'])[0]
+@@ -77,6 +92,12 @@ def _check_python_headers(conf, mandatory):
+         conf.env['PYTHON_SO_ABI_FLAG'] = ''
+ 
+ 
++def PYTHON_BUILD_IS_ENABLED(self):
++    return self.CONFIG_SET('HAVE_PYTHON_H')
++
++Build.BuildContext.PYTHON_BUILD_IS_ENABLED = PYTHON_BUILD_IS_ENABLED
++
++
+ def SAMBA_PYTHON(bld, name,
+                  source='',
+                  deps='',
+@@ -91,6 +112,11 @@ def SAMBA_PYTHON(bld, name,
+                  enabled=True):
+     '''build a python extension for Samba'''
+ 
++    # force-disable when we can't build python modules, so
++    # every single call doesn't need to pass this in.
++    if not bld.PYTHON_BUILD_IS_ENABLED():
++        enabled = False
++
+     if bld.env['IS_EXTRA_PYTHON']:
+         name = 'extra-' + name
+ 
+@@ -138,7 +164,10 @@ Build.BuildContext.SAMBA_PYTHON = SAMBA_PYTHON
+ 
+ 
+ def pyembed_libname(bld, name, extrapython=False):
+-    return name + bld.env['PYTHON_SO_ABI_FLAG']
++    if bld.env['PYTHON_SO_ABI_FLAG']:
++        return name + bld.env['PYTHON_SO_ABI_FLAG']
++    else:
++        return name
+ 
+ Build.BuildContext.pyembed_libname = pyembed_libname
+ 
+diff --git a/buildtools/wafsamba/wscript b/buildtools/wafsamba/wscript
+index 8802e5a..3b86dcf 100755
+--- a/buildtools/wafsamba/wscript
++++ b/buildtools/wafsamba/wscript
+@@ -196,6 +196,10 @@ def set_options(opt):
+                    help='tag release in git at the same time',
+                    type='string', action='store', dest='TAG_RELEASE')
+ 
++    opt.add_option('--disable-python',
++                    help='do not generate python modules',
++                    action='store_true', dest='disable_python', default=False)
++
+     opt.add_option('--extra-python', type=str,
+                     help=("build selected libraries for the specified "
+                           "additional version of Python "
+@@ -279,8 +283,14 @@ def configure(conf):
+     conf.env.AUTOCONF_HOST  = Options.options.AUTOCONF_HOST
+     conf.env.AUTOCONF_PROGRAM_PREFIX = Options.options.AUTOCONF_PROGRAM_PREFIX
+ 
++    conf.env.disable_python = Options.options.disable_python
++
+     conf.env.EXTRA_PYTHON = Options.options.EXTRA_PYTHON
+ 
++    if (conf.env.disable_python and conf.env.EXTRA_PYTHON):
++        Logs.error('ERROR: cannot specify both --disable-python and --extra-python.')
++        sys.exit(1)
++
+     if (conf.env.AUTOCONF_HOST and
+         conf.env.AUTOCONF_BUILD and
+         conf.env.AUTOCONF_BUILD != conf.env.AUTOCONF_HOST):
+-- 
+2.10.2
+

--- a/meta-openpli/recipes-connectivity/samba/samba/0002-waf-disable-python-configuration-adjustments.patch
+++ b/meta-openpli/recipes-connectivity/samba/samba/0002-waf-disable-python-configuration-adjustments.patch
@@ -1,0 +1,37 @@
+From 5f6ba420b4170a66d394757b72dfd648f7584598 Mon Sep 17 00:00:00 2001
+From: Ian Stakenvicius <axs@gentoo.org>
+Date: Fri, 27 Jan 2017 14:07:21 -0500
+Subject: [PATCH 02/14] waf: disable-python - configuration adjustments
+
+Adjust configuration to accomodate when --disable-python is set:
+
+- Error when AD-DC is still enabled (and others later as needed)
+
+- Set mandatory=false on SAMBA_CHECK_PYTHON_HEADERS
+
+Signed-off-by: Ian Stakenvicius <axs@gentoo.org>
+---
+ wscript | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/wscript b/wscript
+index 77aacef..36463f6 100644
+--- a/wscript
++++ b/wscript
+@@ -103,8 +103,12 @@ def configure(conf):
+     conf.SAMBA_CHECK_PERL(mandatory=True)
+     conf.find_program('xsltproc', var='XSLTPROC')
+ 
++    if conf.env.disable_python:
++        if not (Options.options.without_ad_dc):
++            raise Utils.WafError('--disable-python requires --without-ad-dc')
++
+     conf.SAMBA_CHECK_PYTHON(mandatory=True, version=(2, 6, 0))
+-    conf.SAMBA_CHECK_PYTHON_HEADERS(mandatory=True)
++    conf.SAMBA_CHECK_PYTHON_HEADERS(mandatory=(not conf.env.disable_python))
+ 
+     if sys.platform == 'darwin' and not conf.env['HAVE_ENVIRON_DECL']:
+         # Mac OSX needs to have this and it's also needed that the python is compiled with this
+-- 
+2.10.2
+

--- a/meta-openpli/recipes-connectivity/samba/samba/0003-waf-disable-python-align-talloc-s-wscript.patch
+++ b/meta-openpli/recipes-connectivity/samba/samba/0003-waf-disable-python-align-talloc-s-wscript.patch
@@ -1,0 +1,86 @@
+From 7c613b91c8505d32dc7b589e9129620c7464fc95 Mon Sep 17 00:00:00 2001
+From: Ian Stakenvicius <axs@gentoo.org>
+Date: Fri, 27 Jan 2017 14:27:50 -0500
+Subject: [PATCH 03/15] waf: disable-python - align talloc's wscript
+
+Drop the configure option for --disable-python as it is now
+global in wafsamba
+
+If samba is set to use a system copy of talloc, and talloc wasn't built
+with python support, then the system pytalloc-util will not be found.
+If samba is being built without python support then pytalloc-util is not
+needed, so do not bother to try and find it.
+
+The build configuration for pytalloc-util needs to exist even if it's
+not being built, so that dependency resolution can occur throughout
+the rest of the samba build system -- this required dropping the higher
+level conditional and using the enabled= parameter instead.
+
+Signed-off-by: Ian Stakenvicius <axs@gentoo.org>
+---
+ lib/talloc/wscript | 15 +++++++--------
+ 1 file changed, 7 insertions(+), 8 deletions(-)
+
+diff --git a/lib/talloc/wscript b/lib/talloc/wscript
+index 7f9bad74355..508b2bca812 100644
+--- a/lib/talloc/wscript
++++ b/lib/talloc/wscript
+@@ -32,9 +32,6 @@ def set_options(opt):
+         opt.add_option('--enable-talloc-compat1',
+                        help=("Build talloc 1.x.x compat library [False]"),
+                        action="store_true", dest='TALLOC_COMPAT1', default=False)
+-        opt.add_option('--disable-python',
+-                       help=("disable the pytalloc module"),
+-                       action="store_true", dest='disable_python', default=False)
+ 
+ 
+ def configure(conf):
+@@ -46,13 +43,12 @@ def configure(conf):
+     conf.define('TALLOC_BUILD_VERSION_MINOR', int(VERSION.split('.')[1]))
+     conf.define('TALLOC_BUILD_VERSION_RELEASE', int(VERSION.split('.')[2]))
+ 
+-    conf.env.disable_python = getattr(Options.options, 'disable_python', False)
+-
+     if not conf.env.standalone_talloc:
+         if conf.CHECK_BUNDLED_SYSTEM_PKG('talloc', minversion=VERSION,
+                                      implied_deps='replace'):
+             conf.define('USING_SYSTEM_TALLOC', 1)
+-        if conf.CHECK_BUNDLED_SYSTEM_PKG('pytalloc-util', minversion=VERSION,
++        if not conf.env.disable_python and \
++            conf.CHECK_BUNDLED_SYSTEM_PKG('pytalloc-util', minversion=VERSION,
+                                      implied_deps='talloc replace'):
+             conf.define('USING_SYSTEM_PYTALLOC_UTIL', 1)
+ 
+@@ -126,7 +122,7 @@ def build(bld):
+                           private_library=private_library,
+                           manpages='man/talloc.3')
+ 
+-    if not bld.CONFIG_SET('USING_SYSTEM_PYTALLOC_UTIL') and not bld.env.disable_python:
++    if not bld.CONFIG_SET('USING_SYSTEM_PYTALLOC_UTIL'):
+         for env in bld.gen_python_environments(['PKGCONFIGDIR']):
+             name = bld.pyembed_libname('pytalloc-util')
+ 
+@@ -140,16 +136,19 @@ def build(bld):
+                 abi_match='pytalloc_* _pytalloc_*',
+                 private_library=private_library,
+                 public_headers=('' if private_library else 'pytalloc.h'),
+-                pc_files='pytalloc-util.pc'
++                pc_files='pytalloc-util.pc',
++                enabled=bld.PYTHON_BUILD_IS_ENABLED()
+                 )
+             bld.SAMBA_PYTHON('pytalloc',
+                             'pytalloc.c',
+                             deps='talloc ' + name,
++                            enabled=bld.PYTHON_BUILD_IS_ENABLED(),
+                             realname='talloc.so')
+ 
+             bld.SAMBA_PYTHON('test_pytalloc',
+                             'test_pytalloc.c',
+                             deps='pytalloc',
++                            enabled=bld.PYTHON_BUILD_IS_ENABLED(),
+                             realname='_test_pytalloc.so',
+                             install=False)
+ 
+-- 
+2.13.0
+

--- a/meta-openpli/recipes-connectivity/samba/samba/0004-waf-disable-python-align-ldb-s-wscript.patch
+++ b/meta-openpli/recipes-connectivity/samba/samba/0004-waf-disable-python-align-ldb-s-wscript.patch
@@ -1,0 +1,95 @@
+From 34759a3aa19ea6104b306e532c69119cf489dbbd Mon Sep 17 00:00:00 2001
+From: Ian Stakenvicius <axs@gentoo.org>
+Date: Fri, 27 Jan 2017 14:34:25 -0500
+Subject: [PATCH 04/14] waf: disable-python - align ldb's wscript
+
+If samba is set to use a system copy of ldb, and ldb wasn't built with
+python support, then no system pyldb-util will be found.  If samba is
+being built without python support then pyldb-util isn not needed, so
+do not bother to try and find it.
+
+The system ldb check had to be duplicated due to the earlier commits
+which changed order of ldb and pyldb-util checks, and by association
+also added a dependency of pyldb-util onto ldb.  This seemed cleaner
+than messing with variables.
+
+The build configuration for pyldb-util needs to exist even if it's
+not being built, so that dependency resolution can occur throughout
+the rest of the samba build system -- this required dropping the higher
+level conditional and using the enabled= parameter instead.
+
+Signed-off-by: Ian Stakenvicius <axs@gentoo.org>
+---
+ lib/ldb/wscript | 25 ++++++++++++++++---------
+ 1 file changed, 16 insertions(+), 9 deletions(-)
+
+diff --git a/lib/ldb/wscript b/lib/ldb/wscript
+index 13f1d93..ef48d1d 100755
+--- a/lib/ldb/wscript
++++ b/lib/ldb/wscript
+@@ -46,7 +46,7 @@ def configure(conf):
+     conf.find_program('xsltproc', var='XSLTPROC')
+     conf.check_tool('python')
+     conf.check_python_version((2,4,2))
+-    conf.SAMBA_CHECK_PYTHON_HEADERS(mandatory=True)
++    conf.SAMBA_CHECK_PYTHON_HEADERS(mandatory=not conf.env.disable_python)
+ 
+     # where does the default LIBDIR end up? in conf.env somewhere?
+     #
+@@ -55,10 +55,16 @@ def configure(conf):
+     conf.env.standalone_ldb = conf.IN_LAUNCH_DIR()
+ 
+     if not conf.env.standalone_ldb:
+-        if conf.CHECK_BUNDLED_SYSTEM_PKG('pyldb-util', minversion=VERSION,
++        if conf.env.disable_python:
++            if conf.CHECK_BUNDLED_SYSTEM_PKG('ldb', minversion=VERSION,
++                                         onlyif='talloc tdb tevent',
++                                         implied_deps='replace talloc tdb tevent'):
++                conf.define('USING_SYSTEM_LDB', 1)
++        else:
++            if conf.CHECK_BUNDLED_SYSTEM_PKG('pyldb-util', minversion=VERSION,
+                                      onlyif='talloc tdb tevent',
+                                      implied_deps='replace talloc tdb tevent ldb'):
+-            conf.define('USING_SYSTEM_PYLDB_UTIL', 1)
++                conf.define('USING_SYSTEM_PYLDB_UTIL', 1)
+             if conf.CHECK_BUNDLED_SYSTEM_PKG('ldb', minversion=VERSION,
+                                          onlyif='talloc tdb tevent pyldb-util',
+                                          implied_deps='replace talloc tdb tevent'):
+@@ -120,11 +126,10 @@ def build(bld):
+         bld.env.PACKAGE_VERSION = VERSION
+         bld.env.PKGCONFIGDIR = '${LIBDIR}/pkgconfig'
+ 
+-    if not bld.env.disable_python:
+-        if not bld.CONFIG_SET('USING_SYSTEM_PYLDB_UTIL'):
+-            for env in bld.gen_python_environments(['PKGCONFIGDIR']):
+-                name = bld.pyembed_libname('pyldb-util')
+-                bld.SAMBA_LIBRARY(name,
++    if not bld.CONFIG_SET('USING_SYSTEM_PYLDB_UTIL'):
++        for env in bld.gen_python_environments(['PKGCONFIGDIR']):
++            name = bld.pyembed_libname('pyldb-util')
++            bld.SAMBA_LIBRARY(name,
+                                   deps='ldb',
+                                   source='pyldb_util.c',
+                                   public_headers=('' if private_library else 'pyldb.h'),
+@@ -133,15 +138,17 @@ def build(bld):
+                                   private_library=private_library,
+                                   pc_files='pyldb-util.pc',
+                                   pyembed=True,
++                                  enabled=bld.PYTHON_BUILD_IS_ENABLED(),
+                                   abi_directory='ABI',
+                                   abi_match='pyldb_*')
+ 
+-                if not bld.CONFIG_SET('USING_SYSTEM_LDB'):
++            if not bld.CONFIG_SET('USING_SYSTEM_LDB'):
+                     bld.SAMBA_PYTHON('pyldb', 'pyldb.c',
+                                      deps='ldb ' + name,
+                                      realname='ldb.so',
+                                      cflags='-DPACKAGE_VERSION=\"%s\"' % VERSION)
+ 
++        if bld.PYTHON_BUILD_IS_ENABLED():
+             for env in bld.gen_python_environments(['PKGCONFIGDIR']):
+                 bld.SAMBA_SCRIPT('_ldb_text.py',
+                                  pattern='_ldb_text.py',
+-- 
+2.10.2
+

--- a/meta-openpli/recipes-connectivity/samba/samba/0005-waf-disable-python-align-tevent-wscript.patch
+++ b/meta-openpli/recipes-connectivity/samba/samba/0005-waf-disable-python-align-tevent-wscript.patch
@@ -1,0 +1,55 @@
+From 554c803924cd7e08f37a9d6012939f7aad83a41c Mon Sep 17 00:00:00 2001
+From: Ian Stakenvicius <axs@gentoo.org>
+Date: Fri, 27 Jan 2017 14:37:39 -0500
+Subject: [PATCH 05/14] waf: disable-python - align tevent wscript
+
+Drop the configure option for --disable-python as it is now
+global in wafsamba.
+
+If samba is set to use a system copy of tevent, and tevent wasn't built
+with python support, then the system pytevent will not be found.  If
+samba is being built without python support then pytevent is not needed,
+so do not bother to try and find it.
+
+Signed-off-by: Ian Stakenvicius <axs@gentoo.org>
+---
+ lib/tevent/wscript | 9 ++-------
+ 1 file changed, 2 insertions(+), 7 deletions(-)
+
+diff --git a/lib/tevent/wscript b/lib/tevent/wscript
+index 71b9475..89825cb 100755
+--- a/lib/tevent/wscript
++++ b/lib/tevent/wscript
+@@ -22,10 +22,6 @@ def set_options(opt):
+     opt.PRIVATE_EXTENSION_DEFAULT('tevent', noextension='tevent')
+     opt.RECURSE('lib/replace')
+     opt.RECURSE('lib/talloc')
+-    if opt.IN_LAUNCH_DIR():
+-        opt.add_option('--disable-python',
+-                       help=("disable the pytevent module"),
+-                       action="store_true", dest='disable_python', default=False)
+ 
+ 
+ def configure(conf):
+@@ -38,7 +34,8 @@ def configure(conf):
+         if conf.CHECK_BUNDLED_SYSTEM_PKG('tevent', minversion=VERSION,
+                                      onlyif='talloc', implied_deps='replace talloc'):
+             conf.define('USING_SYSTEM_TEVENT', 1)
+-            if conf.CHECK_BUNDLED_SYSTEM_PYTHON('pytevent', 'tevent', minversion=VERSION):
++            if not conf.env.disable_python and \
++                conf.CHECK_BUNDLED_SYSTEM_PYTHON('pytevent', 'tevent', minversion=VERSION):
+                 conf.define('USING_SYSTEM_PYTEVENT', 1)
+ 
+     if conf.CHECK_FUNCS('epoll_create', headers='sys/epoll.h'):
+@@ -61,8 +58,6 @@ def configure(conf):
+     if not conf.CONFIG_SET('USING_SYSTEM_TEVENT'):
+         conf.DEFINE('TEVENT_NUM_SIGNALS', tevent_num_signals)
+ 
+-    conf.env.disable_python = getattr(Options.options, 'disable_python', False)
+-
+     if not conf.env.disable_python:
+         # also disable if we don't have the python libs installed
+         conf.find_program('python', var='PYTHON')
+-- 
+2.10.2
+

--- a/meta-openpli/recipes-connectivity/samba/samba/0006-waf-disable-python-align-tdb-s-wscript.patch
+++ b/meta-openpli/recipes-connectivity/samba/samba/0006-waf-disable-python-align-tdb-s-wscript.patch
@@ -1,0 +1,50 @@
+From 00de441ccad4e3bd7c12590dd70c291add47325d Mon Sep 17 00:00:00 2001
+From: Ian Stakenvicius <axs@gentoo.org>
+Date: Fri, 27 Jan 2017 14:42:05 -0500
+Subject: [PATCH 06/14] waf: disable-python - align tdb's wscript
+
+Drop the configure option for --disable-python as it is now
+global in wafsamba.
+
+If samba is set to use a system copy of tdb, and tdb wasn't built
+with python support, then the system pytevent will not be found.  If
+samba is being built without python support then pytdb is not needed,
+so do not bother to try and find it.
+
+Signed-off-by: Ian Stakenvicius <axs@gentoo.org>
+---
+ lib/tdb/wscript | 9 ++-------
+ 1 file changed, 2 insertions(+), 7 deletions(-)
+
+diff --git a/lib/tdb/wscript b/lib/tdb/wscript
+index c854a21..400b906 100644
+--- a/lib/tdb/wscript
++++ b/lib/tdb/wscript
+@@ -60,10 +60,6 @@ def set_options(opt):
+                    help=("Disable the use of pthread robust mutexes"),
+                    action="store_true", dest='disable_tdb_mutex_locking',
+                    default=False)
+-    if opt.IN_LAUNCH_DIR():
+-        opt.add_option('--disable-python',
+-                       help=("disable the pytdb module"),
+-                       action="store_true", dest='disable_python', default=False)
+ 
+ 
+ def configure(conf):
+@@ -82,11 +78,10 @@ def configure(conf):
+                                      implied_deps='replace'):
+             conf.define('USING_SYSTEM_TDB', 1)
+             conf.env.building_tdb = False
+-            if conf.CHECK_BUNDLED_SYSTEM_PYTHON('pytdb', 'tdb', minversion=VERSION):
++            if not conf.env.disable_python and \
++                conf.CHECK_BUNDLED_SYSTEM_PYTHON('pytdb', 'tdb', minversion=VERSION):
+                 conf.define('USING_SYSTEM_PYTDB', 1)
+ 
+-    conf.env.disable_python = getattr(Options.options, 'disable_python', False)
+-
+     if (conf.CONFIG_SET('HAVE_ROBUST_MUTEXES') and
+         conf.env.building_tdb and
+         not conf.env.disable_tdb_mutex_locking):
+-- 
+2.10.2
+

--- a/meta-openpli/recipes-connectivity/samba/samba/0007-waf-disable-python-don-t-build-python.patch
+++ b/meta-openpli/recipes-connectivity/samba/samba/0007-waf-disable-python-don-t-build-python.patch
@@ -1,0 +1,41 @@
+commit b7c8ee3b42c4db1368afd3ea17c47806359c03f2
+Author: Ian Stakenvicius <axs@gentoo.org>
+Date:   Fri Jan 27 16:38:36 2017 -0500
+
+    waf: disable-python - don't build python/
+    
+    Signed-off-by: Ian Stakenvicius <axs@gentoo.org>
+
+diff --git a/python/wscript_build b/python/wscript_build
+index 5ab0d7d..85a983e 100644
+--- a/python/wscript_build
++++ b/python/wscript_build
+@@ -5,7 +5,8 @@ bld.SAMBA_LIBRARY('samba_python',
+ 	deps='LIBPYTHON pytalloc-util pyrpc_util',
+ 	grouping_library=True,
+ 	private_library=True,
+-	pyembed=True)
++	pyembed=True,
++	enabled=bld.PYTHON_BUILD_IS_ENABLED())
+ 
+ bld.SAMBA_SUBSYSTEM('LIBPYTHON',
+ 	source='modules.c',
+@@ -13,7 +14,7 @@ bld.SAMBA_SUBSYSTEM('LIBPYTHON',
+ 	init_function_sentinel='{NULL,NULL}',
+ 	deps='talloc',
+ 	pyext=True,
+-	)
++	enabled=bld.PYTHON_BUILD_IS_ENABLED())
+ 
+ 
+ bld.SAMBA_PYTHON('python_glue',
+@@ -22,7 +23,8 @@ bld.SAMBA_PYTHON('python_glue',
+ 	realname='samba/_glue.so'
+ 	)
+ 
+-for env in bld.gen_python_environments():
++if bld.PYTHON_BUILD_IS_ENABLED():
++    for env in bld.gen_python_environments():
+ 	# install out various python scripts for use by make test
+ 	bld.SAMBA_SCRIPT('samba_python_files',
+ 	                 pattern='samba/**/*.py',

--- a/meta-openpli/recipes-connectivity/samba/samba/0008-waf-disable-python-don-t-build-PROVISION-pyparam_uti.patch
+++ b/meta-openpli/recipes-connectivity/samba/samba/0008-waf-disable-python-don-t-build-PROVISION-pyparam_uti.patch
@@ -1,0 +1,34 @@
+From b50aa908832eb8d7bf48521e36b2f7415589c773 Mon Sep 17 00:00:00 2001
+From: Ian Stakenvicius <axs@gentoo.org>
+Date: Fri, 27 Jan 2017 16:49:29 -0500
+Subject: [PATCH 08/14] waf: disable-python - don't build PROVISION,
+ pyparam_util
+
+Signed-off-by: Ian Stakenvicius <axs@gentoo.org>
+---
+ source4/param/wscript_build | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/source4/param/wscript_build b/source4/param/wscript_build
+index 2ad753b..8de5fb5 100644
+--- a/source4/param/wscript_build
++++ b/source4/param/wscript_build
+@@ -4,6 +4,7 @@ bld.SAMBA_SUBSYSTEM('PROVISION',
+ 	source='provision.c pyparam.c',
+ 	deps='LIBPYTHON pyparam_util ldb pytalloc-util pyldb-util',
+ 	pyext=True,
++	enabled=bld.PYTHON_BUILD_IS_ENABLED(),
+ 	)
+ 
+ 
+@@ -51,6 +52,7 @@ bld.SAMBA_SUBSYSTEM('pyparam_util',
+ 	source='pyparam_util.c',
+ 	deps='LIBPYTHON samba-hostconfig pytalloc-util',
+ 	pyext=True,
++	enabled=bld.PYTHON_BUILD_IS_ENABLED(),
+ 	)
+ 
+ bld.SAMBA_LIBRARY('shares',
+-- 
+2.10.2
+

--- a/meta-openpli/recipes-connectivity/samba/samba/0009-waf-disable-python-don-t-build-pyrpc_util-dcerpc.py.patch
+++ b/meta-openpli/recipes-connectivity/samba/samba/0009-waf-disable-python-don-t-build-pyrpc_util-dcerpc.py.patch
@@ -1,0 +1,38 @@
+From 510165c54061725c437977552653e1d5294e7cae Mon Sep 17 00:00:00 2001
+From: Ian Stakenvicius <axs@gentoo.org>
+Date: Fri, 27 Jan 2017 17:04:18 -0500
+Subject: [PATCH 09/14] waf: disable-python - don't build pyrpc_util, dcerpc.py
+
+Signed-off-by: Ian Stakenvicius <axs@gentoo.org>
+---
+ source4/librpc/wscript_build | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/source4/librpc/wscript_build b/source4/librpc/wscript_build
+index a28669a..6012b26 100755
+--- a/source4/librpc/wscript_build
++++ b/source4/librpc/wscript_build
+@@ -130,6 +130,7 @@ bld.SAMBA_SUBSYSTEM('pyrpc_util',
+ 	source='rpc/pyrpc_util.c',
+ 	public_deps='pytalloc-util pyparam_util dcerpc MESSAGING',
+ 	pyext=True,
++	enabled=bld.PYTHON_BUILD_IS_ENABLED(),
+ 	)
+ 
+ 
+@@ -345,9 +346,10 @@ bld.SAMBA_PYTHON('python_dcerpc_smb_acl',
+ 	realname='samba/dcerpc/smb_acl.so'
+ 	)
+ 
+-bld.SAMBA_SCRIPT('python_dcerpc_init',
++if bld.PYTHON_BUILD_IS_ENABLED():
++    bld.SAMBA_SCRIPT('python_dcerpc_init',
+                  pattern='rpc/dcerpc.py',
+                  installdir='python/samba/dcerpc',
+                  installname='__init__.py')
+ 
+-bld.INSTALL_FILES('${PYTHONARCHDIR}/samba/dcerpc', 'rpc/dcerpc.py', destname='__init__.py')
++    bld.INSTALL_FILES('${PYTHONARCHDIR}/samba/dcerpc', 'rpc/dcerpc.py', destname='__init__.py')
+-- 
+2.10.2
+

--- a/meta-openpli/recipes-connectivity/samba/samba/0010-waf-disable-python-don-t-build-samba-net.patch
+++ b/meta-openpli/recipes-connectivity/samba/samba/0010-waf-disable-python-don-t-build-samba-net.patch
@@ -1,0 +1,29 @@
+From 5204843623f970d6b44556024bc2d57fc65a31bf Mon Sep 17 00:00:00 2001
+From: Ian Stakenvicius <axs@gentoo.org>
+Date: Fri, 27 Jan 2017 21:31:21 -0500
+Subject: [PATCH 10/14] waf: disable-python - don't build samba-net
+
+samba-net requires PROVISION, which is disabled when python isn't available.
+
+Signed-off-by: Ian Stakenvicius <axs@gentoo.org>
+---
+ source4/libnet/wscript_build | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/source4/libnet/wscript_build b/source4/libnet/wscript_build
+index 1274a82..f29da29 100644
+--- a/source4/libnet/wscript_build
++++ b/source4/libnet/wscript_build
+@@ -4,7 +4,8 @@ bld.SAMBA_LIBRARY('samba-net',
+ 	source='libnet.c libnet_passwd.c libnet_time.c libnet_rpc.c libnet_join.c libnet_site.c libnet_become_dc.c libnet_unbecome_dc.c libnet_vampire.c libnet_samdump.c libnet_samsync_ldb.c libnet_user.c libnet_group.c libnet_share.c libnet_lookup.c libnet_domain.c userinfo.c groupinfo.c userman.c groupman.c prereq_domain.c libnet_samsync.c',
+ 	autoproto='libnet_proto.h',
+ 	public_deps='samba-credentials dcerpc dcerpc-samr RPC_NDR_LSA RPC_NDR_SRVSVC RPC_NDR_DRSUAPI cli_composite LIBCLI_RESOLVE LIBCLI_FINDDCS cli_cldap LIBCLI_FINDDCS gensec_schannel LIBCLI_AUTH ndr smbpasswdparser PROVISION LIBCLI_SAMSYNC LIBTSOCKET',
+-	private_library=True
++	private_library=True,
++	enabled=bld.PYTHON_BUILD_IS_ENABLED()
+ 	)
+ 
+ 
+-- 
+2.10.2
+

--- a/meta-openpli/recipes-connectivity/samba/samba/0011-waf-disable-python-don-t-build-samba-policy.patch
+++ b/meta-openpli/recipes-connectivity/samba/samba/0011-waf-disable-python-don-t-build-samba-policy.patch
@@ -1,0 +1,30 @@
+From 66105f8d4c67a50b78f837d113d43f13dfe9405f Mon Sep 17 00:00:00 2001
+From: Ian Stakenvicius <axs@gentoo.org>
+Date: Fri, 27 Jan 2017 21:32:22 -0500
+Subject: [PATCH 11/14] waf: disable-python - don't build samba-policy
+
+samba-policy requires samba-net which requires PROVISION, which
+is disabled when python isn't available.
+
+Signed-off-by: Ian Stakenvicius <axs@gentoo.org>
+---
+ source4/lib/policy/wscript_build | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/source4/lib/policy/wscript_build b/source4/lib/policy/wscript_build
+index b8ba638..f7c5909 100644
+--- a/source4/lib/policy/wscript_build
++++ b/source4/lib/policy/wscript_build
+@@ -6,7 +6,8 @@ bld.SAMBA_LIBRARY('samba-policy',
+ 	public_deps='ldb samba-net',
+ 	vnum='0.0.1',
+ 	pyembed=True,
+-	public_headers='policy.h'
++	public_headers='policy.h',
++	enabled=bld.PYTHON_BUILD_IS_ENABLED()
+ 	)
+ 
+ bld.SAMBA_PYTHON('py_policy',
+-- 
+2.10.2
+

--- a/meta-openpli/recipes-connectivity/samba/samba/0012-waf-disable-python-don-t-build-torture-bits.patch
+++ b/meta-openpli/recipes-connectivity/samba/samba/0012-waf-disable-python-don-t-build-torture-bits.patch
@@ -1,0 +1,146 @@
+From 271230aa184066774d44d43568671fc143cffe9a Mon Sep 17 00:00:00 2001
+From: Ian Stakenvicius <axs@gentoo.org>
+Date: Fri, 27 Jan 2017 22:53:39 -0500
+Subject: [PATCH 12/14] waf: disable-python - don't build torture bits
+
+samba-net being disabled causes a chain of dependency or proto.h-based
+missing code issues that require a number of modules or subsystems
+to be disabled in samba4/torture.
+
+Signed-off-by: Ian Stakenvicius <axs@gentoo.org>
+---
+ source4/torture/drs/wscript_build   |  3 ++-
+ source4/torture/local/wscript_build |  3 ++-
+ source4/torture/wscript_build       | 28 +++++++++++++++++++---------
+ 3 files changed, 23 insertions(+), 11 deletions(-)
+
+diff --git a/source4/torture/drs/wscript_build b/source4/torture/drs/wscript_build
+index cfdd8a2..67bf034 100644
+--- a/source4/torture/drs/wscript_build
++++ b/source4/torture/drs/wscript_build
+@@ -6,6 +6,7 @@ bld.SAMBA_MODULE('TORTURE_DRS',
+ 	subsystem='smbtorture',
+ 	init_function='torture_drs_init',
+ 	deps='samba-util ldb POPT_SAMBA samba-errors torture ldbsamba talloc dcerpc ndr NDR_DRSUAPI gensec samba-hostconfig RPC_NDR_DRSUAPI DSDB_MODULE_HELPERS asn1util samdb NDR_DRSBLOBS samba-credentials samdb-common LIBCLI_RESOLVE LP_RESOLVE torturemain',
+-	internal_module=True
++	internal_module=True,
++	enabled=bld.PYTHON_BUILD_IS_ENABLED()
+ 	)
+ 
+diff --git a/source4/torture/local/wscript_build b/source4/torture/local/wscript_build
+index 3a12b6b..087b842 100644
+--- a/source4/torture/local/wscript_build
++++ b/source4/torture/local/wscript_build
+@@ -32,5 +32,6 @@ bld.SAMBA_MODULE('TORTURE_LOCAL',
+ 	subsystem='smbtorture',
+ 	init_function='torture_local_init',
+ 	deps=TORTURE_LOCAL_DEPS,
+-	internal_module=True
++	internal_module=True,
++	enabled=bld.PYTHON_BUILD_IS_ENABLED()
+ 	)
+diff --git a/source4/torture/wscript_build b/source4/torture/wscript_build
+index ff79c3d..96ca6e0 100755
+--- a/source4/torture/wscript_build
++++ b/source4/torture/wscript_build
+@@ -14,7 +14,8 @@ bld.SAMBA_MODULE('TORTURE_BASIC',
+ 	deps='LIBCLI_SMB popt POPT_CREDENTIALS TORTURE_UTIL smbclient-raw TORTURE_RAW',
+ 	internal_module=True,
+ 	autoproto='basic/proto.h',
+-	init_function='torture_base_init'
++	init_function='torture_base_init',
++	enabled=bld.PYTHON_BUILD_IS_ENABLED()
+ 	)
+ 
+ 
+@@ -24,7 +25,8 @@ bld.SAMBA_MODULE('TORTURE_RAW',
+ 	subsystem='smbtorture',
+ 	init_function='torture_raw_init',
+ 	deps='LIBCLI_SMB LIBCLI_LSA LIBCLI_SMB_COMPOSITE popt POPT_CREDENTIALS TORTURE_UTIL',
+-	internal_module=True
++	internal_module=True,
++	enabled=bld.PYTHON_BUILD_IS_ENABLED()
+ 	)
+ 
+ bld.RECURSE('smb2')
+@@ -64,7 +66,8 @@ bld.SAMBA_SUBSYSTEM('TORTURE_NDR',
+                   ndr/krb5pac.c
+ 		  ''',
+ 	autoproto='ndr/proto.h',
+-	deps='torture krb5samba'
++	deps='torture krb5samba',
++	enabled=bld.PYTHON_BUILD_IS_ENABLED()
+ 	)
+ 
+ torture_rpc_backupkey = ''
+@@ -176,7 +179,8 @@ bld.SAMBA_MODULE('torture_rpc',
+                       RPC_NDR_WITNESS
+                       RPC_NDR_BACKUPKEY
+                       ''' + ntvfs_specific['deps'],
+-                 internal_module=True)
++                 internal_module=True,
++                 enabled=bld.PYTHON_BUILD_IS_ENABLED())
+ 
+ bld.RECURSE('drs')
+ bld.RECURSE('dns')
+@@ -187,7 +191,8 @@ bld.SAMBA_MODULE('TORTURE_RAP',
+ 	subsystem='smbtorture',
+ 	init_function='torture_rap_init',
+ 	deps='TORTURE_UTIL LIBCLI_SMB NDR_RAP LIBCLI_RAP',
+-	internal_module=True
++	internal_module=True,
++	enabled=bld.PYTHON_BUILD_IS_ENABLED()
+ 	)
+ 
+ bld.SAMBA_MODULE('TORTURE_DFS',
+@@ -247,7 +252,8 @@ bld.SAMBA_MODULE('TORTURE_NBT',
+ 	subsystem='smbtorture',
+ 	init_function='torture_nbt_init',
+ 	deps='LIBCLI_SMB cli-nbt LIBCLI_DGRAM LIBCLI_WREPL torture_rpc',
+-	internal_module=True
++	internal_module=True,
++	enabled=bld.PYTHON_BUILD_IS_ENABLED()
+ 	)
+ 
+ 
+@@ -257,7 +263,8 @@ bld.SAMBA_MODULE('TORTURE_NET',
+ 	subsystem='smbtorture',
+ 	init_function='torture_net_init',
+ 	deps='samba-net popt POPT_CREDENTIALS torture_rpc PROVISION',
+-	internal_module=True
++	internal_module=True,
++	enabled=bld.PYTHON_BUILD_IS_ENABLED()
+ 	)
+ 
+ 
+@@ -267,7 +274,8 @@ bld.SAMBA_MODULE('TORTURE_NTP',
+ 	subsystem='smbtorture',
+ 	init_function='torture_ntp_init',
+ 	deps='popt POPT_CREDENTIALS torture_rpc',
+-	internal_module=True
++	internal_module=True,
++	enabled=bld.PYTHON_BUILD_IS_ENABLED()
+ 	)
+ 
+ bld.SAMBA_MODULE('TORTURE_VFS',
+@@ -285,6 +293,7 @@ bld.SAMBA_SUBSYSTEM('torturemain',
+                     source='smbtorture.c torture.c shell.c',
+                     subsystem_name='smbtorture',
+                     deps='torture popt POPT_SAMBA POPT_CREDENTIALS dcerpc LIBCLI_SMB SMBREADLINE ' + TORTURE_MODULES,
++                    enabled=bld.PYTHON_BUILD_IS_ENABLED()
+                     )
+ 
+ bld.SAMBA_BINARY('smbtorture',
+@@ -292,7 +301,8 @@ bld.SAMBA_BINARY('smbtorture',
+                  manpages='man/smbtorture.1',
+                  private_headers='smbtorture.h',
+                  deps='torturemain torture popt POPT_SAMBA POPT_CREDENTIALS dcerpc LIBCLI_SMB SMBREADLINE ' + TORTURE_MODULES,
+-                 pyembed=True
++                 pyembed=True,
++                 enabled=bld.PYTHON_BUILD_IS_ENABLED()
+                  )
+ 
+ bld.SAMBA_BINARY('gentest',
+-- 
+2.10.2
+

--- a/meta-openpli/recipes-connectivity/samba/samba/0013-autobuild-Add-nopython-environment-to-test-disable-p.patch
+++ b/meta-openpli/recipes-connectivity/samba/samba/0013-autobuild-Add-nopython-environment-to-test-disable-p.patch
@@ -1,0 +1,75 @@
+From 701420d7e19bebfba1fe67163eabef0365a63c94 Mon Sep 17 00:00:00 2001
+From: Andrew Bartlett <abartlet@samba.org>
+Date: Mon, 30 Jan 2017 09:36:31 -0500
+Subject: [PATCH 13/15] autobuild: Add nopython environment to test
+ --disable-python  builds (but without tests)
+
+This ensures we keep this option building as we extend our use of python.
+
+The rule is that new features and changes to existing features that
+require python are most welcome, they just need to be disabled for the
+minimalistic targets we still ecourage Samba on, that typically just
+want smbd
+---
+ .travis.yml         |  1 +
+ script/autobuild.py | 18 +++++++++++++++++-
+ 2 files changed, 18 insertions(+), 1 deletion(-)
+
+diff --git a/.travis.yml b/.travis.yml
+index 483ad501798..ce0e745548b 100644
+--- a/.travis.yml
++++ b/.travis.yml
+@@ -12,6 +12,7 @@ env:
+   - TASK=samba-libs
+   - TASK=samba-static
+   - TASK=samba-o3
++  - TASK=samba-nopython
+   - TASK=ldb
+   - TASK=tdb
+   - TASK=talloc
+diff --git a/script/autobuild.py b/script/autobuild.py
+index e46869c0407..27deec472df 100755
+--- a/script/autobuild.py
++++ b/script/autobuild.py
+@@ -32,6 +32,7 @@ builddirs = {
+     "samba-static"  : ".",
+     "samba-test-only"  : ".",
+     "samba-systemkrb5"  : ".",
++    "samba-nopython"  : ".",
+     "ldb"     : "lib/ldb",
+     "tdb"     : "lib/tdb",
+     "talloc"  : "lib/talloc",
+@@ -43,7 +44,7 @@ builddirs = {
+     "retry"   : "."
+     }
+ 
+-defaulttasks = [ "ctdb", "samba", "samba-xc", "samba-o3", "samba-ctdb", "samba-libs", "samba-static", "samba-systemkrb5", "ldb", "tdb", "talloc", "replace", "tevent", "pidl" ]
++defaulttasks = [ "ctdb", "samba", "samba-xc", "samba-o3", "samba-ctdb", "samba-libs", "samba-static", "samba-systemkrb5", "samba-nopython", "ldb", "tdb", "talloc", "replace", "tevent", "pidl" ]
+ 
+ if os.environ.get("AUTOBUILD_SKIP_SAMBA_O3", "0") == "1":
+     defaulttasks.remove("samba-o3")
+@@ -177,6 +178,21 @@ tasks = {
+                       ("clean", "make clean", "text/plain")
+                       ],
+ 
++    # Test Samba without python still builds.  When this test fails
++    # due to more use of Python, the expectations is that the newly
++    # failing part of the code should be disabled when
++    # --disable-python is set (rather than major work being done to
++    # support this environment).  The target here is for vendors
++    # shipping a minimal smbd.
++    "samba-nopython" : [
++                      ("random-sleep", "script/random-sleep.sh 60 600", "text/plain"),
++                      ("configure", "./configure.developer --picky-developer ${PREFIX} --with-profiling-data --disable-python --without-ad-dc", "text/plain"),
++                      ("make", "make -j", "text/plain"),
++                      ("install", "make install", "text/plain"),
++                      ("check-clean-tree", "script/clean-source-tree.sh", "text/plain"),
++                      ("clean", "make clean", "text/plain")
++                      ],
++
+ 
+ 
+     "ldb" : [
+-- 
+2.13.0
+

--- a/meta-openpli/recipes-connectivity/samba/samba/0014-waf-disable-python-don-t-include-python.h-in-test_he.patch
+++ b/meta-openpli/recipes-connectivity/samba/samba/0014-waf-disable-python-don-t-include-python.h-in-test_he.patch
@@ -1,0 +1,29 @@
+From fe29be4c9d82fb355a9bea848c0bedd2ad35e5bb Mon Sep 17 00:00:00 2001
+From: Ian Stakenvicius <axs@gentoo.org>
+Date: Mon, 30 Jan 2017 10:11:46 -0500
+Subject: [PATCH 14/14] waf: disable-python - don't include python.h in
+ test_headers.c
+
+Signed-off-by: Ian Stakenvicius <axs@gentoo.org>
+---
+ testsuite/headers/test_headers.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/testsuite/headers/test_headers.c b/testsuite/headers/test_headers.c
+index a36575f..4e63e99 100644
+--- a/testsuite/headers/test_headers.c
++++ b/testsuite/headers/test_headers.c
+@@ -23,7 +23,9 @@
+ 
+ #define _GNU_SOURCE 1
+ 
+-#include <Python.h>
++#ifdef HAVE_PYTHON_H
++# include <Python.h>
++#endif
+ #include <stdio.h>
+ #include <unistd.h>
+ #include <stdlib.h>
+-- 
+2.10.2
+

--- a/meta-openpli/recipes-connectivity/samba/samba/0015-waf-disable-python-fix-ctdb-configuration.patch
+++ b/meta-openpli/recipes-connectivity/samba/samba/0015-waf-disable-python-fix-ctdb-configuration.patch
@@ -1,0 +1,36 @@
+From c9b0f177efb0fb1d0c19d8d4b3a41cb771b5d60e Mon Sep 17 00:00:00 2001
+From: Ian Stakenvicius <axs@gentoo.org>
+Date: Thu, 23 Feb 2017 10:16:25 -0500
+Subject: [PATCH 15/15] waf: disable-python - fix ctdb configuration
+
+When ctdb is built in standalone mode, it turned off the python
+requirement for submodules by setting Options.options.disable_python
+to True before checking for its own (non-optional) python support.
+
+Ad ctdb does not need python for itself or any of the submodules
+it is built against, the safest solution seems to be to allow
+the python and python-headers checks to not find python.
+
+Signed-off-by: Ian Stakenvicius <axs@gentoo.org>
+---
+ ctdb/wscript | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/ctdb/wscript b/ctdb/wscript
+index fe7d7122308..3aa1e9675ae 100644
+--- a/ctdb/wscript
++++ b/ctdb/wscript
+@@ -107,8 +107,8 @@ def configure(conf):
+     if conf.env.standalone_ctdb:
+         conf.SAMBA_CHECK_PERL(mandatory=True)
+ 
+-        conf.SAMBA_CHECK_PYTHON(mandatory=True, version=(2,5,0))
+-        conf.SAMBA_CHECK_PYTHON_HEADERS(mandatory=True)
++        conf.SAMBA_CHECK_PYTHON(mandatory=False, version=(2,5,0))
++        conf.SAMBA_CHECK_PYTHON_HEADERS(mandatory=False)
+ 
+     if conf.CHECK_FOR_THIRD_PARTY():
+         conf.RECURSE('third_party/popt')
+-- 
+2.13.0
+

--- a/meta-openpli/recipes-connectivity/samba/samba/0016-waf-disable-python-don-t-build-third_party.patch
+++ b/meta-openpli/recipes-connectivity/samba/samba/0016-waf-disable-python-don-t-build-third_party.patch
@@ -1,0 +1,24 @@
+From: Taapat <taapat@gmail.com>
+Disable third_party python package buildig
+
+--- a/third_party/wscript	2017-01-11 09:55:16.000000000 +0200
++++ b/third_party/wscript	2018-02-10 20:04:17.672469789 +0200
+@@ -60,6 +60,9 @@
+         except ImportError:
+             list.append(package)
+ 
++    if bld.env.disable_python:
++        list = []
++
+     for e in list:
+         bld.INSTALL_WILDCARD('${PYTHONARCHDIR}/samba/third_party', e + '/**/*', flat=False,
+                              exclude='*.pyc', trim_path=os.path.dirname(e))
+@@ -68,6 +71,7 @@
+                         rule='touch ${TGT}',
+                         target='empty_file')
+ 
+-    bld.INSTALL_FILES('${PYTHONARCHDIR}/samba/third_party', 'empty_file', destname='__init__.py')
++    if not bld.env.disable_python:
++        bld.INSTALL_FILES('${PYTHONARCHDIR}/samba/third_party', 'empty_file', destname='__init__.py')
+     bld.RECURSE('zlib')
+     bld.RECURSE('popt')

--- a/meta-openpli/recipes-connectivity/samba/samba_4.%.bbappend
+++ b/meta-openpli/recipes-connectivity/samba/samba_4.%.bbappend
@@ -14,6 +14,7 @@ EXTRA_OECONF += " \
                  --without-quotas \
                  --without-winbind \
                  --without-syslog \
+                 --disable-python \
                 "
 
 EXTRA_OECONF_remove = " \
@@ -26,6 +27,22 @@ EXTRA_OECONF_remove = " \
 SRC_URI += " \
            file://smb.conf \
            file://samba.sh \
+           file://0001-waf-disable-python-add-option-globally-to-build-syst.patch \
+           file://0002-waf-disable-python-configuration-adjustments.patch \
+           file://0003-waf-disable-python-align-talloc-s-wscript.patch \
+           file://0004-waf-disable-python-align-ldb-s-wscript.patch \
+           file://0005-waf-disable-python-align-tevent-wscript.patch \
+           file://0006-waf-disable-python-align-tdb-s-wscript.patch \
+           file://0007-waf-disable-python-don-t-build-python.patch \
+           file://0008-waf-disable-python-don-t-build-PROVISION-pyparam_uti.patch \
+           file://0009-waf-disable-python-don-t-build-pyrpc_util-dcerpc.py.patch \
+           file://0010-waf-disable-python-don-t-build-samba-net.patch \
+           file://0011-waf-disable-python-don-t-build-samba-policy.patch \
+           file://0012-waf-disable-python-don-t-build-torture-bits.patch \
+           file://0013-autobuild-Add-nopython-environment-to-test-disable-p.patch \
+           file://0014-waf-disable-python-don-t-include-python.h-in-test_he.patch \
+           file://0015-waf-disable-python-fix-ctdb-configuration.patch \
+           file://0016-waf-disable-python-don-t-build-third_party.patch \
            "
 
 FILES_${PN}-base += "${sysconfdir}/init.d/samba.sh \


### PR DESCRIPTION
Slightly increases the building speed and reduces the overall size of the samba packages.
Patches from: https://dev.gentoo.org/~axs/distfiles/
Adapted for the latest OE.