### PR TITLE
samba: remove unused and not working init script

### DIFF
--- a/meta-openpli/recipes-connectivity/samba/samba_4.%.bbappend
+++ b/meta-openpli/recipes-connectivity/samba/samba_4.%.bbappend
@@ -60,10 +60,10 @@ do_install_append() {
 	rm -fR ${D}${bindir}
 	rm -fR ${D}${sysconfdir}/tmpfiles.d
 	rm -fR ${D}${sysconfdir}/sysconfig
+	rm -f ${D}${sysconfdir}/init.d/samba
 	install -d ${D}/var/lib/samba/private
 	install -d ${D}${sysconfdir}/samba
 	install -m 644 ${WORKDIR}/smb.conf ${D}${sysconfdir}/samba
-	install -d ${D}${sysconfdir}/init.d
 	install -m 755 ${WORKDIR}/samba.sh ${D}${sysconfdir}/init.d
 }
 


### PR DESCRIPTION
Init script smaba added in bb file but does not work because of the use of seed options that our busybox does not support.
We use our own smaba.sh int file, so the smaba init file only confuses users.

Also remove unnecessary init.d directory creation which already created in the bb file.