### PR TITLE
common.conf: compile glibc expliciet with -O2 to silence warnings

### DIFF
--- a/meta-openpli/conf/distro/openpli-common.conf
+++ b/meta-openpli/conf/distro/openpli-common.conf
@@ -43,7 +43,12 @@ COMMERCIAL_VIDEO_PLUGINS ?= "gst-plugins-ugly-mpeg2dec gst-plugins-ugly-mpegstre
 # Override here to use -Os instead, resulting in smaller images.
 FULL_OPTIMIZATION = "-Os -pipe ${DEBUG_FLAGS}"
 # build some core libs with better compiler optimization for better performance
+O2_OPT = "-O2 -pipe ${DEBUG_FLAGS}"
 O3_OPT = "-O3 -pipe ${DEBUG_FLAGS}"
+FULL_OPTIMIZATION_pn-glibc = "${O2_OPT}"
+FULL_OPTIMIZATION_pn-nativesdk-glibc = "${O2_OPT}"
+FULL_OPTIMIZATION_pn-glibc-initial = "${O2_OPT}"
+FULL_OPTIMIZATION_pn-nativesdk-glibc-initial = "${O2_OPT}"
 FULL_OPTIMIZATION_pn-flac = "${O3_OPT}"
 FULL_OPTIMIZATION_pn-jpeg = "${O3_OPT}"
 FULL_OPTIMIZATION_pn-lame = "${O3_OPT}"


### PR DESCRIPTION
NOTE: /openpli-oe-core/openembedded-core/meta/recipes-core/glibc/glibc_2.26.bb: glibc
(nativesdk-glibc/glibc-initial) doesn't build cleanly with -Os, adding -Wno-error to SELECTED_OPTIMIZATION

Option -O3 breaks gobject-introspection.