### PR TITLE
firewall: change RDEPENDS

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-security-firewall.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-security-firewall.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "Firewall"
 
 require conf/license/openpli-gplv2.inc
 
-RDEPENDS_${PN} = "iptables kernel-module-ip-tables kernel-module-ip-conntrack kernel-module-ipt-reject kernel-module-ipt-state kernel-module-iptable-filter"
+RDEPENDS_${PN} = "iptables kernel-module-ip-tables kernel-module-nf-conntrack kernel-module-ipt-reject kernel-module-xt-state kernel-module-iptable-filter"
 
 SRC_URI = "file://firewall.sh file://firewall.users"
 


### PR DESCRIPTION
kernel-module-ip-conntrack => kernel-module-nf-conntrack.
kernel-module-ipt-state => kernel-module-xt-state.

http://conntrack-tools.netfilter.org/manual.html
http://www.nslu2-linux.org/wiki/pmwiki.php?pagename=OpenSlug/IptablesConnTrack

To silence warnings as well:
WARNING: enigma2-plugin-security-firewall-2.0-r0 do_package_qa: QA Issue: enigma2-plugin-security-firewall
rdepends on kernel-module-ip-conntrack/kernel-module-ipt-state, but it isn't a build dependency? [build-deps]

Not tested.