### PR TITLE
openpli-common.conf: use default FULL_OPTIMIZATION -O2 OE-core

### DIFF
--- a/meta-openpli/conf/distro/openpli-common.conf
+++ b/meta-openpli/conf/distro/openpli-common.conf
@@ -39,16 +39,8 @@ LICENSE_FLAGS_WHITELIST = "commercial"
 COMMERCIAL_AUDIO_PLUGINS ?= "gst-plugins-ugly-mad gst-plugins-ugly-mpegaudioparse"
 COMMERCIAL_VIDEO_PLUGINS ?= "gst-plugins-ugly-mpeg2dec gst-plugins-ugly-mpegstream gst-plugins-bad-mpegvideoparse"
 
-# OE optimization defaults to -O2 which makes for much larger binaries.
-# Override here to use -Os instead, resulting in smaller images.
-FULL_OPTIMIZATION = "-Os -pipe ${DEBUG_FLAGS}"
-# build some core libs with better compiler optimization for better performance
-O2_OPT = "-O2 -pipe ${DEBUG_FLAGS}"
+# Build some core libs with better compiler optimization for better performance
 O3_OPT = "-O3 -pipe ${DEBUG_FLAGS}"
-FULL_OPTIMIZATION_pn-glibc = "${O2_OPT}"
-FULL_OPTIMIZATION_pn-nativesdk-glibc = "${O2_OPT}"
-FULL_OPTIMIZATION_pn-glibc-initial = "${O2_OPT}"
-FULL_OPTIMIZATION_pn-nativesdk-glibc-initial = "${O2_OPT}"
 FULL_OPTIMIZATION_pn-flac = "${O3_OPT}"
 FULL_OPTIMIZATION_pn-jpeg = "${O3_OPT}"
 FULL_OPTIMIZATION_pn-lame = "${O3_OPT}"


### PR DESCRIPTION
For better performance.
This increasing the image size a bit(2.5MB for dm8000).

Small cosmetic change in comment.

Thanks to Athoik.