### PR TITLE
autobouquetsmaker: add enigma2 to RDEPENDS to silence warning

### DIFF
--- a/meta-openpli/recipes-openpli/e2openplugins/enigma2-plugin-systemplugins-autobouquetsmaker.bb
+++ b/meta-openpli/recipes-openpli/e2openplugins/enigma2-plugin-systemplugins-autobouquetsmaker.bb
@@ -8,6 +8,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 inherit autotools-brokensep gitpkgv pythonnative gettext
 
 DEPENDS += "python"
+RDEPENDS_${PN} = "enigma2"
 
 PV = "2.1+git${SRCPV}"
 PKGV = "2.1+git${GITPKGV}"


### PR DESCRIPTION
QA Issue: enigma2-plugin-systemplugins-autobouquetsmaker(-src) rdepends on enigma2, but it isn't a build dependency,
missing enigma2 in DEPENDS or PACKAGECONFIG? [build-deps]