### PR TITLE
[.gitmodules] Use https for Axas-UHD

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -66,4 +66,4 @@
 	url = https://github.com/pli3/meta-qviart-5.git
 [submodule "meta-axasuhd"]
 	path = meta-axasuhd
-	url = git@github.com:Axas-UHD/meta-axasuhd.git
+	url = https://github.com/Axas-UHD/meta-axasuhd.git


### PR DESCRIPTION
This avoids people having to have Git credentials when building. All others also use https