### PR TITLE
Default to O2 for building our images

### DIFF
--- a/meta-openpli/conf/distro/openpli-common.conf
+++ b/meta-openpli/conf/distro/openpli-common.conf
@@ -41,7 +41,10 @@ COMMERCIAL_VIDEO_PLUGINS ?= "gst-plugins-ugly-mpeg2dec gst-plugins-ugly-mpegstre
 
 # OE optimization defaults to -O2 which makes for much larger binaries.
 # Override here to use -Os instead, resulting in smaller images.
-FULL_OPTIMIZATION = "-Os -pipe ${DEBUG_FLAGS}"
+
+# UPDATE: We don't support receivers with small flash anymore.
+# So default to 02 for faster code
+FULL_OPTIMIZATION = "-O2 -pipe ${DEBUG_FLAGS}"
 # build some core libs with better compiler optimization for better performance
 O2_OPT = "-O2 -pipe ${DEBUG_FLAGS}"
 O3_OPT = "-O3 -pipe ${DEBUG_FLAGS}"


### PR DESCRIPTION
We do not support receivers with small flash memory anymore (like Dreambox DM800Se).
So lets default to O2 instead of Os for faster code.

btw.. it still builds for dm800se/dm800hd fine..the images didn't increase that much.