### PR TITLE
Add Revert disable all ipcpipeline tests patch

### DIFF
--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/06-Revert-disable-all-ipcpipeline-tests.patch
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/06-Revert-disable-all-ipcpipeline-tests.patch
@@ -1,0 +1,20 @@
+diff --git a/tests/check/Makefile.am b/tests/check/Makefile.am
+index 0713dd4..775ba75 100644
+--- a/tests/check/Makefile.am
++++ b/tests/check/Makefile.am
+@@ -230,7 +230,6 @@ VALGRIND_TESTS_DISABLE = \
+ noinst_PROGRAMS = \
+ 	pipelines/streamheader \
+ 	$(check_dash_demux) \
+-	$(check_ipcpipeline) \
+ 	$(check_neon)
+ 
+ check_PROGRAMS = \
+@@ -280,6 +282,7 @@ check_PROGRAMS = \
+ 	elements/rtponviftimestamp \
+ 	elements/id3mux \
+ 	pipelines/mxf \
++	$(check_ipcpipeline) \
+ 	libs/isoff \
+ 	libs/mpegvideoparser \
+ 	libs/mpegts \

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_git.bb
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_git.bb
@@ -15,6 +15,7 @@ SRC_URI = " \
 	file://fix-maybe-uninitialized-warnings-when-compiling-with-Os.patch \
 	file://dvbapi5-fix-old-kernel.patch \
 	file://hls-main-thread-block.patch \
+	file://06-Revert-disable-all-ipcpipeline-tests.patch \
 "
 
 EXTRA_OECONF += " \


### PR DESCRIPTION
This patch fix compile error to ipcpipeline tests from (oe-alliance-core)

> | Makefile:3129: recipe for target 'pipelines/pipelines_ipcpipeline-ipcpipeline.o' failed
| make[3]: *** [pipelines/pipelines_ipcpipeline-ipcpipeline.o] Error 1
| make[3]: *** Waiting for unfinished jobs....
| mipsel-oe-linux-libtool: link: mipsel-oe-linux-ar cru .libs/libparser.a elements/.libs/libparser_la-parser.o
| mipsel-oe-linux-ar: `u' modifier ignored since `D' is the default (see `U')
| mipsel-oe-linux-libtool: link: mipsel-oe-linux-ranlib .libs/libparser.a
| mipsel-oe-linux-libtool: link: ( cd ".libs" && rm -f "libparser.la" && ln -s "../libparser.la" "libparser.la" )