### PR TITLE
Revert "plugin: Unify static and dynamic plugin interface"

### DIFF
--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0/003-Revert-plugin-Unify-static-and-dynamic-plugin-interface.patch
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0/003-Revert-plugin-Unify-static-and-dynamic-plugin-interface.patch
@@ -1,0 +1,285 @@
+From e6435e6bb74db9c6d94effc42b7fb3937e617642 Mon Sep 17 00:00:00 2001
+From: Hains van den Bosch <hainsvdbosch@ziggo.nl>
+Date: Tue, 27 Jun 2017 21:16:33 +0200
+Subject: [PATCH] Revert "plugin: Unify static and dynamic plugin interface"
+
+commit:
+https://cgit.freedesktop.org/gstreamer/gstreamer/commit/?id=e7ede5a487d8c1571a4387a5f8eeb4d5e73a9553
+seems to break video with some plugins like exteplayer/gstplayer.
+Not tested by myself.
+Thanks fairbird for reporting and figure out the culprit commit.
+
+This reverts commit:
+https://cgit.freedesktop.org/gstreamer/gstreamer/commit/?id=e7ede5a487d8c1571a4387a5f8eeb4d5e73a9553
+---
+ gst/gst_private.h |   4 ++-
+ gst/gstplugin.c   | 100 ++++++++++++------------------------------------------
+ gst/gstplugin.h   |  62 ++++++++++++++++-----------------
+ 3 files changed, 55 insertions(+), 111 deletions(-)
+
+diff --git a/gst/gst_private.h b/gst/gst_private.h
+index e88bb60f5..ad43b3d8b 100644
+--- a/gst/gst_private.h
++++ b/gst/gst_private.h
+@@ -97,7 +97,7 @@ G_GNUC_INTERNAL  gboolean priv_gst_plugin_loading_have_whitelist (void);
+ 
+ G_GNUC_INTERNAL  guint32  priv_gst_plugin_loading_get_whitelist_hash (void);
+ 
+-G_GNUC_INTERNAL  gboolean priv_gst_plugin_desc_is_whitelisted (const GstPluginDesc * desc,
++G_GNUC_INTERNAL  gboolean priv_gst_plugin_desc_is_whitelisted (GstPluginDesc * desc,
+                                                                const gchar   * filename);
+ 
+ G_GNUC_INTERNAL  gboolean _priv_plugin_deps_env_vars_changed (GstPlugin * plugin);
+@@ -355,6 +355,8 @@ struct _GstPlugin {
+   /*< private >*/
+   GstPluginDesc	desc;
+ 
++  GstPluginDesc *orig_desc;
++
+   gchar *	filename;
+   gchar *	basename;       /* base name (non-dir part) of plugin path */
+ 
+diff --git a/gst/gstplugin.c b/gst/gstplugin.c
+index 12f874375..506478dcd 100644
+--- a/gst/gstplugin.c
++++ b/gst/gstplugin.c
+@@ -344,7 +344,7 @@ _priv_gst_plugin_initialize (void)
+  * name and the plugin's source package name, to keep the format simple.
+  */
+ static gboolean
+-gst_plugin_desc_matches_whitelist_entry (const GstPluginDesc * desc,
++gst_plugin_desc_matches_whitelist_entry (GstPluginDesc * desc,
+     const gchar * filename, const gchar * pattern)
+ {
+   const gchar *sep;
+@@ -406,7 +406,7 @@ done:
+ }
+ 
+ gboolean
+-priv_gst_plugin_desc_is_whitelisted (const GstPluginDesc * desc,
++priv_gst_plugin_desc_is_whitelisted (GstPluginDesc * desc,
+     const gchar * filename)
+ {
+   gchar **entry;
+@@ -681,55 +681,12 @@ gst_plugin_load_file (const gchar * filename, GError ** error)
+   return _priv_gst_plugin_load_file_for_registry (filename, NULL, error);
+ }
+ 
+-static gchar *
+-extract_symname (const char *filename)
+-{
+-  gchar *bname, *name, *symname;
+-  const gchar *dot;
+-  gsize prefix_len, len;
+-  int i;
+-
+-  bname = g_path_get_basename (filename);
+-  for (i = 0; bname[i]; ++i) {
+-    if (bname[i] == '-')
+-      bname[i] = '_';
+-  }
+-
+-  if (g_str_has_prefix (bname, "libgst"))
+-    prefix_len = 6;
+-  else if (g_str_has_prefix (bname, "lib"))
+-    prefix_len = 3;
+-  else if (g_str_has_prefix (bname, "gst"))
+-    prefix_len = 3;
+-  else
+-    prefix_len = 0;             /* use whole name (minus suffix) as plugin name */
+-
+-  dot = g_utf8_strchr (bname, -1, '.');
+-  if (dot)
+-    len = dot - bname - prefix_len;
+-  else
+-    len = strlen (bname + prefix_len);
+-
+-  name = g_strndup (bname + prefix_len, len);
+-  g_free (bname);
+-
+-  symname = g_strconcat ("gst_plugin_", name, "_get_desc", NULL);
+-  g_free (name);
+-
+-  return symname;
+-}
+-
+-/* Note: The return value is (transfer full) although we work with floating
+- * references here. If a new plugin instance is created, it is always sinked
+- * in the registry first and a new reference is returned
+- */
+ GstPlugin *
+ _priv_gst_plugin_load_file_for_registry (const gchar * filename,
+     GstRegistry * registry, GError ** error)
+ {
+-  const GstPluginDesc *desc;
++  GstPluginDesc *desc;
+   GstPlugin *plugin;
+-  gchar *symname;
+   GModule *module;
+   gboolean ret;
+   gpointer ptr;
+@@ -798,20 +757,7 @@ _priv_gst_plugin_load_file_for_registry (const gchar * filename,
+     goto return_error;
+   }
+ 
+-  symname = extract_symname (filename);
+-  ret = g_module_symbol (module, symname, &ptr);
+-
+-  if (ret) {
+-    GstPluginDesc *(*get_desc) (void) = ptr;
+-    ptr = get_desc ();
+-  } else {
+-    GST_DEBUG ("Could not find symbol '%s', falling back to gst_plugin_desc",
+-        symname);
+-    ret = g_module_symbol (module, "gst_plugin_desc", &ptr);
+-  }
+-
+-  g_free (symname);
+-
++  ret = g_module_symbol (module, "gst_plugin_desc", &ptr);
+   if (!ret) {
+     GST_DEBUG ("Could not find plugin entry point in \"%s\"", filename);
+     g_set_error (error,
+@@ -822,7 +768,7 @@ _priv_gst_plugin_load_file_for_registry (const gchar * filename,
+     goto return_error;
+   }
+ 
+-  desc = (const GstPluginDesc *) ptr;
++  desc = (GstPluginDesc *) ptr;
+ 
+   if (priv_gst_plugin_loading_have_whitelist () &&
+       !priv_gst_plugin_desc_is_whitelisted (desc, filename)) {
+@@ -843,30 +789,28 @@ _priv_gst_plugin_load_file_for_registry (const gchar * filename,
+   }
+ 
+   plugin->module = module;
++  plugin->orig_desc = desc;
+ 
+   if (new_plugin) {
+     /* check plugin description: complain about bad values and fail */
+-    CHECK_PLUGIN_DESC_FIELD (desc, name, filename);
+-    CHECK_PLUGIN_DESC_FIELD (desc, description, filename);
+-    CHECK_PLUGIN_DESC_FIELD (desc, version, filename);
+-    CHECK_PLUGIN_DESC_FIELD (desc, license, filename);
+-    CHECK_PLUGIN_DESC_FIELD (desc, source, filename);
+-    CHECK_PLUGIN_DESC_FIELD (desc, package, filename);
+-    CHECK_PLUGIN_DESC_FIELD (desc, origin, filename);
+-
+-    if (desc->name != NULL && desc->name[0] == '"') {
++    CHECK_PLUGIN_DESC_FIELD (plugin->orig_desc, name, filename);
++    CHECK_PLUGIN_DESC_FIELD (plugin->orig_desc, description, filename);
++    CHECK_PLUGIN_DESC_FIELD (plugin->orig_desc, version, filename);
++    CHECK_PLUGIN_DESC_FIELD (plugin->orig_desc, license, filename);
++    CHECK_PLUGIN_DESC_FIELD (plugin->orig_desc, source, filename);
++    CHECK_PLUGIN_DESC_FIELD (plugin->orig_desc, package, filename);
++    CHECK_PLUGIN_DESC_FIELD (plugin->orig_desc, origin, filename);
++
++    if (plugin->orig_desc->name != NULL && plugin->orig_desc->name[0] == '"') {
+       g_warning ("Invalid plugin name '%s' - fix your GST_PLUGIN_DEFINE "
+-          "(remove quotes around plugin name)", desc->name);
++          "(remove quotes around plugin name)", plugin->orig_desc->name);
+     }
+ 
+-    if (desc->release_datetime != NULL &&
+-        !check_release_datetime (desc->release_datetime)) {
+-      g_warning ("GstPluginDesc for '%s' has invalid datetime '%s'",
+-          filename, desc->release_datetime);
+-      g_set_error (error, GST_PLUGIN_ERROR, GST_PLUGIN_ERROR_MODULE,
+-          "Plugin %s has invalid plugin description field 'release_datetime'",
+-          filename);
+-      goto return_error;
++    if (plugin->orig_desc->release_datetime != NULL &&
++        !check_release_datetime (plugin->orig_desc->release_datetime)) {
++      GST_ERROR ("GstPluginDesc for '%s' has invalid datetime '%s'",
++          filename, plugin->orig_desc->release_datetime);
++      plugin->orig_desc->release_datetime = NULL;
+     }
+   }
+ 
+@@ -880,7 +824,7 @@ _priv_gst_plugin_load_file_for_registry (const gchar * filename,
+   GST_LOG ("Plugin %p for file \"%s\" prepared, registering...",
+       plugin, filename);
+ 
+-  if (!gst_plugin_register_func (plugin, desc, NULL)) {
++  if (!gst_plugin_register_func (plugin, plugin->orig_desc, NULL)) {
+     /* remove signal handler */
+     _gst_plugin_fault_handler_restore ();
+     GST_DEBUG ("gst_plugin_register_func failed for plugin \"%s\"", filename);
+diff --git a/gst/gstplugin.h b/gst/gstplugin.h
+index 7258388ab..589e1e763 100644
+--- a/gst/gstplugin.h
++++ b/gst/gstplugin.h
+@@ -248,40 +248,38 @@ struct _GstPluginDesc {
+  * If defined, the GST_PACKAGE_RELEASE_DATETIME will also be used for the
+  * #GstPluginDesc,release_datetime field.
+  */
+-#define GST_PLUGIN_DEFINE(major,minor,name,description,init,version,license,package,origin) \
++#ifdef GST_PLUGIN_BUILD_STATIC
++#define GST_PLUGIN_DEFINE(major,minor,name,description,init,version,license,package,origin)	\
++G_BEGIN_DECLS						\
++GST_PLUGIN_EXPORT void G_PASTE(gst_plugin_, G_PASTE(name, _register)) (void);			\
++							\
++void							\
++G_PASTE(gst_plugin_, G_PASTE(name, _register)) (void)	\
++{							\
++  gst_plugin_register_static (major, minor, G_STRINGIFY(name),	\
++      description, init, version, license,		\
++      PACKAGE, package, origin);			\
++}							\
++G_END_DECLS
++#else /* !GST_PLUGIN_BUILD_STATIC */
++#define GST_PLUGIN_DEFINE(major,minor,name,description,init,version,license,package,origin)	\
+ G_BEGIN_DECLS \
+-GST_PLUGIN_EXPORT const GstPluginDesc * G_PASTE(gst_plugin_, G_PASTE(name, _get_desc)) (void); \
+-GST_PLUGIN_EXPORT void G_PASTE(gst_plugin_, G_PASTE(name, _register)) (void); \
+-\
+-static const GstPluginDesc gst_plugin_desc = { \
+-  major, \
+-  minor, \
+-  G_STRINGIFY(name), \
+-  (gchar *) description, \
+-  init, \
+-  version, \
+-  license, \
+-  PACKAGE, \
+-  package, \
+-  origin, \
+-  __GST_PACKAGE_RELEASE_DATETIME, \
+-  GST_PADDING_INIT \
+-};                                       \
+-\
+-const GstPluginDesc * \
+-G_PASTE(gst_plugin_, G_PASTE(name, _get_desc)) (void) \
+-{ \
+-    return &gst_plugin_desc; \
+-} \
+-\
+-void \
+-G_PASTE(gst_plugin_, G_PASTE(name, _register)) (void) \
+-{ \
+-  gst_plugin_register_static (major, minor, G_STRINGIFY(name), \
+-      description, init, version, license, \
+-      PACKAGE, package, origin); \
+-} \
++GST_PLUGIN_EXPORT GstPluginDesc gst_plugin_desc = {	\
++  major,						\
++  minor,						\
++  G_STRINGIFY(name),                                    \
++  (gchar *) description,				\
++  init,							\
++  version,						\
++  license,						\
++  PACKAGE,						\
++  package,						\
++  origin,						\
++  __GST_PACKAGE_RELEASE_DATETIME,                       \
++  GST_PADDING_INIT				        \
++}; \
+ G_END_DECLS
++#endif /* GST_PLUGIN_BUILD_STATIC */
+ 
+ /**
+  * GST_LICENSE_UNKNOWN:
+-- 
+2.11.0
+

--- a/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0_git.bb
+++ b/meta-openpli/recipes-multimedia/gstreamer/gstreamer1.0_git.bb
@@ -9,5 +9,6 @@ SRC_URI = " \
 	git://anongit.freedesktop.org/gstreamer/gstreamer;branch=${GST_BRANCH};name=base \
 	file://0001-revert-use-new-gst-adapter-get-buffer.patch \
 	file://0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch \
+	file://003-Revert-plugin-Unify-static-and-dynamic-plugin-interface.patch \
 "
 


### PR DESCRIPTION
Fix break video with some plugins like exteplayer/gstplayer.

This reverts commit:
https://cgit.freedesktop.org/gstreamer/gstreamer/commit/?id=e7ede5a487d8c1571a4387a5f8eeb4d5e73a9553