### PR TITLE
Update ffmpeg 3.4 bbappend

### DIFF
--- a/meta-openpli/recipes-multimedia/ffmpeg/ffmpeg_3.%.bbappend
+++ b/meta-openpli/recipes-multimedia/ffmpeg/ffmpeg_3.%.bbappend
@@ -63,7 +63,7 @@ EXTRA_FFCONF = " \
     --disable-manpages \
     --disable-podpages \
     --disable-txtpages \
-    ${@bb.utils.contains("TARGET_ARCH", "mipsel", "${MIPSFPU} --disable-vfp --disable-neon", "", d)} \
+    ${@bb.utils.contains("TARGET_ARCH", "mipsel", "${MIPSFPU} --disable-vfp --disable-neon --disable-mipsdsp --disable-mipsdspr2", "", d)} \
     ${@bb.utils.contains("TARGET_ARCH", "arm", "--enable-armv6 --enable-armv6t2 --enable-vfp --enable-neon", "", d)} \
     ${@bb.utils.contains("TUNE_FEATURES", "aarch64", "--enable-armv8 --enable-vfp --enable-neon", "", d)} \
     --disable-debug \


### PR DESCRIPTION
- broadcom soc's don't feature mipsel cpu's with r2 dsp support
Without these flags, the linker will give us warnings