### PR TITLE
exteplayer3: update to git HEAD master

### DIFF
--- a/meta-openpli/conf/distro/reporefs.conf
+++ b/meta-openpli/conf/distro/reporefs.conf
@@ -38,7 +38,7 @@ SRCREV_pn-enigma2-plugin-settings-hans-kabelnl = "${AUTOREV}"
 SRCREV_pn-enigma2-plugins = "${AUTOREV}"
 
 SRCREV_pn-libdreamdvd = "${AUTOREV}"
-SRCREV_pn-exteplayer3 = "74c7263cd7ed3a8074cafecb801d81d50379f5cd"
+SRCREV_pn-exteplayer3 = "${AUTOREV}"
 SRCREV_pn-gstplayer = "${AUTOREV}"
 SRCREV_pn-libdvdread = "${AUTOREV}"
 SRCREV_pn-dcadec = "${AUTOREV}"

--- a/meta-openpli/recipes-multimedia/exteplayer3/exteplayer3_git.bb
+++ b/meta-openpli/recipes-multimedia/exteplayer3/exteplayer3_git.bb
@@ -51,6 +51,7 @@ output/writer/sh4/pcm.c \
 output/writer/sh4/vc1.c \
 output/writer/sh4/wma.c \
 output/writer/sh4/wmv.c ", " \
+output/linuxdvb_buffering.c \
 output/linuxdvb_mipsel.c \
 output/writer/mipsel/writer.c \
 output/writer/mipsel/aac.c \


### PR DESCRIPTION
No exteplayer has patches for ffmpeg 3.4.2
https://github.com/samsamsam-iptvplayer/exteplayer3/commit/b2e73a598378ceab3ea15b043e7b66c7fe14c3c0

Added linuxdvb_buffering.c to source, see commit:
https://github.com/samsamsam-iptvplayer/exteplayer3/commit/86c7be1cdea3a05c9b3edcd845c3d24c9a2d4499

No tested for sh4.