### PR TITLE
exteplayer3: update recipe

### DIFF
--- a/meta-openpli/recipes-multimedia/exteplayer3/exteplayer3_git.bb
+++ b/meta-openpli/recipes-multimedia/exteplayer3/exteplayer3_git.bb
@@ -8,8 +8,8 @@ DEPENDS = "ffmpeg"
 
 inherit gitpkgv
 
-PV = "47+gitr${SRCPV}"
-PKGV = "47+gitr${GITPKGV}"
+PV = "49+gitr${SRCPV}"
+PKGV = "49+gitr${GITPKGV}"
 
 SRC_URI = "git://github.com/samsamsam-iptvplayer/exteplayer3.git;branch=master"
 
@@ -27,6 +27,7 @@ SOURCE_FILES =+ "output/output_subtitle.c"
 SOURCE_FILES =+ "output/output.c"
 SOURCE_FILES =+ "output/writer/common/pes.c"
 SOURCE_FILES =+ "output/writer/common/misc.c"
+SOURCE_FILES =+ "output/writer/common/writer.c"
 SOURCE_FILES =+ "playback/playback.c"
 SOURCE_FILES =+ "external/ffmpeg/src/bitstream.c"
 SOURCE_FILES =+ "external/ffmpeg/src/latmenc.c"


### PR DESCRIPTION
To fix build.

writer.c:(.text+0x26c): undefined reference to `FlusPipe'
| writer.c:(.text+0x3e0): undefined reference to `FlusPipe'

https://github.com/samsamsam-iptvplayer/exteplayer3/commit/1127e2997d9616e09539884e8991b6f66170939e