### PR TITLE
Move source file since it applies to all architectures now.

### DIFF
--- a/meta-openpli/recipes-multimedia/exteplayer3/exteplayer3_git.bb
+++ b/meta-openpli/recipes-multimedia/exteplayer3/exteplayer3_git.bb
@@ -28,6 +28,7 @@ SOURCE_FILES =+ "output/output.c"
 SOURCE_FILES =+ "output/writer/common/pes.c"
 SOURCE_FILES =+ "output/writer/common/misc.c"
 SOURCE_FILES =+ "output/writer/common/writer.c"
+SOURCE_FILES =+ "output/linuxdvb_buffering.c"
 SOURCE_FILES =+ "playback/playback.c"
 SOURCE_FILES =+ "external/ffmpeg/src/bitstream.c"
 SOURCE_FILES =+ "external/ffmpeg/src/latmenc.c"
@@ -52,7 +53,6 @@ output/writer/sh4/pcm.c \
 output/writer/sh4/vc1.c \
 output/writer/sh4/wma.c \
 output/writer/sh4/wmv.c ", " \
-output/linuxdvb_buffering.c \
 output/linuxdvb_mipsel.c \
 output/writer/mipsel/writer.c \
 output/writer/mipsel/aac.c \


### PR DESCRIPTION
output/linuxdvb_buffering.c is required for all architectures now.
so we move it to the top :)