### PR TITLE
Backup Suite: revision update 370

### DIFF
--- a/meta-openpli/conf/distro/reporefs.conf
+++ b/meta-openpli/conf/distro/reporefs.conf
@@ -1,6 +1,6 @@
 SRCREV_pn-enigma2-plugin-extensions-automatic-fullbackup = "bf819dec1a4fb67c8cc8140e6077f33c2c5d97a9"
 
-SRCREV_pn-enigma2-plugin-extensions-backupsuite = "5cb829bdbdafa3311004e05e99ccdd56c1ae75f4"
+SRCREV_pn-enigma2-plugin-extensions-backupsuite = "8f1c675286759b51a903175cbe0fa9b356e34552"
 SRCREV_pn-enigma2-plugin-extensions-blurayplayer = "73be06bdee0b3dad40e485418546b3f1d9c6150a"
 
 SRCREV_pn-enigma2-plugin-extensions-dlnabrowser = "bf98d039922c7028569dcfe5f8abc420f7ad261d"


### PR DESCRIPTION
Git 351-370
- Zgemma H7/H9 kernel detection fixed.
- Protek 4K support
- GigaBlue 4K kernel detection fixed.
- plugin.py changes for new Vivant Dinobot 4K models and Protek 4K
- More Vivant Dinobot support (4K)
- Amiko Viper Slim support
- Italian translation updated, Thanks to https://github.com/Gringit
- Bulgarian translation added, Thanks to https://github.com/marto74bg
- et11000 kernel detection fixed.