### PR TITLE
Update openpli-common.conf

### DIFF
--- a/meta-openpli/conf/distro/openpli-common.conf
+++ b/meta-openpli/conf/distro/openpli-common.conf
@@ -47,6 +47,9 @@ COMMERCIAL_VIDEO_PLUGINS ?= "gst-plugins-ugly-mpeg2dec gst-plugins-ugly-mpegstre
 # UPDATE: We don't support receivers with small flash anymore.
 # So default to 02 for faster code
 FULL_OPTIMIZATION = "-O2 -pipe ${DEBUG_FLAGS}"
+FULL_OPTIMIZATION_dm500hd = "-Os -pipe ${DEBUG_FLAGS}"
+FULL_OPTIMIZATION_dm800 = "-Os -pipe ${DEBUG_FLAGS}"
+FULL_OPTIMIZATION_dm800se = "-Os -pipe ${DEBUG_FLAGS}"
 # build some core libs with better compiler optimization for better performance
 O2_OPT = "-O2 -pipe ${DEBUG_FLAGS}"
 O3_OPT = "-O3 -pipe ${DEBUG_FLAGS}"


### PR DESCRIPTION
I know PLi won't support dm500hd/dm800/dm800se anymore but with this configuration we can build compressed images again, see: https://github.com/PLi-metas/pli-extras#how-to-build-compressed-images-for-smallflash-stbs

It won't harm anything and it's a good thing to have what could work in this file as a reference for other developers.