### PR TITLE
Update layer.conf

### DIFF
--- a/meta-dream/conf/layer.conf
+++ b/meta-dream/conf/layer.conf
@@ -2,3 +2,13 @@
 BBPATH .= ":${LAYERDIR}"
 
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb"
+
+FULL_OPTIMIZATION_dm500hd = "-Os -pipe ${DEBUG_FLAGS}"
+O2_OPT_dm500hd = "-Os -pipe ${DEBUG_FLAGS}"
+O3_OPT_dm500hd = "-Os -pipe ${DEBUG_FLAGS}"
+FULL_OPTIMIZATION_dm800 = "-Os -pipe ${DEBUG_FLAGS}"
+O2_OPT_dm800 = "-Os -pipe ${DEBUG_FLAGS}"
+O3_OPT_dm800 = "-Os -pipe ${DEBUG_FLAGS}"
+FULL_OPTIMIZATION_dm800se = "-Os -pipe ${DEBUG_FLAGS}"
+O2_OPT_dm800se = "-Os -pipe ${DEBUG_FLAGS}"
+O3_OPT_dm800se = "-Os -pipe ${DEBUG_FLAGS}"


### PR DESCRIPTION
I know PLi won't support dm500hd/dm800/dm800se anymore but with this configuration we can build compressed images again, see: https://github.com/PLi-metas/pli-extras/tree/8ea9b0e7cc32c693af6106210c4712dc2201860c#how-to-build-compressed-images-for-smallflash-stbs

It won't harm anything and it's a good thing to have what could work in this file as a reference for other developers.

It works for all small flash boxes as we do this for azboxhd too.

You can build and use Open PLi 6.x with pli-extras and see for yourself but we use UPX compression too ;) So FULL_OPTIMIZATION and UPX.

UPX example: https://github.com/PLi-metas/pli-extras/blob/develop/recipes-multimedia/exteplayer3/exteplayer3_git.bbappend

What UPX does: https://github.com/PLi-metas/pli-extras/blob/develop/classes/upx_compress.bbclass