### PR TITLE
libudfread: remove unnecessary SRCREV

### DIFF
--- a/meta-openpli/recipes-support/libudfread/libudfread_git.bb
+++ b/meta-openpli/recipes-support/libudfread/libudfread_git.bb
@@ -5,11 +5,10 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM="file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 SRC_URI = "git://git.videolan.org/libudfread.git;branch=master;protocol=git"
-SRCREV="50d41b171c90d299ee3f685bbe6298d15a44eec0"
 
 inherit gitpkgv autotools-brokensep pkgconfig
 
-PV = "0.0.0+git${SRCPV}"
-PKGV = "0.0.0+git${GITPKGV}"
+PV = "1.0.0+git${SRCPV}"
+PKGV = "1.0.0+git${GITPKGV}"
 
 S="${WORKDIR}/git"


### PR DESCRIPTION
As it is already set to AUTOREV in reporefs.conf and
SRCREV in the recipe will be overruled by that.

Also for cosmetic bump version to 1.0.0
http://git.videolan.org/?p=libudfread.git;a=commit;h=7663e6ac543374d430eaf36475e0ed70cf3864ac