### PR TITLE
Update softcams-enigma2-meta.bb

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-softcams/softcams-enigma2-meta.bb
+++ b/meta-openpli/recipes-openpli/enigma2-softcams/softcams-enigma2-meta.bb
@@ -14,7 +14,7 @@ DEPENDS_append_mipsel = "\
 
 # other softcams
 DEPENDS += " \
-	enigma2-plugin-softcams-cccam \
+	${@bb.utils.contains("TARGET_ARCH", "aarch64", "", "enigma2-plugin-softcams-cccam", d)} \
 	enigma2-plugin-softcams-oscam \
 	enigma2-plugin-softcams-oscam-emu \
 	"


### PR DESCRIPTION
We don't have an "aarch64" binary for CCcam.