### PR TITLE
openpli-enigma2-feed.bb: Enable Backup Suite for dreamboxes too.

### DIFF
--- a/meta-openpli/recipes-openpli/images/openpli-enigma2-feed.bb
+++ b/meta-openpli/recipes-openpli/images/openpli-enigma2-feed.bb
@@ -145,7 +145,7 @@ ENIGMA2_OPTIONAL = " \
 	softcams-enigma2-meta \
 	packagegroup-openplugins \
 	${@bb.utils.contains("MACHINE_FEATURES", "blindscan-dvbs", "enigma2-plugin-systemplugins-satscan" , "", d)} \
-	${@bb.utils.contains("MACHINE_FEATURES", "dreambox", "", "enigma2-plugin-extensions-backupsuite", d)} \
+	enigma2-plugin-extensions-backupsuite \
 	${@bb.utils.contains('EXTRA_IMAGEDEPENDS', 'vuplus-tuner-turbo', 'enigma2-plugin-drivers-dvb-usb-turbo', '', d)} \
 	${@bb.utils.contains('OPENPLI_FEATURES', 'kodi', 'enigma2-plugin-extensions-kodi', '', d)} \
 	${@bb.utils.contains('MACHINE_FEATURES', 'kodi', 'enigma2-plugin-extensions-kodi', '', d)} \


### PR DESCRIPTION
We support dreamboxes in Backup Suite (all of them) and they work just fine.