### PR TITLE
dvbsnoop.bb: Version 1.4.54

### DIFF
--- a/meta-openpli/recipes-multimedia/dvbsnoop/dvbsnoop.bb
+++ b/meta-openpli/recipes-multimedia/dvbsnoop/dvbsnoop.bb
@@ -7,8 +7,8 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
 
 inherit gitpkgv
 
-PV = "1.4.53"
-PKGV = "1.4.53+git${GITPKGV}"
+PV = "1.4.54"
+PKGV = "1.4.54+git${GITPKGV}"
 
 SRC_URI = "git://github.com/PLi-metas/dvbsnoop.git;protocol=git"
 


### PR DESCRIPTION
New: dvb_api.h is compatible with old V4L DVB headers now.
New: Experimental BBFrame filtering support. (Reverted)
Fix: Add missing autogen.sh