### PR TITLE
initial multilib support

### DIFF
--- a/meta-openpli/recipes-multimedia/tuxtxt/tuxtxt-enigma2.bb
+++ b/meta-openpli/recipes-multimedia/tuxtxt/tuxtxt-enigma2.bb
@@ -16,8 +16,8 @@ PKGV = "2.0+git${GITPKGV}"
 PR = "r3"
 
 PACKAGES = "${PN}-src ${PN}-dbg ${PN}-dev ${PN}"
-FILES_${PN}-src = "/usr/src /usr/lib/enigma2/python/Plugins/Extensions/Tuxtxt/*.py"
-FILES_${PN} = "/usr/lib/libtuxtxt32bpp.so.* /usr/share/fonts /usr/lib/enigma2/python/Plugins/Extensions/Tuxtxt/*.pyo /etc/tuxtxt"
+FILES_${PN}-src = "/usr/src ${libdir}/enigma2/python/Plugins/Extensions/Tuxtxt/*.py"
+FILES_${PN} = "${libdir}/libtuxtxt32bpp.so.* /usr/share/fonts ${libdir}/enigma2/python/Plugins/Extensions/Tuxtxt/*.pyo /etc/tuxtxt"
 CONFFILES_${PN} = "/etc/tuxtxt/tuxtxt2.conf"
 
 inherit autotools pkgconfig
@@ -29,7 +29,7 @@ EXTRA_OECONF = "--with-boxtype=generic --with-configdir=/etc \
 
 do_install_append() {
 	# remove unused .pyc files
-	find ${D}/usr/lib/enigma2/python/ -name '*.pyc' -exec rm {} \;
+	find ${D}${libdir}/enigma2/python/ -name '*.pyc' -exec rm {} \;
 }
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/meta-openpli/recipes-multimedia/vlc/libaacs_git.bb
+++ b/meta-openpli/recipes-multimedia/vlc/libaacs_git.bb
@@ -6,7 +6,7 @@ DEPENDS = "libgcrypt"
 PV = "0.3.0+git${SRCPV}"
 PR = "r1"
 
-SRC_URI = "git://git.videolan.org/${PN}.git;protocol=git"
+SRC_URI = "git://git.videolan.org/libaacs.git;protocol=git"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openpli/recipes-openpli/e2openplugins/enigma2-plugin-extensions-autobackup.bb
+++ b/meta-openpli/recipes-openpli/e2openplugins/enigma2-plugin-extensions-autobackup.bb
@@ -11,5 +11,5 @@ require openplugins-distutils.inc
 # and decided that this would be good enough until someone explains how to do this properly
 # with distutils.
 do_install_append() {
-	chmod a+x ${D}/usr/lib/enigma2/python/Plugins/*/*/*.sh
+	chmod a+x ${D}${libdir}/enigma2/python/Plugins/*/*/*.sh
 }

--- a/meta-openpli/recipes-openpli/e2openplugins/enigma2-plugin-extensions-openwebif.bb
+++ b/meta-openpli/recipes-openpli/e2openplugins/enigma2-plugin-extensions-openwebif.bb
@@ -29,7 +29,7 @@ do_compile() {
 	python -O -m compileall -d ${PLUGINPATH} ${S}/plugin
 }
 
-PLUGINPATH = "/usr/lib/enigma2/python/Plugins/Extensions/${MODULE}"
+PLUGINPATH = "${libdir}/enigma2/python/Plugins/Extensions/${MODULE}"
 do_install_append() {
 	install -d ${D}${PLUGINPATH}
 	cp -r ${S}/plugin/* ${D}${PLUGINPATH}

--- a/meta-openpli/recipes-openpli/enigma2/enigma2.bb
+++ b/meta-openpli/recipes-openpli/enigma2/enigma2.bb
@@ -149,35 +149,35 @@ EXTRA_OEMAKE = "\
 
 # Swig generated 200k enigma.py file has no purpose for end users
 FILES_${PN}-src += "\
-	/usr/lib/enigma2/python/enigma.py \
+	${libdir}/enigma2/python/enigma.py \
 	"
 
 # some plugins contain so's, their stripped symbols should not end up in the enigma2 package
 FILES_${PN}-dbg += "\
-	/usr/lib/enigma2/python/Plugins/*/*/.debug \
+	${libdir}/enigma2/python/Plugins/*/*/.debug \
 	"
 
 # Save some space by not installing sources (mytest.py must remain)
 FILES_${PN}-src = "\
-	/usr/lib/enigma2/python/GlobalActions.py \
-	/usr/lib/enigma2/python/Navigation.py \
-	/usr/lib/enigma2/python/NavigationInstance.py \
-	/usr/lib/enigma2/python/RecordTimer.py \
-	/usr/lib/enigma2/python/ServiceReference.py \
-	/usr/lib/enigma2/python/SleepTimer.py \
-	/usr/lib/enigma2/python/e2reactor.py \
-	/usr/lib/enigma2/python/keyids.py \
-	/usr/lib/enigma2/python/keymapparser.py \
-	/usr/lib/enigma2/python/skin.py \
-	/usr/lib/enigma2/python/timer.py \
-	/usr/lib/enigma2/python/*/*.py \
-	/usr/lib/enigma2/python/*/*/*.py \
-	/usr/lib/enigma2/python/*/*/*/*.py \
+	${libdir}/enigma2/python/GlobalActions.py \
+	${libdir}/enigma2/python/Navigation.py \
+	${libdir}/enigma2/python/NavigationInstance.py \
+	${libdir}/enigma2/python/RecordTimer.py \
+	${libdir}/enigma2/python/ServiceReference.py \
+	${libdir}/enigma2/python/SleepTimer.py \
+	${libdir}/enigma2/python/e2reactor.py \
+	${libdir}/enigma2/python/keyids.py \
+	${libdir}/enigma2/python/keymapparser.py \
+	${libdir}/enigma2/python/skin.py \
+	${libdir}/enigma2/python/timer.py \
+	${libdir}/enigma2/python/*/*.py \
+	${libdir}/enigma2/python/*/*/*.py \
+	${libdir}/enigma2/python/*/*/*/*.py \
 	"
 
 do_install_append() {
 	install -d ${D}/usr/share/keymaps
-	find ${D}/usr/lib/enigma2/python/ -name '*.pyc' -exec rm {} \;
+	find ${D}${libdir}/enigma2/python/ -name '*.pyc' -exec rm {} \;
 }
 
 python populate_packages_prepend() {


### PR DESCRIPTION
This replaces the hardcoded lib path with a variable to allow for [multilib](https://www.yoctoproject.org/docs/current/dev-manual/dev-manual.html#combining-multiple-versions-library-files-into-one-image) builds, similar to [oealliance recent changes](https://github.com/oe-alliance/oe-alliance-core/search?q=multilib&type=Commits)
PS: There are a lot more recipes to be fixed but this PR only fixes the basic recipes needed for openpli-enigma2-image, and we can fix other images on subsequent PRs.