### PR TITLE
Serviceapp requires curl for script support

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-systemplugins-serviceapp.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-systemplugins-serviceapp.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 DEPENDS = "enigma2 uchardet openssl"
-RDEPENDS_${PN} = "enigma2 uchardet openssl python-json"
+RDEPENDS_${PN} = "enigma2 uchardet openssl python-json curl"
 RRECOMMENDS_${PN} = "exteplayer3 gstplayer"
 
 SRC_URI = "git://github.com/mx3L/serviceapp.git;branch=develop"


### PR DESCRIPTION
ServiceApp recently got support for running scripts.
So we also install curl, as this is mostly used for url processing.