### PR TITLE
reporefs.conf: Backup Suite revision update

### DIFF
--- a/meta-openpli/conf/distro/reporefs.conf
+++ b/meta-openpli/conf/distro/reporefs.conf
@@ -1,6 +1,6 @@
 SRCREV_pn-enigma2-plugin-extensions-automatic-fullbackup = "bf819dec1a4fb67c8cc8140e6077f33c2c5d97a9"
 
-SRCREV_pn-enigma2-plugin-extensions-backupsuite = "8f1c675286759b51a903175cbe0fa9b356e34552"
+SRCREV_pn-enigma2-plugin-extensions-backupsuite = "ffaac81851ae459ce2d0b7560624ae24bbd1f7ef"
 SRCREV_pn-enigma2-plugin-extensions-blurayplayer = "73be06bdee0b3dad40e485418546b3f1d9c6150a"
 
 SRCREV_pn-enigma2-plugin-extensions-dlnabrowser = "bf98d039922c7028569dcfe5f8abc420f7ad261d"


### PR DESCRIPTION
Git 376-388
- schermen.py : menu button for MMC (Only full hd skins for now).
- MMC support, Now you can create backups on MMC (/media/mmc) with Menu button.
- Persian language added.
- Zgemma H9 changes for restore problem, still not ready.
- BackupSuite.pot and all po files updated with latest strings (MMC support).
- French translation updated, Thanks to https://github.com/pr2git
- Qviart Lunix2 4K support

Git 371-375
- Evo Nova Combo/IP/Twin support
- plugin.py changes for Clap CC1 4K
- Clap CC1 4K support
- Iqon Force 4 support