### PR TITLE
set back use_localtime to its default value NO to see the correct

### DIFF
--- a/meta-openpli/recipes-daemons/vsftpd/vsftpd/vsftpd.conf
+++ b/meta-openpli/recipes-daemons/vsftpd/vsftpd/vsftpd.conf
@@ -127,7 +127,7 @@ userlist_enable=NO
 # If enabled,  vsftpd  will display directory listings with the time in your
 # local time zone. The default is to display GMT. The times returned by the
 # MDTM FTP command are also affected by this option.
-use_localtime=YES
+use_localtime=NO
 #
 # If set to YES, local users will be (by default) placed in a chroot() jail in
 # their home directory after login.  Warning: This  option has  security  


### PR DESCRIPTION
file time in FTP client