### PR TITLE
python2-native: fix build with gcc 8

### DIFF
--- a/meta-openpli/recipes-devtools/python/python-native/fix-gc-alignment.patch
+++ b/meta-openpli/recipes-devtools/python/python-native/fix-gc-alignment.patch
@@ -1,0 +1,43 @@
+Upstream-Status: Submitted
+Signed-off-by: Ross Burton <ross.burton@intel.com>
+
+Fix for over-aligned GC info
+Patch by Florian Weimer
+
+See: https://bugzilla.redhat.com/show_bug.cgi?id=1540316
+Upstream discussion: https://mail.python.org/pipermail/python-dev/2018-January/152000.html
+
+diff --git a/Include/objimpl.h b/Include/objimpl.h
+index 55e83eced6..aa906144dc 100644
+--- a/Include/objimpl.h
++++ b/Include/objimpl.h
+@@ -248,6 +248,18 @@ PyAPI_FUNC(PyVarObject *) _PyObject_GC_Resize(PyVarObject *, Py_ssize_t);
+ /* for source compatibility with 2.2 */
+ #define _PyObject_GC_Del PyObject_GC_Del
+ 
++/* Former over-aligned definition of PyGC_Head, used to compute the
++   size of the padding for the new version below. */
++union _gc_head;
++union _gc_head_old {
++    struct {
++        union _gc_head *gc_next;
++        union _gc_head *gc_prev;
++        Py_ssize_t gc_refs;
++    } gc;
++    long double dummy;
++};
++
+ /* GC information is stored BEFORE the object structure. */
+ typedef union _gc_head {
+     struct {
+@@ -255,7 +267,8 @@ typedef union _gc_head {
+         union _gc_head *gc_prev;
+         Py_ssize_t gc_refs;
+     } gc;
+-    long double dummy;  /* force worst-case alignment */
++    double dummy;  /* force worst-case alignment */
++    char dummy_padding[sizeof(union _gc_head_old)];
+ } PyGC_Head;
+ 
+ extern PyGC_Head *_PyGC_generation0;
+ 

--- a/meta-openpli/recipes-devtools/python/python-native_2.7.13.bbappend
+++ b/meta-openpli/recipes-devtools/python/python-native_2.7.13.bbappend
@@ -1,3 +1,5 @@
 MY_EXTRA_PATH := "${THISDIR}"
 FILESPATH .= ":${MY_EXTRA_PATH}/python-native/"
-SRC_URI += "file://04-default-is-optimized.patch"
+SRC_URI += "file://04-default-is-optimized.patch \
+			file://fix-gc-alignment.patch \
+			"


### PR DESCRIPTION
Backport patch from commit:
http://cgit.openembedded.org/openembedded-core/commit/?h=sumo&id=04c2d53ef48a09747d0577d9ec1ffa548d247615

To fix build python-native 2 with distro's which has gcc 8 as default host compiler like Fedora 28, Ubuntu 18.10
and Arch Linux.

Error:

| if test $? -ne 0 ; then \
|	echo "generate-posix-vars failed" ; \
|	rm -f ./pybuilddir.txt ; \
|      exit 1 ; \
| fi
| Segmentation fault (core dumped)
| generate-posix-vars failed
| make: *** [Makefile:515: pybuilddir.txt] Error 1
| ERROR: oe_runmake failed
| WARNING: exit code 1 from a shell command.