### PR TITLE
perl-native: fix building on linux 4.16 and newer

### DIFF
--- a/meta-openpli/recipes-devtools/perl/perl-native/0001-pp-Guard-fix-for-really-old-bug-in-glibc-libcrypt.patch
+++ b/meta-openpli/recipes-devtools/perl/perl-native/0001-pp-Guard-fix-for-really-old-bug-in-glibc-libcrypt.patch
@@ -1,0 +1,34 @@
+From 046b0bfd29a9bec4e40dadfb1ebf0321efff3f8b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Bj=C3=B6rn=20Esser?= <besser82@fedoraproject.org>
+Date: Thu, 25 Jan 2018 09:10:49 +0100
+Subject: [PATCH] pp: Guard fix for really old bug in glibc libcrypt
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Petr Písař <ppisar@redhat.com>
+---
+ pp.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/pp.c b/pp.c
+index d50ad7ddbf..6510c7b15c 100644
+--- a/pp.c
++++ b/pp.c
+@@ -3650,8 +3650,12 @@ PP(pp_crypt)
+ #if defined(__GLIBC__) || defined(__EMX__)
+ 	if (PL_reentrant_buffer->_crypt_struct_buffer) {
+ 	    PL_reentrant_buffer->_crypt_struct_buffer->initialized = 0;
+-	    /* work around glibc-2.2.5 bug */
++#if (defined(__GLIBC__) && __GLIBC__ == 2) && \
++    (defined(__GLIBC_MINOR__) && __GLIBC_MINOR__ >= 2 && __GLIBC_MINOR__ < 4)
++	    /* work around glibc-2.2.5 bug, has been fixed at some
++	     * time in glibc-2.3.X */
+ 	    PL_reentrant_buffer->_crypt_struct_buffer->current_saltbits = 0;
++#endif
+ 	}
+ #endif
+     }
+-- 
+2.13.6
+

--- a/meta-openpli/recipes-devtools/perl/perl-native_5.24.1.bbappend
+++ b/meta-openpli/recipes-devtools/perl/perl-native_5.24.1.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += " \
+	file://0001-pp-Guard-fix-for-really-old-bug-in-glibc-libcrypt.patch \
+"


### PR DESCRIPTION
Backported a fix from Fedora.
Fixes: pp.c:3822:47: error: ‘struct crypt_data’ has no member named ‘current_saltbits’