### PR TITLE
pyton-twisted: replace underscore with dash

### DIFF
--- a/meta-openpli/recipes-devtools/python/python-twisted.inc
+++ b/meta-openpli/recipes-devtools/python/python-twisted.inc
@@ -54,7 +54,7 @@ RDEPENDS_${PN} = "\
     ${PN}-words \
 "
 
-RDEPENDS_${PN}-core = "${PYTHON_PN}-core ${PYTHON_PN}-zopeinterface ${PYTHON_PN}-incremental ${PYTHON_PN}-constantly ${PYTHON_PN}-hyperlink ${PYTHON_PN}-automat ${PYTHON_PN}-service_identity"
+RDEPENDS_${PN}-core = "${PYTHON_PN}-core ${PYTHON_PN}-zopeinterface ${PYTHON_PN}-incremental ${PYTHON_PN}-constantly ${PYTHON_PN}-hyperlink ${PYTHON_PN}-automat ${PYTHON_PN}-service-identity"
 RDEPENDS_${PN}-test = "${PN}"
 RDEPENDS_${PN}-conch = "${PN}-core ${PN}-protocols"
 RDEPENDS_${PN}-mail = "${PN}-core ${PN}-protocols"


### PR DESCRIPTION
To fix build error:

ERROR: Nothing RPROVIDES 'python-service_identity' (but /home/hains/openpli-oe-core/
meta-openpli/recipes-devtools/python/python-twisted_17.9.0.bb RDEPENDS on or otherwise requires it)