### PR TITLE
python-incremental_17.5.0.bb: include python-package-split.inc

### DIFF
--- a/meta-openpli/recipes-devtools/python/python-incremental_17.5.0.bb
+++ b/meta-openpli/recipes-devtools/python/python-incremental_17.5.0.bb
@@ -1,2 +1,3 @@
 inherit setuptools
 require python-incremental.inc
+include python-package-split.inc


### PR DESCRIPTION
For some machines it gives error on write ipk stage but with this fix the problem goes away.