### PR TITLE
Update reporefs.conf

### DIFF
--- a/meta-openpli/conf/distro/reporefs.conf
+++ b/meta-openpli/conf/distro/reporefs.conf
@@ -190,7 +190,7 @@ SRCREV_pn-enigma2-pliplugins = "84d68642c2da3f3d8af47e68c0b6a795a7971be9"
 SRCREV_pn-enigma2-plugin-extensions-subssupport = "c61d76b1d634132db803c2df8dcf97859c546d36"
 SRCREV_pn-enigma2-plugin-extensions-kodi = "241a5aabf50aa21ed06c8180e854a65ebec47790"
 SRCREV_pn-enigma2-plugin-extensions-qthbbtv = "e5a62e00c481dabcc51a1e96881cccbcdb66e597"
-SRCREV_pn-enigma2-plugin-extensions-qtstalker = "c4f12aca33adbe6603b1a38c3493719b004b5031"
+SRCREV_pn-enigma2-plugin-extensions-qtstalker = "e7927eca8a9147fd9de5618bccc448214e19e275"
 
 SRCREV_pn-enigma2-skins = "472e9d9257dbef16205b00b3dc748eeddc10e3aa"
 SRCREV_pn-enigma2-plugin-skins-pli-hd = "aa832f30ed08cc7abeaef73e317b2d54cdf63d48"


### PR DESCRIPTION
QTStalker use always mac from eth0 device even if it's disabled/not used