### PR TITLE
Fix mdev.conf to load duo4k wifi firmware and driver.

### DIFF
--- a/meta-openpli/recipes-core/busybox/busybox/vuduo4k/mdev.conf
+++ b/meta-openpli/recipes-core/busybox/busybox/vuduo4k/mdev.conf
@@ -1,0 +1,55 @@
+console 0:0 0600 
+cpu_dma_latency 0:0 0660 
+fb([0-2]) 0:0 0660 >fb/%1
+i2c-([0-9]) 0:0 0660 >i2c/%1
+mtd([0-9]) 0:0 0660 >mtd/%1
+mtdblock([0-9]) 0:0 0660 >mtdblock/%1
+full 0:0 0666 
+initctl 0:0 0600 
+ircomm[0-9].* 0:20 0660 
+kmem 0:15 0640 
+kmsg 0:0 0660 
+log 0:0 0666 
+loop[0-9].* 0:6 0640 
+mem 0:15 0640 
+network_latency 0:0 0660 
+network_throughput 0:0 0660 
+null 0:0 0666 
+port 0:15 0640 
+ptmx 0:5 0666 
+ram[0-9].* 0:6 0640 
+random 0:0 0666 
+tty 0:5 0666 
+tty.* 0:0 0620 
+urandom 0:0 0666 
+usbdev.* 0:0 0660 
+vcs.* 0:5 0660 
+zero 0:0 0666
+tun[0-9]* 0:0 0640 =net/
+
+pcm.* 0:0 0660 =snd/ 
+control.* 0:0 0660 =snd/ 
+timer 0:0 0660 =snd/ 
+
+event.* 0:0 0660 =input/
+mice 0:0 0660 =input/
+mouse.* 0:0 0660 =input/
+
+rtc0 0:0 0666 =misc/rtc
+
+[hs]d[a-z][0-9]? 0:0    664     */etc/mdev/mdev-mount.sh
+mmcblk[0-9]p[0-9] 0:0   664     */etc/mdev/mdev-mount.sh
+sr[0-9]          0:0    664     @/usr/bin/bdpoll $MDEV -c
+
+dvb([0-9])\.(.*)([0-9]) 0:0     660     >dvb/adapter%1/%2%3
+
+lcd0            0:0     660     =dbox/lcd0
+oled0           0:0     660     =dbox/oled0
+dboxlcd         0:0     660     =dbox/lcd0
+pvr             0:0     660     =misc/pvr
+vtuner([0-9])   0:0     660     =misc/
+
+$MODALIAS=usb:v0A5CpBD27.* 0:0 664 @/etc/mdev/bcmwifi_firmware.sh
+$MODALIAS=usb:v0A5Cp0BDC.* 0:0 664 @/etc/mdev/bcmwifi_drv.sh
+
+$MODALIAS=.*	0:0     660 @modprobe "$MODALIAS"


### PR DESCRIPTION
Fix mdev.conf to load duo4k's wifi firmware and drivers.

Unlike udev, mdev uses a single config file (/etc/mdev.conf), so the duo4k wifi problem could not be resolved in meta-vuplus BSP Layer.