### PR TITLE
Fix exFAT filesystem support

### DIFF
--- a/meta-openpli/recipes-core/busybox/busybox/mdev-mount.sh
+++ b/meta-openpli/recipes-core/busybox/busybox/mdev-mount.sh
@@ -155,9 +155,6 @@ case "$ACTION" in
 				MOUNTPOINT="/media/$MDEV"
 				mkdir -p "${MOUNTPOINT}"
 			fi
-			if [ $TYPE == exfat ] && [ -f /usr/sbin/mount.exfat ] && mount.exfat -o noatime /dev/$MDEV "${MOUNTPOINT}" ; then
-				exit 0
-			fi
 			if ! mount -t auto -o noatime /dev/$MDEV "${MOUNTPOINT}" ; then
 				rmdir "${MOUNTPOINT}"
 			else

--- a/meta-openpli/recipes-openpli/images/openpli-enigma2-feed.bb
+++ b/meta-openpli/recipes-openpli/images/openpli-enigma2-feed.bb
@@ -35,7 +35,6 @@ OPTIONAL_PACKAGES += " \
 	evtest \
 	exfat-utils \
 	exteplayer3 \
-	fuse-exfat \
 	gdb \
 	grep \
 	gstplayer \

--- a/meta-openpli/recipes-openpli/images/openpli-image.bb
+++ b/meta-openpli/recipes-openpli/images/openpli-image.bb
@@ -17,6 +17,7 @@ IMAGE_INSTALL = "\
 	e2fsprogs-mke2fs \
 	e2fsprogs-tune2fs \
 	fakelocale \
+	fuse-exfat \
 	glibc-binary-localedata-en-gb \
 	kernel-params \
 	modutils-loadscript \


### PR DESCRIPTION
For exFAT file system mount is used fuse-exfat module.
Without it, the exFAT mount does not work.
After the fuse-exfat installation, also works the standard 'mount -t auto'.

Therefore, add fuse-exfat in openpli-image and remove the unnecessary exception for exFAT mount in mdev-mount.sh.
Also, the correct mount.exfat path is /sbin/mount.exfat instead of /usr/sbin/mount.exfat, so the exception in mdev-mount.sh does not work in any case.