### PR TITLE
qt plugin remove symlink to fonts

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-qthbbtv.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-qthbbtv.bb
@@ -25,7 +25,6 @@ FILES_${PN} =  " \
 	${bindir} \
 	/usr/lib/mozilla/plugins \
 	/usr/lib/${QtHbbtv} \
-	/usr/lib/fonts \
 "
 
 do_install() {
@@ -39,9 +38,6 @@ do_install() {
 	install -m 0755 ${S}/qthbbtv ${D}${bindir}
 	install -d ${D}${libdir}/mozilla/plugins
 	install -m 0755 ${S}/libnpapihbbtvplugin.so ${D}${libdir}/mozilla/plugins
-	install -d ${D}/usr/lib
-	cd ${D}/usr/lib
-	ln -sf ../share/fonts fonts
 }
 
 do_package_qa() {

--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-qthbbtv.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-qthbbtv.bb
@@ -22,7 +22,7 @@ do_compile () {
 }
 
 FILES_${PN} =  " \
-	/${bindir} \
+	${bindir} \
 	/usr/lib/mozilla/plugins \
 	/usr/lib/${QtHbbtv} \
 	/usr/lib/fonts \
@@ -51,3 +51,5 @@ PACKAGE_ARCH := "${MACHINE_ARCH}"
 
 # prevent 'double stripping' our binaries, which will break them
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+
+INSANE_SKIP_${PN} += "already-stripped dev-so"

--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-qtstalker.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-qtstalker.bb
@@ -22,7 +22,7 @@ do_compile () {
 }
 
 FILES_${PN} =  " \
-	/${bindir} \
+	${bindir} \
 	/usr/lib/${QtStalker} \
 	/usr/lib/fonts \
 	/usr/share/stalker \
@@ -40,7 +40,7 @@ do_install() {
 	install -m 0755 ${S}/plugin/stalker.py ${D}/usr/lib/${QtStalker}
 	install -m 0755 ${S}/plugin/stalker.png ${D}/usr/lib/${QtStalker}
 	install -d ${D}/${bindir}
-	install -m 0755 ${S}/stalker ${D}/${bindir}
+	install -m 0755 ${S}/stalker ${D}${bindir}
 	install -d ${D}/usr/lib
 	cd ${D}/usr/lib
 	ln -sf ../share/fonts fonts
@@ -53,3 +53,5 @@ PACKAGE_ARCH := "${MACHINE_ARCH}"
 
 # prevent 'double stripping' our binaries, which will break them
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+
+INSANE_SKIP_${PN} += "already-stripped"

--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-qtstalker.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-qtstalker.bb
@@ -24,7 +24,6 @@ do_compile () {
 FILES_${PN} =  " \
 	${bindir} \
 	/usr/lib/${QtStalker} \
-	/usr/lib/fonts \
 	/usr/share/stalker \
 "
 
@@ -41,9 +40,6 @@ do_install() {
 	install -m 0755 ${S}/plugin/stalker.png ${D}/usr/lib/${QtStalker}
 	install -d ${D}/${bindir}
 	install -m 0755 ${S}/stalker ${D}${bindir}
-	install -d ${D}/usr/lib
-	cd ${D}/usr/lib
-	ln -sf ../share/fonts fonts
 }
 
 do_package_qa() {


### PR DESCRIPTION
QT can been startup with a font path. ( export QT_QPA_FONTDIR=/usr/share/fonts )
The map /usr/lib/fonts is not needed by the plugin anymore.