### PR TITLE
kodi: do not use e2player as standard player for some models with ...

### DIFF
--- a/meta-openpli/recipes-mediacenter/kodi/kodi_17.bbappend
+++ b/meta-openpli/recipes-mediacenter/kodi/kodi_17.bbappend
@@ -8,8 +8,8 @@ SRC_URI_append += "\
 	file://kodi-platform-support.patch \
 	file://brcmstb-settings.patch \
 	file://input-devices.patch \
-	file://e2player.patch \
 	file://quit.patch \
+	${@bb.utils.contains('MACHINE_FEATURES', 'hisil', '', 'file://e2player.patch', d)} \
 	${@bb.utils.contains('MACHINE_FEATURES', 'v3d-nxpl', 'file://EGLNativeTypeV3D-nxpl.patch', '', d)} \
 	${@bb.utils.contains('MACHINE_FEATURES', 'mali', 'file://EGLNativeTypeMali.patch', '', d)} \
 	"


### PR DESCRIPTION
... hisilicon chipset. The native or HiPlayer will been used as standard player.