### PR TITLE
Try fix cross-localedef-native building

### DIFF
--- a/meta-openpli/recipes-core/glibc/cross-localedef-native_2.25.bbappend
+++ b/meta-openpli/recipes-core/glibc/cross-localedef-native_2.25.bbappend
@@ -1,0 +1,6 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_remove = "file://0023-eglibc-Install-PIC-archives.patch"
+
+SRC_URI_append = "file://0026-fix__locale_t-redefinition-on-newer-host-glibc.patch"
+

--- a/meta-openpli/recipes-core/glibc/files/0026-fix__locale_t-redefinition-on-newer-host-glibc.patch
+++ b/meta-openpli/recipes-core/glibc/files/0026-fix__locale_t-redefinition-on-newer-host-glibc.patch
@@ -1,0 +1,19 @@
+--- a/locale/xlocale.h	2018-12-18 21:01:39.033644166 +0200
++++ b/locale/xlocale.h	2018-12-18 21:02:10.337156441 +0200
+@@ -17,6 +17,11 @@
+    License along with the GNU C Library; if not, see
+    <http://www.gnu.org/licenses/>.  */
+ 
++#ifdef HAVE_CTYPE_H
++#include_next <ctype.h>
++#endif
++
++#ifndef _BITS_TYPES___LOCALE_T_H
+ #ifndef _XLOCALE_H
+ #define _XLOCALE_H	1
+ 
+@@ -42,3 +47,4 @@
+ typedef __locale_t locale_t;
+ 
+ #endif /* xlocale.h */
++#endif


### PR DESCRIPTION
The second attempt to fix cross-localedef-native building on host glibc newer that 2.65
Tested on Ubuntu 18.04 and Ubuntu 16.04.
