### PR TITLE
Fix building cross-localedef on hosts running glibc 2.28

### DIFF
--- a/meta-openpli/recipes-core/glibc/cross-localedef-native_2.25.bbappend
+++ b/meta-openpli/recipes-core/glibc/cross-localedef-native_2.25.bbappend
@@ -2,5 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI_remove = "file://0023-eglibc-Install-PIC-archives.patch"
 
-SRC_URI_append = "file://0026-fix__locale_t-redefinition-on-newer-host-glibc.patch"
-
+SRC_URI_append = "\
+	file://0026-fix__locale_t-redefinition-on-newer-host-glibc.patch \
+	file://0027-workaround-build-with-glibc228.patch \
+	"

--- a/meta-openpli/recipes-core/glibc/files/0027-workaround-build-with-glibc228.patch
+++ b/meta-openpli/recipes-core/glibc/files/0027-workaround-build-with-glibc228.patch
@@ -1,0 +1,18 @@
+--- a/argp/argp-fmtstream.c	2018-12-20 08:53:15.632427348 +0100
++++ b/argp/argp-fmtstream.c	2018-12-20 08:54:58.802412578 +0100
+@@ -45,6 +45,15 @@
+ # define __vsnprintf(s, l, f, a) _IO_vsnprintf (s, l, f, a)
+ #endif
+ 
++#ifndef _IO_fwide
++# include <stdio.h>
++int
++_IO_fwide ( __FILE *fp, int mode)
++{
++    return fp->_mode;
++}
++#endif
++
+ #define INIT_BUF_SIZE 200
+ #define PRINTF_SIZE_GUESS 150
+ 


### PR DESCRIPTION
Thanks Hains and Taapat for this.
Now we can build images again on hosts running Fedora 29 (or other distros shipping glibc 2.28).