### PR TITLE
dvbmediasink: Apply dmm patches to dm8000 only

### DIFF
--- a/meta-dream/recipes-multimedia/gstreamer/gstreamer1.0-plugin-dvbmediasink.bbappend
+++ b/meta-dream/recipes-multimedia/gstreamer/gstreamer1.0-plugin-dvbmediasink.bbappend
@@ -1,4 +1,4 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-SRC_URI += " file://dmm.patch \
+SRC_URI_dm8000 += " file://dmm.patch \
 	file://0001-meta-dream-fix-framerate-and-video-size.patch"


### PR DESCRIPTION
Other boxes uses gstreamer1.0-plugin-dvbmediasink as well.