### PR TITLE
gstplayer: update url

### DIFF
--- a/meta-openpli/recipes-multimedia/gstplayer/gstplayer/0001-set-iptv-download-timeout-0-to-disable-ifdsrc.patch
+++ b/meta-openpli/recipes-multimedia/gstplayer/gstplayer/0001-set-iptv-download-timeout-0-to-disable-ifdsrc.patch
@@ -4,13 +4,13 @@ Date: Fri, 11 Mar 2016 13:10:38 +0100
 Subject: [PATCH 01/11] set iptv download timeout 0 to disable ifdsrc
 
 ---
- gstplayer/gst-1.0/gst-backend.c | 2 +-
+ gst-1.0/gst-backend.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/gstplayer/gst-1.0/gst-backend.c b/gstplayer/gst-1.0/gst-backend.c
+diff --git a/gst-1.0/gst-backend.c b/gst-1.0/gst-backend.c
 index 83a863f..f941d6d 100644
---- a/gstplayer/gst-1.0/gst-backend.c
-+++ b/gstplayer/gst-1.0/gst-backend.c
+--- a/gst-1.0/gst-backend.c
++++ b/gst-1.0/gst-backend.c
 @@ -55,7 +55,7 @@ static gint    g_buffer_size = 0;
  static StrPair_t **g_ptr_http_header_fields = NULL;
  static int  g_sfd = -1;     /* Used to wake up main loop when new message in the gst bus is available */

--- a/meta-openpli/recipes-multimedia/gstplayer/gstplayer/0002-use-getopt-added-possibility-to-set-custom-sinks.patch
+++ b/meta-openpli/recipes-multimedia/gstplayer/gstplayer/0002-use-getopt-added-possibility-to-set-custom-sinks.patch
@@ -4,15 +4,15 @@ Date: Fri, 11 Mar 2016 12:37:14 +0100
 Subject: [PATCH 02/11] use getopt, added possibility to set custom sinks
 
 ---
- gstplayer/common/gst-backend.h  |   2 +-
- gstplayer/common/gstplayer.c    | 152 +++++++++++++++++++++-------------------
- gstplayer/gst-1.0/gst-backend.c |  13 +++-
+ common/gst-backend.h  |   2 +-
+ common/gstplayer.c    | 152 +++++++++++++++++++++-------------------
+ gst-1.0/gst-backend.c |  13 +++-
  3 files changed, 91 insertions(+), 76 deletions(-)
 
-diff --git a/gstplayer/common/gst-backend.h b/gstplayer/common/gst-backend.h
+diff --git a/common/gst-backend.h b/common/gst-backend.h
 index 0c8f8b0..fa1dbe2 100644
---- a/gstplayer/common/gst-backend.h
-+++ b/gstplayer/common/gst-backend.h
+--- a/common/gst-backend.h
++++ b/common/gst-backend.h
 @@ -79,7 +79,7 @@ typedef struct TrackDescription_s
  
  void backend_init(int *argc, char **argv[], const int sfd);
@@ -22,10 +22,10 @@ index 0c8f8b0..fa1dbe2 100644
  int  backend_stop();
  int  backend_seek(const double seconds);
  int  backend_seek_absolute(const double seconds);
-diff --git a/gstplayer/common/gstplayer.c b/gstplayer/common/gstplayer.c
+diff --git a/common/gstplayer.c b/common/gstplayer.c
 index 42c5ef5..3ed59df 100644
---- a/gstplayer/common/gstplayer.c
-+++ b/gstplayer/common/gstplayer.c
+--- a/common/gstplayer.c
++++ b/common/gstplayer.c
 @@ -23,6 +23,8 @@
  #include <sys/stat.h>
  #include <fcntl.h>

--- a/meta-openpli/recipes-multimedia/gstplayer/gstplayer/0003-fix-buffer-duration-buffer-size-and-ring-buffer-size.patch
+++ b/meta-openpli/recipes-multimedia/gstplayer/gstplayer/0003-fix-buffer-duration-buffer-size-and-ring-buffer-size.patch
@@ -9,14 +9,14 @@ buffer-duration      - can be 0 (turned off)
                      - in seconds
 buffer-size          - can be 0 (turned off)
 ---
- gstplayer/common/gstplayer.c    | 10 +++++-----
- gstplayer/gst-1.0/gst-backend.c |  8 ++++----
+ common/gstplayer.c    | 10 +++++-----
+ gst-1.0/gst-backend.c |  8 ++++----
  2 files changed, 9 insertions(+), 9 deletions(-)
 
-diff --git a/gstplayer/common/gstplayer.c b/gstplayer/common/gstplayer.c
+diff --git a/common/gstplayer.c b/common/gstplayer.c
 index 3ed59df..947dcdc 100644
---- a/gstplayer/common/gstplayer.c
-+++ b/gstplayer/common/gstplayer.c
+--- a/common/gstplayer.c
++++ b/common/gstplayer.c
 @@ -204,10 +204,10 @@ int main(int argc,char* argv[])
      gchar *audioSinkName = NULL;
      
@@ -47,10 +47,10 @@ index 3ed59df..947dcdc 100644
              break;
          case 'p':
              downloadBufferPath = g_strdup(optarg);
-diff --git a/gstplayer/gst-1.0/gst-backend.c b/gstplayer/gst-1.0/gst-backend.c
+diff --git a/gst-1.0/gst-backend.c b/gst-1.0/gst-backend.c
 index 2ffc675..da2df9d 100644
---- a/gstplayer/gst-1.0/gst-backend.c
-+++ b/gstplayer/gst-1.0/gst-backend.c
+--- a/gst-1.0/gst-backend.c
++++ b/gst-1.0/gst-backend.c
 @@ -555,7 +555,7 @@ int backend_play(gchar *filename, gchar *download_buffer_path, guint64 ring_buff
              }
              

--- a/meta-openpli/recipes-multimedia/gstplayer/gstplayer/0004-rename-stored-sink-to-dvbSink-for-clarity.patch
+++ b/meta-openpli/recipes-multimedia/gstplayer/gstplayer/0004-rename-stored-sink-to-dvbSink-for-clarity.patch
@@ -4,13 +4,13 @@ Date: Fri, 11 Mar 2016 12:48:50 +0100
 Subject: [PATCH 04/11] rename stored sink to dvbSink for clarity
 
 ---
- gstplayer/gst-1.0/gst-backend.c | 49 ++++++++++++++++++++---------------------
+ gst-1.0/gst-backend.c | 49 ++++++++++++++++++++---------------------
  1 file changed, 24 insertions(+), 25 deletions(-)
 
-diff --git a/gstplayer/gst-1.0/gst-backend.c b/gstplayer/gst-1.0/gst-backend.c
+diff --git a/gst-1.0/gst-backend.c b/gst-1.0/gst-backend.c
 index da2df9d..97694f6 100644
---- a/gstplayer/gst-1.0/gst-backend.c
-+++ b/gstplayer/gst-1.0/gst-backend.c
+--- a/gst-1.0/gst-backend.c
++++ b/gst-1.0/gst-backend.c
 @@ -33,8 +33,8 @@ Based on:
  #include <fcntl.h>
  

--- a/meta-openpli/recipes-multimedia/gstplayer/gstplayer/0005-added-basic-support-for-plain-text-embedded-subtitle.patch
+++ b/meta-openpli/recipes-multimedia/gstplayer/gstplayer/0005-added-basic-support-for-plain-text-embedded-subtitle.patch
@@ -4,16 +4,16 @@ Date: Thu, 7 Apr 2016 20:03:35 +0200
 Subject: [PATCH 05/11] added basic support for plain text embedded subtitles
 
 ---
- gstplayer/common/gst-backend.h  |   2 +-
- gstplayer/common/gstplayer.c    |  16 +++--
- gstplayer/common/tracks.h       | 142 +++++++++++++++++++++++++++++++++++++++-
- gstplayer/gst-1.0/gst-backend.c | 102 ++++++++++++++++++++++++++++-
+ common/gst-backend.h  |   2 +-
+ common/gstplayer.c    |  16 +++--
+ common/tracks.h       | 142 +++++++++++++++++++++++++++++++++++++++-
+ gst-1.0/gst-backend.c | 102 ++++++++++++++++++++++++++++-
  4 files changed, 253 insertions(+), 9 deletions(-)
 
-diff --git a/gstplayer/common/gst-backend.h b/gstplayer/common/gst-backend.h
+diff --git a/common/gst-backend.h b/common/gst-backend.h
 index fa1dbe2..a75b543 100644
---- a/gstplayer/common/gst-backend.h
-+++ b/gstplayer/common/gst-backend.h
+--- a/common/gst-backend.h
++++ b/common/gst-backend.h
 @@ -79,7 +79,7 @@ typedef struct TrackDescription_s
  
  void backend_init(int *argc, char **argv[], const int sfd);
@@ -23,10 +23,10 @@ index fa1dbe2..a75b543 100644
  int  backend_stop();
  int  backend_seek(const double seconds);
  int  backend_seek_absolute(const double seconds);
-diff --git a/gstplayer/common/gstplayer.c b/gstplayer/common/gstplayer.c
+diff --git a/common/gstplayer.c b/common/gstplayer.c
 index 947dcdc..f2b8b3e 100644
---- a/gstplayer/common/gstplayer.c
-+++ b/gstplayer/common/gstplayer.c
+--- a/common/gstplayer.c
++++ b/common/gstplayer.c
 @@ -172,7 +172,7 @@ static int HandleTracks(const char *argvBuff)
          default: 
          {
@@ -92,10 +92,10 @@ index 947dcdc..f2b8b3e 100644
              {
                  HandleTracks(argvBuff);
                  break;
-diff --git a/gstplayer/common/tracks.h b/gstplayer/common/tracks.h
+diff --git a/common/tracks.h b/common/tracks.h
 index 71e69ee..4029e3f 100644
---- a/gstplayer/common/tracks.h
-+++ b/gstplayer/common/tracks.h
+--- a/common/tracks.h
++++ b/common/tracks.h
 @@ -9,10 +9,13 @@
  int tracksReady = 0;
  TrackDescription_t *g_audio_tracks = NULL;
@@ -298,10 +298,10 @@ index 71e69ee..4029e3f 100644
      return ret;
  }
  
-diff --git a/gstplayer/gst-1.0/gst-backend.c b/gstplayer/gst-1.0/gst-backend.c
+diff --git a/gst-1.0/gst-backend.c b/gst-1.0/gst-backend.c
 index 97694f6..8167e40 100644
---- a/gstplayer/gst-1.0/gst-backend.c
-+++ b/gstplayer/gst-1.0/gst-backend.c
+--- a/gst-1.0/gst-backend.c
++++ b/gst-1.0/gst-backend.c
 @@ -35,6 +35,7 @@ Based on:
  static GstElement *g_gst_playbin = NULL;
  static GstElement *g_dvbAudioSink   = NULL;

--- a/meta-openpli/recipes-multimedia/gstplayer/gstplayer/0006-allow-re-filling-of-audio-subtitle-tracks.patch
+++ b/meta-openpli/recipes-multimedia/gstplayer/gstplayer/0006-allow-re-filling-of-audio-subtitle-tracks.patch
@@ -8,13 +8,13 @@ which causes that not all tracks are added in the array.
 
 So always refill them when client wants to
 ---
- gstplayer/common/tracks.h | 30 +++++++++++++++++++++++++++---
+ common/tracks.h | 30 +++++++++++++++++++++++++++---
  1 file changed, 27 insertions(+), 3 deletions(-)
 
-diff --git a/gstplayer/common/tracks.h b/gstplayer/common/tracks.h
+diff --git a/common/tracks.h b/common/tracks.h
 index 4029e3f..921dc86 100644
---- a/gstplayer/common/tracks.h
-+++ b/gstplayer/common/tracks.h
+--- a/common/tracks.h
++++ b/common/tracks.h
 @@ -17,6 +17,16 @@ int g_audio_idx = -1;
  int g_video_idx = -1;
  int g_subtitle_idx = -1;

--- a/meta-openpli/recipes-multimedia/gstplayer/gstplayer/0007-re-enable-updating-video-track-info-from-dvb-video-d.patch
+++ b/meta-openpli/recipes-multimedia/gstplayer/gstplayer/0007-re-enable-updating-video-track-info-from-dvb-video-d.patch
@@ -10,15 +10,15 @@ It has some benefits over relying only on video-caps:
 streaming
 3. I guess decoder should have better information :)
 ---
- gstplayer/common/gst-backend.h  |  1 +
- gstplayer/common/tracks.h       | 21 ++++++++++++++++++++-
- gstplayer/gst-1.0/gst-backend.c |  5 +++--
+ common/gst-backend.h  |  1 +
+ common/tracks.h       | 21 ++++++++++++++++++++-
+ gst-1.0/gst-backend.c |  5 +++--
  3 files changed, 24 insertions(+), 3 deletions(-)
 
-diff --git a/gstplayer/common/gst-backend.h b/gstplayer/common/gst-backend.h
+diff --git a/common/gst-backend.h b/common/gst-backend.h
 index a75b543..db6b10e 100644
---- a/gstplayer/common/gst-backend.h
-+++ b/gstplayer/common/gst-backend.h
+--- a/common/gst-backend.h
++++ b/common/gst-backend.h
 @@ -74,6 +74,7 @@ typedef struct TrackDescription_s
      unsigned int          frame_rate;
      int                   width;
@@ -27,10 +27,10 @@ index a75b543..db6b10e 100644
      
  } TrackDescription_t;
  
-diff --git a/gstplayer/common/tracks.h b/gstplayer/common/tracks.h
+diff --git a/common/tracks.h b/common/tracks.h
 index 921dc86..9faf494 100644
---- a/gstplayer/common/tracks.h
-+++ b/gstplayer/common/tracks.h
+--- a/common/tracks.h
++++ b/common/tracks.h
 @@ -82,6 +82,24 @@ void UpdateVideoTrackInf_2(const unsigned int framerate)
      }
  }
@@ -73,10 +73,10 @@ index 921dc86..9faf494 100644
          }
      }
      return track; 
-diff --git a/gstplayer/gst-1.0/gst-backend.c b/gstplayer/gst-1.0/gst-backend.c
+diff --git a/gst-1.0/gst-backend.c b/gst-1.0/gst-backend.c
 index 8167e40..271a1dd 100644
---- a/gstplayer/gst-1.0/gst-backend.c
-+++ b/gstplayer/gst-1.0/gst-backend.c
+--- a/gst-1.0/gst-backend.c
++++ b/gst-1.0/gst-backend.c
 @@ -531,14 +531,14 @@ static gboolean gstBusCall(GstBus *bus, GstMessage *msg)
                          gst_structure_get_int (msgstruct, "aspect_ratio", &aspect);
                          gst_structure_get_int (msgstruct, "width", &width);

--- a/meta-openpli/recipes-multimedia/gstplayer/gstplayer/0008-first-flush-then-change-track.patch
+++ b/meta-openpli/recipes-multimedia/gstplayer/gstplayer/0008-first-flush-then-change-track.patch
@@ -11,13 +11,13 @@ we have AAC and AC3. AAC is selected and running, we
 switch to AC3, no caps event with AAC caps in sink ->
 AC3 is written to decoder as AAC -> no sound.
 ---
- gstplayer/common/tracks.h | 28 ++++++++++------------------
+ common/tracks.h | 28 ++++++++++------------------
  1 file changed, 10 insertions(+), 18 deletions(-)
 
-diff --git a/gstplayer/common/tracks.h b/gstplayer/common/tracks.h
+diff --git a/common/tracks.h b/common/tracks.h
 index 9faf494..4d766a5 100644
---- a/gstplayer/common/tracks.h
-+++ b/gstplayer/common/tracks.h
+--- a/common/tracks.h
++++ b/common/tracks.h
 @@ -139,17 +139,13 @@ static int SelectSubtitleTrack(unsigned int i)
                  ppos = 0;
              }

--- a/meta-openpli/recipes-multimedia/gstplayer/gstplayer/0009-try-to-get-PTS-from-video-sink-first.patch
+++ b/meta-openpli/recipes-multimedia/gstplayer/gstplayer/0009-try-to-get-PTS-from-video-sink-first.patch
@@ -7,13 +7,13 @@ This shouldn't matter, but from my tests it looks like,
 that PTS from video is available sooner after flush than
 PTS from audio.
 ---
- gstplayer/gst-1.0/gst-backend.c | 2 +-
+ gst-1.0/gst-backend.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/gstplayer/gst-1.0/gst-backend.c b/gstplayer/gst-1.0/gst-backend.c
+diff --git a/gst-1.0/gst-backend.c b/gst-1.0/gst-backend.c
 index 271a1dd..e726b7f 100644
---- a/gstplayer/gst-1.0/gst-backend.c
-+++ b/gstplayer/gst-1.0/gst-backend.c
+--- a/gst-1.0/gst-backend.c
++++ b/gst-1.0/gst-backend.c
 @@ -938,7 +938,7 @@ int backend_query_position(int64_t *mseconds)
          */
          if ( g_dvbAudioSink || g_dvbVideoSink)

--- a/meta-openpli/recipes-multimedia/gstplayer/gstplayer/0010-fix-framerate-calculation.patch
+++ b/meta-openpli/recipes-multimedia/gstplayer/gstplayer/0010-fix-framerate-calculation.patch
@@ -7,13 +7,13 @@ if num * 1000 is bigger than MAXINT, then MAXINT is used, so
 framerate calculation is invalid.
 Make sure that aritmethic conversion is to long by using long value
 ---
- gstplayer/common/tracks.h | 2 +-
+ common/tracks.h | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/gstplayer/common/tracks.h b/gstplayer/common/tracks.h
+diff --git a/common/tracks.h b/common/tracks.h
 index 4d766a5..2e6b53e 100644
---- a/gstplayer/common/tracks.h
-+++ b/gstplayer/common/tracks.h
+--- a/common/tracks.h
++++ b/common/tracks.h
 @@ -341,7 +341,7 @@ static void FillVideoTracks()
                              {
                                  denom = 1000;

--- a/meta-openpli/recipes-multimedia/gstplayer/gstplayer/0011-increase-eos-fix-timeout-to-10s.patch
+++ b/meta-openpli/recipes-multimedia/gstplayer/gstplayer/0011-increase-eos-fix-timeout-to-10s.patch
@@ -5,13 +5,13 @@ Subject: [PATCH 11/11] increase eos fix timeout to 10s
 
 In adaptive streaming we get sometimes premature eos
 ---
- gstplayer/gst-1.0/gst-backend.c | 2 +-
+ gst-1.0/gst-backend.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/gstplayer/gst-1.0/gst-backend.c b/gstplayer/gst-1.0/gst-backend.c
+diff --git a/gst-1.0/gst-backend.c b/gst-1.0/gst-backend.c
 index e726b7f..701ca27 100644
---- a/gstplayer/gst-1.0/gst-backend.c
-+++ b/gstplayer/gst-1.0/gst-backend.c
+--- a/gst-1.0/gst-backend.c
++++ b/gst-1.0/gst-backend.c
 @@ -947,7 +947,7 @@ int backend_query_position(int64_t *mseconds)
              if(decoder_time  == g_eos_fix.decoder_time && 
                 playbin_time  == g_eos_fix.playbin_time )

--- a/meta-openpli/recipes-multimedia/gstplayer/gstplayer_0.1.bb
+++ b/meta-openpli/recipes-multimedia/gstplayer/gstplayer_0.1.bb
@@ -7,7 +7,7 @@ DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base"
 
 inherit pkgconfig
 
-SRC_URI = "git://gitlab.com/samsamsam/iptvplayer-bin-components.git;protocol=http"
+SRC_URI = "git://gitlab.com/e2i/gstplayer.git;protocol=http"
 SRC_URI =+ "file://0001-set-iptv-download-timeout-0-to-disable-ifdsrc.patch \
             file://0004-rename-stored-sink-to-dvbSink-for-clarity.patch \
             file://0009-try-to-get-PTS-from-video-sink-first.patch \
@@ -16,13 +16,13 @@ SRC_URI =+ "file://0001-set-iptv-download-timeout-0-to-disable-ifdsrc.patch \
 S = "${WORKDIR}/git/"
 
 do_compile() {
-    cd ${S}/gstplayer/gst-1.0
+    cd ${S}/gst-1.0
     ${CC} *.c ../common/*.c -I../common/ `pkg-config --cflags --libs gstreamer-1.0 gstreamer-pbutils-1.0` -o gstplayer_gst-1.0 ${LDFLAGS}
 }
 
 do_install() {
     install -d ${D}${bindir}
-    install -m 0755 ${S}/gstplayer/gst-1.0/gstplayer_gst-1.0 ${D}${bindir}/gstplayer
+    install -m 0755 ${S}/gst-1.0/gstplayer_gst-1.0 ${D}${bindir}/gstplayer
 }
 
 pkg_postinst_${PN}() {


### PR DESCRIPTION
Adapt patches to new repo path.
Root dir gstplayer is gone.