### PR TITLE
kodi: use hiplayer only for select extensions all other extensions wi…

### DIFF
--- a/meta-openpli/recipes-mediacenter/kodi/kodi-17/Apply-workaround-for-scratchy-sound-with-FFmpeg-3.4.patch
+++ b/meta-openpli/recipes-mediacenter/kodi/kodi-17/Apply-workaround-for-scratchy-sound-with-FFmpeg-3.4.patch
@@ -1,0 +1,11 @@
+--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
++++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+@@ -486,7 +486,7 @@
+         // guess next pts
+         m_audioClock += audioframe.duration;
+
+-        int ret = m_pAudioCodec->Decode(nullptr, 0, DVD_NOPTS_VALUE, DVD_NOPTS_VALUE);
++        int ret = 0;
+         if (ret < 0)
+         {
+           CLog::Log(LOGERROR, "CVideoPlayerAudio::DecodeFrame - Decode Error. Skipping audio packet (%d)", ret);

--- a/meta-openpli/recipes-mediacenter/kodi/kodi-17/HiPlayer-defaultplayer.patch
+++ b/meta-openpli/recipes-mediacenter/kodi/kodi-17/HiPlayer-defaultplayer.patch
@@ -1,0 +1,15 @@
+diff --git a/system/playercorefactory.xml b/system/playercorefactory.xml
+index be6b721..c03699e 100644
+--- a/system/playercorefactory.xml
++++ b/system/playercorefactory.xml
+@@ -37,4 +37,8 @@
+     <!-- pvr radio channels should be played by VideoPlayer because they need buffering -->
+     <rule name="radio" filetypes="pvr" filename=".*/radio/.*" player="VideoPlayer" />
+   </rules>
++
++  <rules action="prepend">
++    <rule filetypes="dts|mp3|wav|wave|oga|ogg|flac|m4a|mp2|m2a|ac3|mka|aac|ape|alac|mpg|vob|m4v|mkv|avi|divx|dat|flv|mp4|mov|wmv|asf|3gp|3g2|mpeg|mpe|rm|rmvb|ogm|ogv|stream|amr|au|mid|wv|pva|wtv|ts|m2ts" player="HiPlayer" />
++  </rules>
+ </playercorefactory>
+-- 
+2.17.1

--- a/meta-openpli/recipes-mediacenter/kodi/kodi_17.bbappend
+++ b/meta-openpli/recipes-mediacenter/kodi/kodi_17.bbappend
@@ -11,6 +11,7 @@ SRC_URI_append += "\
 	file://HiPlayer.patch \
 	file://HiPlayer-Subs.patch \
 	file://quit.patch \
+	file://Apply-workaround-for-scratchy-sound-with-FFmpeg-3.4.patch \
 	${@bb.utils.contains('MACHINE_FEATURES', 'hisil', 'file://HiPlayer-defaultplayer.patch', 'file://e2player.patch', d)} \
 	${@bb.utils.contains('MACHINE_FEATURES', 'v3d-nxpl', 'file://EGLNativeTypeV3D-nxpl.patch', '', d)} \
 	${@bb.utils.contains('MACHINE_FEATURES', 'mali', 'file://EGLNativeTypeMali.patch', '', d)} \

--- a/meta-openpli/recipes-mediacenter/kodi/kodi_17.bbappend
+++ b/meta-openpli/recipes-mediacenter/kodi/kodi_17.bbappend
@@ -11,7 +11,7 @@ SRC_URI_append += "\
 	file://HiPlayer.patch \
 	file://HiPlayer-Subs.patch \
 	file://quit.patch \
-	${@bb.utils.contains('MACHINE_FEATURES', 'hisil', '', 'file://e2player.patch', d)} \
+	${@bb.utils.contains('MACHINE_FEATURES', 'hisil', 'file://HiPlayer-defaultplayer.patch', 'file://e2player.patch', d)} \
 	${@bb.utils.contains('MACHINE_FEATURES', 'v3d-nxpl', 'file://EGLNativeTypeV3D-nxpl.patch', '', d)} \
 	${@bb.utils.contains('MACHINE_FEATURES', 'mali', 'file://EGLNativeTypeMali.patch', '', d)} \
 	"


### PR DESCRIPTION
…ll been played by the native videoplayer (only for hisilicon boxes with hiplayer, other boxes will use standard e2player)