### PR TITLE
t230: add missing firmware

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-ct2-usb-geniatech-t230.bb
+++ b/meta-openpli/recipes-openpli/enigma2-dvb-drivers/enigma2-plugin-drivers-ct2-usb-geniatech-t230.bb
@@ -7,6 +7,7 @@ RRECOMMENDS_${PN} = " \
 	kernel-module-si2157 \
 	kernel-module-si2168 \
 	firmware-dvb-demod-si2168-b40 \
+	firmware-dvb-tuner-si2158-a20 \
 	"
 
 PV = "1.0"


### PR DESCRIPTION
dvb-usb: Mygica T230 DVB-T/T2/C successfully initialized and connected.
si2168 3-0064: found a 'Silicon Labs Si2168-B40'
si2168 3-0064: downloading firmware from file 'dvb-demod-si2168-b40-01.fw'
si2168 3-0064: firmware version: 4.0.25
si2157 4-0060: found a 'Silicon Labs Si2158-A20'
si2157 4-0060: downloading firmware from file 'dvb-tuner-si2158-a20-01.fw'
si2157 4-0060: firmware version: 2.1.9