### PR TITLE
exteplayer3: fix build

### DIFF
--- a/meta-openpli/recipes-multimedia/exteplayer3/exteplayer3_git.bb
+++ b/meta-openpli/recipes-multimedia/exteplayer3/exteplayer3_git.bb
@@ -8,8 +8,8 @@ DEPENDS = "ffmpeg"
 
 inherit gitpkgv
 
-PV = "50+gitr${SRCPV}"
-PKGV = "50+gitr${GITPKGV}"
+PV = "54+gitr${SRCPV}"
+PKGV = "54+gitr${GITPKGV}"
 
 SRC_URI = "git://github.com/e2iplayer/exteplayer3.git;branch=master"
 
@@ -60,6 +60,7 @@ output/writer/mipsel/ac3.c \
 output/writer/mipsel/mp3.c \
 output/writer/mipsel/pcm.c \
 output/writer/mipsel/lpcm.c \
+output/writer/mipsel/mjpeg.c \
 output/writer/mipsel/dts.c \
 output/writer/mipsel/amr.c \
 output/writer/mipsel/wma.c \


### PR DESCRIPTION
https://github.com/e2iplayer/exteplayer3/commit/857e07c208204766fa58dc364bf9e9596e136f31

/tmp/ccKMtTYc.o:(.data.rel+0x68): undefined reference to `WriterVideoMJPEG'

-Bump version to 54.