### PR TITLE
exteplayer3: remove h263.c to fix build

### DIFF
--- a/meta-openpli/recipes-multimedia/exteplayer3/exteplayer3_git.bb
+++ b/meta-openpli/recipes-multimedia/exteplayer3/exteplayer3_git.bb
@@ -8,8 +8,8 @@ DEPENDS = "ffmpeg"
 
 inherit gitpkgv
 
-PV = "54+gitr${SRCPV}"
-PKGV = "54+gitr${GITPKGV}"
+PV = "55+gitr${SRCPV}"
+PKGV = "55+gitr${GITPKGV}"
 
 SRC_URI = "git://github.com/e2iplayer/exteplayer3.git;branch=master"
 
@@ -66,7 +66,6 @@ output/writer/mipsel/amr.c \
 output/writer/mipsel/wma.c \
 output/writer/mipsel/h265.c \
 output/writer/mipsel/h264.c \
-output/writer/mipsel/h263.c \
 output/writer/mipsel/mpeg2.c \
 output/writer/mipsel/mpeg4.c \
 output/writer/mipsel/divx3.c \


### PR DESCRIPTION
Log data follows:
| DEBUG: Executing shell function do_compile
| mipsel-oe-linux-gcc: error: output/writer/mipsel/h263.c: No such file or directory

https://github.com/e2iplayer/exteplayer3/commit/a60741577aaac6de05c30bce7149e93f420b1001

-Bumpe version to 55.