### PR TITLE
exteplayer3: remove wma.c and add bcma.c to fix build

### DIFF
--- a/meta-openpli/recipes-multimedia/exteplayer3/exteplayer3_git.bb
+++ b/meta-openpli/recipes-multimedia/exteplayer3/exteplayer3_git.bb
@@ -8,8 +8,8 @@ DEPENDS = "ffmpeg"
 
 inherit gitpkgv
 
-PV = "55+gitr${SRCPV}"
-PKGV = "55+gitr${GITPKGV}"
+PV = "57+gitr${SRCPV}"
+PKGV = "57+gitr${GITPKGV}"
 
 SRC_URI = "git://github.com/e2iplayer/exteplayer3.git;branch=master"
 
@@ -57,13 +57,13 @@ output/linuxdvb_mipsel.c \
 output/writer/mipsel/writer.c \
 output/writer/mipsel/aac.c \
 output/writer/mipsel/ac3.c \
+output/writer/mipsel/bcma.c \
 output/writer/mipsel/mp3.c \
 output/writer/mipsel/pcm.c \
 output/writer/mipsel/lpcm.c \
 output/writer/mipsel/mjpeg.c \
 output/writer/mipsel/dts.c \
 output/writer/mipsel/amr.c \
-output/writer/mipsel/wma.c \
 output/writer/mipsel/h265.c \
 output/writer/mipsel/h264.c \
 output/writer/mipsel/mpeg2.c \


### PR DESCRIPTION
https://github.com/e2iplayer/exteplayer3/commit/d8a827ab38f8f9743017e16caadaab82fdc98e34

-Bump version to 57.