### PR TITLE
Update enigma2-plugins.bb

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugins.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugins.bb
@@ -138,3 +138,6 @@ python populate_packages_prepend() {
 sysroot_stage_all() {
     :
 }
+
+do_package_qa() {
+}


### PR DESCRIPTION
Silence this annoying warning:
do_package_qa: QA Issue: non -staticdev package contains static .a library: enigma2-plugin-systemplugins-networkbrowser path '/enigma2-plugin-systemplugins-networkbrowser/usr/lib/enigma2/python/Plugins/SystemPlugins/NetworkBrowser/netscan.a' [staticdev]