### PR TITLE
add by-name for easy detection of the name of the internal emmc partition

### DIFF
--- a/meta-openpli/recipes-support/partitions-by-name/files/partitions-by-name.sh
+++ b/meta-openpli/recipes-support/partitions-by-name/files/partitions-by-name.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+search=/sys/block/mmcblk0/mmcblk0p*
+for i in $search;
+do
+  if [ "$i" != "$search" ]; then
+    partname=`cat /$i/uevent | grep PARTNAME | cut -d '=' -f 2`
+    devname=`cat /$i/uevent | grep DEVNAME | cut -d '=' -f 2`
+    mkdir -p /dev/block/by-name/
+    ln -sf /dev/$devname /dev/block/by-name/$partname
+  fi
+done

--- a/meta-openpli/recipes-support/partitions-by-name/partitions-by-name_1.0.bb
+++ b/meta-openpli/recipes-support/partitions-by-name/partitions-by-name_1.0.bb
@@ -1,0 +1,25 @@
+SUMMARY = "partitions by name"
+DESCRIPTION = "for internal emmc flash which give partitons names in /dev/block/by-name/"
+SECTION = "base"
+LICENSE = "GPLv2"
+
+require conf/license/openpli-gplv2.inc
+
+SRC_URI = "file://partitions-by-name.sh"
+
+INITSCRIPT_NAME = "partitions-by-name"
+INITSCRIPT_PARAMS = "start 04 S ."
+
+inherit update-rc.d
+
+S = "${WORKDIR}"
+
+do_install() {
+	install -d ${D}${sysconfdir}/init.d
+	install -m 0755 ${S}/partitions-by-name.sh ${D}${sysconfdir}/init.d/partitions-by-name
+}
+
+do_package_qa() {
+}
+
+FILES_${PN} += " ${sysconfdir}/init.d"


### PR DESCRIPTION
Manufactures can add for emmc the follow line in bsplayer: RDEPENDS_${PN} += " partitions-by-name"

It can simplify online update and multiboot as you can direct mount to the partition name. 
It will give you as well a quick view which partitions are available on the internal emmc flash ( ls -1 /dev/block/by-name)