### PR TITLE
Update blindscan-s2.bb

### DIFF
--- a/meta-openpli/recipes-extended/blindscan-s2/blindscan-s2.bb
+++ b/meta-openpli/recipes-extended/blindscan-s2/blindscan-s2.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "Blindscan dvb-s(2) satellites using stv090x devices"
 SECTION = "base"
 PRIORITY = "optional"
 LICENSE = "PD"
-LIC_FILES_CHKSUM = "file://README.md;md5=f084bf390249474bef1b8817e83757fa"
+LIC_FILES_CHKSUM = "file://README.md;md5=b69b6d0feee577047e07a832c67d8076"
 
 SRC_URI = "git://bitbucket.org/majortom/blindscan-s2.git;protocol=http file://support-enigma2.patch"
 


### PR DESCRIPTION
ERROR: blindscan-s2-1+gitAUTOINC+28c50c6c37-r0 do_populate_lic: QA Issue: blindscan-s2: The LIC_FILES_CHKSUM does not match for file://README.md;md5=f084bf390249474bef1b8817e83757fa