### PR TITLE
Fakelocale: add two Norwegian versions - bokmal and nynorsk

### DIFF
--- a/meta-openpli/recipes-openpli/fakelocale/fakelocale.bb
+++ b/meta-openpli/recipes-openpli/fakelocale/fakelocale.bb
@@ -18,7 +18,7 @@ LOCALEDIR = "${libdir}/locale"
 LOCALEDIR2 = "/usr/share/locale"
 
 LANGUAGES = "ar_AE bg_BG ca_AD cs_CZ da_DK de_DE el_GR en_EN es_ES et_EE fa_IR fi_FI \
-	fr_FR fy_NL he_IL hr_HR hu_HU id_ID is_IS it_IT lt_LT lv_LV nl_NL no_NO pl_PL pt_BR pt_PT \
+	fr_FR fy_NL he_IL hr_HR hu_HU id_ID is_IS it_IT lt_LT lv_LV nl_NL nb_NO nn_NO pl_PL pt_BR pt_PT \
 	ru_RU sk_SK sl_SI sr_YU sv_SE th_TH tr_TR uk_UA vi_VN"
 
 RPROVIDES_${PN} = "virtual-locale-ar virtual-locale-bg virtual-locale-ca virtual-locale-cs \

--- a/meta-openpli/recipes-openpli/fakelocale/files/locale.alias
+++ b/meta-openpli/recipes-openpli/fakelocale/files/locale.alias
@@ -18,7 +18,8 @@ Lithuanian lt_LT
 Latvian lv_LV
 Icelandic is_IS
 Italian it_IT
-Norwegian no_NO
+Norwegian Bokmål nb_NO
+Norwegian Nynorsk nn_NO
 Persian fa_IR
 Polish pl_PL
 Portugues pt_PT


### PR DESCRIPTION
to sync with  recent  changes in our fakelocale repo.