### PR TITLE
Import upstream Wiregard 0.0.20191219 from meta-openembedded

### DIFF
--- a/meta-openpli/recipes-linux/wireguard/wireguard-module_0.0.20191219.bb
+++ b/meta-openpli/recipes-linux/wireguard/wireguard-module_0.0.20191219.bb
@@ -1,0 +1,31 @@
+require wireguard.inc
+
+inherit module kernel-module-split
+
+DEPENDS = "virtual/kernel libmnl"
+
+# This module requires Linux 3.10 higher and several networking related
+# configuration options. For exact kernel requirements visit:
+# https://www.wireguard.io/install/#kernel-requirements
+
+EXTRA_OEMAKE_append = " \
+    KERNELDIR=${STAGING_KERNEL_DIR} \
+    "
+
+MAKE_TARGETS = "module"
+
+RRECOMMENDS_${PN} = "kernel-module-xt-hashlimit"
+MODULE_NAME = "wireguard"
+
+# Kernel module packages MUST begin with 'kernel-module-', otherwise
+# multilib image generation can fail.
+#
+# The following line is only necessary if the recipe name does not begin
+# with kernel-module-.
+PKG_${PN} = "kernel-module-${MODULE_NAME}"
+
+module_do_install() {
+    install -d ${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/kernel/${MODULE_NAME}
+    install -m 0644 ${MODULE_NAME}.ko \
+    ${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/kernel/${MODULE_NAME}/${MODULE_NAME}.ko
+}

--- a/meta-openpli/recipes-linux/wireguard/wireguard-tools_0.0.20191219.bb
+++ b/meta-openpli/recipes-linux/wireguard/wireguard-tools_0.0.20191219.bb
@@ -1,0 +1,27 @@
+require wireguard.inc
+
+inherit bash-completion systemd pkgconfig
+
+DEPENDS = "wireguard-module libmnl"
+
+do_compile_prepend () {
+    cd ${S}/tools
+}
+
+do_install () {
+    cd ${S}/tools
+    oe_runmake DESTDIR="${D}" PREFIX="${prefix}" SYSCONFDIR="${sysconfdir}" \
+        SYSTEMDUNITDIR="${systemd_unitdir}" \
+        WITH_SYSTEMDUNITS=${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'yes', '', d)} \
+        WITH_BASHCOMPLETION=yes \
+        WITH_WGQUICK=yes \
+        install
+}
+
+FILES_${PN} = " \
+    ${sysconfdir} \
+    ${systemd_unitdir} \
+    ${bindir} \
+"
+
+RDEPENDS_${PN} = "wireguard-module bash"

--- a/meta-openpli/recipes-linux/wireguard/wireguard.inc
+++ b/meta-openpli/recipes-linux/wireguard/wireguard.inc
@@ -1,0 +1,17 @@
+SUMMARY = "WireGuard is an extremely simple yet fast and modern VPN"
+DESCRIPTION="WireGuard is a secure network tunnel, operating at layer 3, \
+implemented as a kernel virtual network interface for Linux, which aims to \
+replace both IPsec for most use cases, as well as popular user space and/or \
+TLS-based solutions like OpenVPN, while being more secure, more performant, \
+and easier to use."
+SECTION = "networking"
+HOMEPAGE = "https://www.wireguard.io/"
+LICENSE = "GPLv2"
+
+LIC_FILES_CHKSUM = "file://../COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+
+SRC_URI = "https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${PV}.tar.xz"
+SRC_URI[md5sum] = "5175ca88850993dc88a4c9d924ee79d4"
+SRC_URI[sha256sum] = "5aba6f0c38e97faa0b155623ba594bb0e4bd5e29deacd8d5ed8bda8d8283b0e7"
+
+S = "${WORKDIR}/WireGuard-${PV}/src/"


### PR DESCRIPTION
Just import them but not ship it yet in the feeds since I still need to go through all the defconfigs.