### PR TITLE
partitions-by-name: prevent that udev attempts to symlink

### DIFF
--- a/meta-openpli/recipes-support/partitions-by-name/files/device-mapper.rules
+++ b/meta-openpli/recipes-support/partitions-by-name/files/device-mapper.rules
@@ -1,4 +1,4 @@
-KERNEL=="mtd*", SUBSYSTEM=="mtd", SYMLINK+="block/by-name/$sysfs{name}"
+KERNEL=="mtd*", ENV{DEVTYPE}=="mtd", SYMLINK+="block/by-name/$sysfs{name}"
 
 KERNEL=="mmcblk0p*", SUBSYSTEM=="block", RUN+="/etc/udev/scripts/mmc-dev-mapping.sh"
 


### PR DESCRIPTION
udevd[979]: rename '/dev/block/by-name/.tmp-c90:1' '/dev/block/by-name/' failed: Not a directory