### PR TITLE
Don't use AUTOREV for BackupSuite

### DIFF
--- a/meta-openpli/conf/distro/reporefs.conf
+++ b/meta-openpli/conf/distro/reporefs.conf
@@ -189,7 +189,7 @@ SRCREV_pn-minisatip = "${AUTOREV}"
 # plugins
 SRCREV_pn-enigma2-pliplugins ??= "${AUTOREV}"
 SRCREV_pn-enigma2-plugin-extensions-automatic-fullbackup ??= "${AUTOREV}"
-SRCREV_pn-enigma2-plugin-extensions-backupsuite ??= "${AUTOREV}"
+SRCREV_pn-enigma2-plugin-extensions-backupsuite ??= "c7f27f896824ce6fc40fb2fcd852a297373cb330"
 SRCREV_pn-enigma2-plugin-extensions-blurayplayer ??= "${AUTOREV}"
 SRCREV_pn-enigma2-plugin-extensions-dlnabrowser ??= "${AUTOREV}"
 SRCREV_pn-enigma2-plugin-extensions-dlnaserver ??= "${AUTOREV}"


### PR DESCRIPTION
https://github.com/OpenVisionE2/BackupSuite/commit/276a02172ff872cf1069d55ee0248ccd94cc2274 isn't compatible with PLi as we're using full machine names like "vuduo" instead of "duo" in the new "lookuptable.txt"

https://github.com/OpenVisionE2/BackupSuite/blob/master/plugin/backupsuite.sh#L214 returns "duo" for you so the new "lookuptable.txt" won't understand it.

Is there a way to detect machine names like getBoxType but in shell not python? (For PLi I mean as we're fine)