### PR TITLE
python-youtube-dl - set PE var in recipe to enable recent git tags semantics in upstream

### DIFF
--- a/meta-openpli/recipes-devtools/python/python-youtube-dl.bb
+++ b/meta-openpli/recipes-devtools/python/python-youtube-dl.bb
@@ -12,6 +12,7 @@ DEPENDS = "libxml2 bash-completion"
 inherit gitpkgv
 
 SRCREV = "${AUTOREV}"
+PE = "1"
 PV = "git${SRCPV}"
 PKGV = "${GITPKGVTAG}"
 SRC_URI = "git://github.com/ytdl-org/youtube-dl.git;protocol=https;branch=master"
@@ -51,4 +52,3 @@ FILES_${PN}-src = " \
     "
 
 FILES_${PN} += "${sysconfdir}"
-


### PR DESCRIPTION
- tags changed backwards from 2020.06.16.1 to 2020.07.28 upstream
- see details in gitpkgv class in meta-OE