### PR TITLE
kodi_18: mipsel fixes

### DIFF
--- a/meta-openpli/recipes-mediacenter/kodi/kodi-vuplus-support.bb
+++ b/meta-openpli/recipes-mediacenter/kodi/kodi-vuplus-support.bb
@@ -20,3 +20,4 @@ FILES_SOLIBSDEV = ""
 FILES_${PN} = " ${bindir}/xbmc.helper ${libdir}/libxbmc_base.so"
 
 INSANE_SKIP_${PN}_append += "already-stripped dev-so"
+PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/meta-openpli/recipes-mediacenter/kodi/kodi_18.bb
+++ b/meta-openpli/recipes-mediacenter/kodi/kodi_18.bb
@@ -69,7 +69,7 @@ DEPENDS += " \
             zlib \
           "
 
-SRCREV = "085bd1b92e2bc01f6426577df1b0666a212be235"
+SRCREV = "0655c2c71821567e4c21c1c5a508a39ab72f0ef1"
 
 # 'patch' doesn't support binary diffs
 PATCHTOOL = "git"
@@ -77,8 +77,7 @@ PATCHTOOL = "git"
 # Correct 18+git vs 18-git screwup
 PE = "1"
 
-#PV = "18.1-gitr${SRCPV}"
-PV = "18.5+gitr${SRCPV}"
+PV = "18.9+gitr${SRCPV}"
 SRC_URI = "git://github.com/xbmc/xbmc.git;protocol=https;branch=Leia \
            \
            file://0001-Add-support-for-musl-triplets.patch \

--- a/meta-openpli/recipes-mediacenter/kodi/kodi_18.bb
+++ b/meta-openpli/recipes-mediacenter/kodi/kodi_18.bb
@@ -125,10 +125,10 @@ PACKAGECONFIG[pulseaudio] = "-DENABLE_PULSEAUDIO=ON,-DENABLE_PULSEAUDIO=OFF,puls
 PACKAGECONFIG[lcms] = ",,lcms"
 
 LDFLAGS += "${TOOLCHAIN_OPTIONS}"
-LDFLAGS_append_mips = " -latomic"
-LDFLAGS_append_mipsel = " -latomic"
-LDFLAGS_append_mips64 = " -latomic"
-LDFLAGS_append_mips64el = " -latomic"
+LDFLAGS_append_mips = " -latomic -lpthread"
+LDFLAGS_append_mipsel = " -latomic -lpthread"
+LDFLAGS_append_mips64 = " -latomic -lpthread"
+LDFLAGS_append_mips64el = " -latomic -lpthread"
 
 KODI_ARCH = ""
 KODI_ARCH_mips = "-DWITH_ARCH=${TARGET_ARCH}"


### PR DESCRIPTION
While the binary still terminates with SIGBUS (or SEGFAULT if heavily hacked...) I send here the fixes for mips.

There remain some points to consider:
- gold linker vs bfd for mips
- libfmt/fmt v4  vs newer
- in meta-kodi there are more PACKAGECONFIG options to implement