### PR TITLE
binutils_2.32: fix warning about patch not found, merge recipes

### DIFF
--- a/meta-openpli/recipes-devtools/binutils/binutils-cross_2.32.bbappend
+++ b/meta-openpli/recipes-devtools/binutils/binutils-cross_2.32.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://0001-binutils-missing-string-include.patch"

--- a/meta-openpli/recipes-devtools/binutils/files/0001-binutils-missing-string-include.patch
+++ b/meta-openpli/recipes-devtools/binutils/files/0001-binutils-missing-string-include.patch
@@ -1,0 +1,11 @@
+diff -ur a/gold/debug.h b/gold/debug.h
+--- a/gold/debug.h	2020-07-17 20:56:54.213143987 +0200
++++ b/gold/debug.h	2020-07-18 12:48:13.035259962 +0200
+@@ -24,6 +24,7 @@
+ #define GOLD_DEBUG_H
+ 
+ #include <cstring>
++#include <string>
+ 
+ #include "parameters.h"
+ #include "errors.h"


### PR DESCRIPTION
In OpenPLi we have extra patches for the target and cross recipes.
Fix following warning:

WARNING: /oe/openpli-oe-core/openembedded-core/meta
/recipes-devtools/binutils/binutils_2.32.bb:
 Unable to get checksum for nativesdk-binutils SRC_URI entry
0001-binutils-program-name-multiply-defined.patchfile:
 file could not be found

Signed-off-by: Andrea Adami <andrea.adami@gmail.com>