### PR TITLE
kodi_18 - mipsel WIP

### DIFF
--- a/meta-openpli/recipes-mediacenter/kodi/kodi-vuplus-support.bb
+++ b/meta-openpli/recipes-mediacenter/kodi/kodi-vuplus-support.bb
@@ -17,7 +17,9 @@ do_install(){
 }
 
 FILES_SOLIBSDEV = ""
-FILES_${PN} = " ${bindir}/xbmc.helper ${libdir}/libxbmc_base.so"
+FILES_${PN} = "${bindir}/xbmc.helper ${libdir}/libxbmc_base.so"
 
-INSANE_SKIP_${PN}_append += "already-stripped dev-so"
+INHIBIT_PACKAGE_STRIP = "1"
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+
 PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/meta-openpli/recipes-mediacenter/kodi/kodi-vuplus.inc
+++ b/meta-openpli/recipes-mediacenter/kodi/kodi-vuplus.inc
@@ -11,3 +11,10 @@ SRC_URI[xbmc-vusolo2.md5sum] = "e29a91b185133ec60a59e94a8229d2b4"
 SRC_URI[xbmc-vusolo2.sha256sum] = "3c56b7ee890b3e21f378acd79db3752d721de0880b6d763bbd37fa942c2ae2b5"
 SRC_URI[xbmc-vusolose.md5sum] = "831014212eed47e36ec084f2e803e2d8"
 SRC_URI[xbmc-vusolose.sha256sum] = "97bfc26a316bcba4b897f81f31179e8861cc123a0b4d8589a2290f3cd7268c1d"
+
+# workaround for vuxxo2 unversioned shared libs
+ASSUME_SHLIBS += "libEGL.so:libgles-${MACHINE} libGLESv2.so:libgles-${MACHINE}"
+ASSUME_SHLIBS += "libdvb_base.so:libgles-${MACHINE} libdvb_client.so:libgles-${MACHINE}"
+ASSUME_SHLIBS += "libnxpl.so:libgles-${MACHINE} libv3ddriver.so:libgles-${MACHINE}"
+
+ASSUME_SHLIBS += "libxbmc_base.so:kodi-vuplus-support"


### PR DESCRIPTION
After the last changes kodi survives enough to create the crashlog!
More work is needed...

/home/root/kodi_crashlog-20201226_233058.log          778/1751               44%
############## Kodi CRASH LOG ###############

################ SYSTEM INFO ################
 Date: Sat Dec 26 23:30:58 CET 2020
 Kodi Options:
 Arch: mips
 Kernel: Linux 3.13.5 #1 SMP Mon Dec 21 08:30:38 UTC 2020
 Release: lsb_release not available
############## END SYSTEM INFO ##############

############### STACK TRACE #################
=====>  Core file: /home/root/core (2020-12-26 23:30:58.000000000)
        =========================================
[New LWP 1646]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/libthread_db.so.1".
Core was generated by `/usr/lib/kodi/kodi-stb'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x0000ca62 in ?? ()

Thread 1 (Thread 0x746ab300 (LWP 1646)):
#0  0x0000ca62 in ?? ()
#1  0x009f9738 in CLinuxTimezone::CLinuxTimezone() ()
warning: GDB can't find the start of the function at 0x7fafa097.

    GDB is unable to find the start of the function at 0x7fafa097
and thus can't determine the size of that function's stack frame.
This means that GDB may be unable to access that stack frame, or
the frames below it.
    This problem is most likely caused by an invalid program counter or
stack pointer.
    However, if you think GDB should simply search farther back
from 0x7fafa097 for code which looks like the beginning of a
function, you can increase the range of the search using the `set
heuristic-fence-post' command.
#2  0x7fafa098 in ?? ()
############# END STACK TRACE ###############

################# LOG FILE ##################

Logfile not found in the usual place.
Please attach it separately.
Use pastebin.com or similar for forums or IRC.

############### END LOG FILE ################

############ END Kodi CRASH LOG #############

