### PR TITLE
binutils_2.32: really fix fetcher error for nativesdk-binutils

### DIFF
--- a/meta-openpli/recipes-devtools/binutils/binutils-cross_2.32.bbappend
+++ b/meta-openpli/recipes-devtools/binutils/binutils-cross_2.32.bbappend
@@ -1,3 +1,3 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SRC_URI += "file://0001-binutils-missing-string-include.patch"
+SRC_URI += " file://0001-binutils-missing-string-include.patch "

--- a/meta-openpli/recipes-devtools/binutils/binutils_2.32.bbappend
+++ b/meta-openpli/recipes-devtools/binutils/binutils_2.32.bbappend
@@ -1,3 +1,3 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:${THISDIR}/files:"
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SRC_URI += "file://0001-binutils-program-name-multiply-defined.patch"
+SRC_URI += " file://0001-binutils-program-name-multiply-defined.patch "


### PR DESCRIPTION
Even though the search-paths were correct an obscure 'issue' (or bug)
makes necessary for the bbappends to add spaces around patches in SRC_URI.

andrea@andrea-ThinkPad-T520:/oe/openpli-oe-core/build$ bitbake -p nativesdk-binutils
Loading cache: 100% |############################################| Time: 0:00:00
Loaded 4192 entries from dependency cache.
WARNING: /oe/openpli-oe-core/openembedded-core/meta/recipes-devtools/
binutils/binutils_2.32.bb:
Unable to get checksum for nativesdk-binutils SRC_URI entry
0001-binutils-missing-string-include.patchfile: file could not be found
                                         ^^^

See
http://git.yoctoproject.org/cgit.cgi/poky/commit/?
id=69e3b6c80ea7cab7f8687ee223dfd29dcc2c0d75

Signed-off-by: Andrea Adami <andrea.adami@gmail.com>