### PR TITLE
camstop script: add missing --oknodo option

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-softcams/cardserver.inc
+++ b/meta-openpli/recipes-openpli/enigma2-softcams/cardserver.inc
@@ -11,7 +11,7 @@ CSLINK = "${sysconfdir}/init.d/cardserver"
 CSPATH = "${sysconfdir}/init.d/cardserver.${CSNAME}"
 
 CSSTART ?= "exec start-stop-daemon -S -x /usr/bin/${CSNAME}"
-CSSTOP  ?= "exec start-stop-daemon -K -R 2 -x /usr/bin/${CSNAME}"
+CSSTOP  ?= "exec start-stop-daemon -K -o -R 2 -x /usr/bin/${CSNAME}"
 
 # Generate a simplistic standard init script
 # (sorry for the sleep 1, but start-stop-daemon -R does not work as advertised)

--- a/meta-openpli/recipes-openpli/enigma2-softcams/softcam.inc
+++ b/meta-openpli/recipes-openpli/enigma2-softcams/softcam.inc
@@ -19,7 +19,7 @@ CAMLINK = "/etc/init.d/softcam"
 CAMPATH = "/etc/init.d/softcam.${CAMNAME}"
 
 CAMSTART ?= "exec start-stop-daemon -S -x /usr/bin/${CAMNAME}"
-CAMSTOP  ?= "exec start-stop-daemon -K -R 2 -x /usr/bin/${CAMNAME}"
+CAMSTOP  ?= "exec start-stop-daemon -K -o -R 2 -x /usr/bin/${CAMNAME}"
 
 # Generate a simplistic standard init script
 # (sorry for the sleep 1, but start-stop-daemon -R does not work as advertised)


### PR DESCRIPTION
This fixes the issue of not being able to remove some softcam packages if cam was not running.
If a process does not exist, start-stop-daemon exits with error status 1, unless -o | --oknodo is spcified, and this was causing the prerm script to fail.
Added also to cardserver stop script.