### PR TITLE
Activate swap space by udev

### DIFF
--- a/meta-openpli/recipes-core/udev/files/mount.sh
+++ b/meta-openpli/recipes-core/udev/files/mount.sh
@@ -118,6 +118,14 @@ automount() {
 		exit 0
 	fi
 
+	# Activate swap space
+	if [ "$ID_FS_TYPE" == "swap" ] ; then
+		if ! grep -q "^/dev/${NAME} " /proc/swaps ; then
+			swapon /dev/${NAME}
+		fi
+		exit 0
+	fi
+
 	# check for "please don't mount it" file
 	if [ -f "/dev/nomount.${DEVBASE}" ]; then
 		# blocked


### PR DESCRIPTION
If you have a swap partition then activate it as swap space instead of trying to mount it.