### PR TITLE
distro: add 'mplt' to DISTRO_FEATURES - fix kodi for Vu+ mipsel

### DIFF
--- a/meta-openpli/conf/distro/openpli-common.conf
+++ b/meta-openpli/conf/distro/openpli-common.conf
@@ -74,7 +74,7 @@ FULL_OPTIMIZATION_pn-libvorbis = "${O2_OPT}"
 FULL_OPTIMIZATION_pn-tremor = "${O2_OPT}"
 FULL_OPTIMIZATION_pn-zlib = "${O2_OPT}"
 
-DISTRO_FEATURES ?= "alsa bluetooth directfb ext2 largefile wifi nfs zeroconf pam ${DISTRO_FEATURES_LIBC} ipv4 ipv6"
+DISTRO_FEATURES ?= "alsa bluetooth directfb ext2 largefile wifi nfs zeroconf mplt pam ${DISTRO_FEATURES_LIBC} ipv4 ipv6"
 
 QA_LOGFILE = "${TMPDIR}/qa.log"
 


### PR DESCRIPTION
The toolchain needs to be compiled with --with-mips-plt
Otherwise the vendor-provided drivers badly link during kodi build and
the binary crashes at start.

Signed-off-by: Andrea Adami <andrea.adami@gmail.com>