### PR TITLE
vuplus-hdmi-in-helper: silence QA, nothing to strip here

### DIFF
--- a/meta-openpli/recipes-openpli/vuplus-hdmi-in-helper/vuplus-hdmi-in-helper.bb
+++ b/meta-openpli/recipes-openpli/vuplus-hdmi-in-helper/vuplus-hdmi-in-helper.bb
@@ -25,3 +25,9 @@ INITSCRIPT_NAME = "update_systemconfig.sh"
 INITSCRIPT_PARAMS = "start 90 3 ."
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+# nothing to strip for debug here,
+# update_systemconfig_arm is stripped
+INHIBIT_PACKAGE_STRIP = "1"
+INHIBIT_SYSROOT_STRIP = "1"
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"


### PR DESCRIPTION
Fix QA Issue: File '/usr/bin/update_systemconfig' ...  was already stripped,
     this will prevent future debugging! [already-stripped]

Signed-off-by: Andrea Adami <andrea.adami@gmail.com>