### PR TITLE
libtalloc: silence QA about [patch-fuzz]

### DIFF
--- a/meta-openpli/recipes-support/libtalloc/libtalloc_2.3.0.bbappend
+++ b/meta-openpli/recipes-support/libtalloc/libtalloc_2.3.0.bbappend
@@ -1,0 +1,2 @@
+# rebased to fix QA about patch fuzz in OE-zeus ver 2.3.0
+FILESEXTRAPATHS_prepend := "${THISDIR}:"

--- a/meta-openpli/recipes-support/libtalloc/openpli/avoid-attr-unless-wanted.patch
+++ b/meta-openpli/recipes-support/libtalloc/openpli/avoid-attr-unless-wanted.patch
@@ -1,0 +1,20 @@
+--- a/lib/replace/wscript	2015-11-13 16:04:04.000000000 +0100
++++ b/lib/replace/wscript	2015-11-13 16:23:20.000000000 +0100
+@@ -890,8 +890,6 @@ def build(bld):
+     if not bld.CONFIG_SET('HAVE_INET_ATON'):     REPLACE_SOURCE += ' inet_aton.c'
+     if not bld.CONFIG_SET('HAVE_INET_NTOP'):     REPLACE_SOURCE += ' inet_ntop.c'
+     if not bld.CONFIG_SET('HAVE_INET_PTON'):     REPLACE_SOURCE += ' inet_pton.c'
+-    if not bld.CONFIG_SET('HAVE_GETXATTR') or bld.CONFIG_SET('XATTR_ADDITIONAL_OPTIONS'):
+-                                                 REPLACE_SOURCE += ' xattr.c'
+ 
+     if not bld.CONFIG_SET('HAVE_CLOSEFROM'):
+         REPLACE_SOURCE += ' closefrom.c'
+@@ -905,7 +903,7 @@ def build(bld):
+                       # at the moment:
+                       # hide_symbols=bld.BUILTIN_LIBRARY('replace'),
+                       private_library=True,
+-                      deps='crypt dl nsl socket rt attr' + extra_libs)
++                      deps='crypt dl nsl socket rt ' + extra_libs)
+ 
+     replace_test_cflags = ''
+     if bld.CONFIG_SET('HAVE_WNO_FORMAT_TRUNCATION'):


### PR DESCRIPTION
 Applying patch avoid-attr-unless-wanted.patch
 patching file lib/replace/wscript
 Hunk #1 succeeded at 890 (offset 53 lines).
 Hunk #2 succeeded at 903 with fuzz 2 (offset 53 lines).

 The recipe in OE meta-networking/recipes/support
 was updated in meta-openembedded with commit
 517bd23 libtalloc: upgrade 2.2.0 -> 2.3.0

 The patch does now apply with fuzz so we
 overlay with our version.

Signed-off-by: Andrea Adami <andrea.adami@gmail.com>