### PR TITLE
libtevent: silence QA about [patch-fuzz]

### DIFF
--- a/meta-openpli/recipes-support/libtevent/libtevent_0.10.1.bbappend
+++ b/meta-openpli/recipes-support/libtevent/libtevent_0.10.1.bbappend
@@ -1,0 +1,2 @@
+# rebased to fix QA about patch fuzz in OE-zeus ver 2.3.0
+FILESEXTRAPATHS_prepend := "${THISDIR}:"

--- a/meta-openpli/recipes-support/libtevent/openpli/avoid-attr-unless-wanted.patch
+++ b/meta-openpli/recipes-support/libtevent/openpli/avoid-attr-unless-wanted.patch
@@ -1,0 +1,24 @@
+diff --git a/lib/replace/wscript b/lib/replace/wscript
+index 079761d..07e0104 100644
+--- a/lib/replace/wscript
++++ b/lib/replace/wscript
+--- a	2021-05-24 23:33:17.953643190 +0200
++++ b	2021-05-24 23:28:24.152180557 +0200
+@@ -888,8 +888,6 @@ def build(bld):
+     if not bld.CONFIG_SET('HAVE_INET_ATON'):     REPLACE_SOURCE += ' inet_aton.c'
+     if not bld.CONFIG_SET('HAVE_INET_NTOP'):     REPLACE_SOURCE += ' inet_ntop.c'
+     if not bld.CONFIG_SET('HAVE_INET_PTON'):     REPLACE_SOURCE += ' inet_pton.c'
+-    if not bld.CONFIG_SET('HAVE_GETXATTR') or bld.CONFIG_SET('XATTR_ADDITIONAL_OPTIONS'):
+-                                                 REPLACE_SOURCE += ' xattr.c'
+ 
+     if not bld.CONFIG_SET('HAVE_CLOSEFROM'):
+         REPLACE_SOURCE += ' closefrom.c'
+@@ -903,7 +901,7 @@ def build(bld):
+                       # at the moment:
+                       # hide_symbols=bld.BUILTIN_LIBRARY('replace'),
+                       private_library=True,
+-                      deps='crypt dl nsl socket rt attr' + extra_libs)
++                      deps='crypt dl nsl socket rt ' + extra_libs)
+ 
+     replace_test_cflags = ''
+     if bld.CONFIG_SET('HAVE_WNO_FORMAT_TRUNCATION'):


### PR DESCRIPTION
Applying patch avoid-attr-unless-wanted.patch
patching file lib/replace/wscript
Hunk #1 succeeded at 888 (offset 95 lines).
Hunk #2 succeeded at 901 with fuzz 2 (offset 95 lines).

The recipe in OE meta-networking/recipes/support
was updated in meta-openembedded with commit
4472914 libtevent: upgrade 0.10.0 -> 0.10.1

The patch does now apply with fuzz so we
overlay with our version.

Signed-off-by: Andrea Adami <andrea.adami@gmail.com>