### PR TITLE
kodi-addons: fix build downgrading kodi-platform and p8platform

### DIFF
--- a/meta-openpli/recipes-mediacenter/kodi-addons/kodi-platform_18.0.0.bb
+++ b/meta-openpli/recipes-mediacenter/kodi-addons/kodi-platform_18.0.0.bb
@@ -1,47 +1,45 @@
-SUMMARY = "Kodi platform support library"
-DESCRIPTION = "Platform support library used by libCEC and binary add-ons for Kodi"
-HOMEPAGE = "https://github.com/xbmc/kodi-platform"
+SUMMARY = "Platform support library used by libCEC and binary add-ons for Kodi"
+HOMEPAGE = "http://libcec.pulse-eight.com/"
 
-PACKAGE_ARCH = "${MACHINE_ARCH}"
+PACKAGE_ARCH = "${MACHINE}"
 
 LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://src/util/XMLUtils.cpp;beginline=2;endline=18;md5=dae8e846500e70dd8ecee55f3f018c30"
 
 DEPENDS = "libtinyxml kodi"
 
-SRCREV = "809c5e9d711e378561440a896fcb7dbcd009eb3d"
+PE = "1"
+PV = "18.0.0"
 
+SRCREV = "e8574b883ffa2131f2eeb96ff3724d60b21130f7"
 SRC_URI = "git://github.com/xbmc/kodi-platform.git;protocol=https \
            file://kodi-platform-01_crosscompile-badness.patch \
            file://kodi-platform-02_no-multi-lib.patch \
           "
-
-PV = "18.9+gitr${SRCPV}"
 
 S = "${WORKDIR}/git"
 
 inherit cmake pkgconfig
 
 OECMAKE_GENERATOR="Unix Makefiles"
-EXTRA_OECMAKE = " \
+EXTRA_OECMAKE = " -DCMAKE_INSTALL_PREFIX_TOOLCHAIN=${STAGING_DIR_HOST}${prefix} \
                   -DCMAKE_INSTALL_LIBDIR=${libdir} \
                   -DCMAKE_INSTALL_LIBDIR_NOARCH=${libdir} \
-                  -DCMAKE_INSTALL_PREFIX_TOOLCHAIN=${STAGING_DIR_HOST}${prefix} \
+                  -DKODI_INCLUDE_DIR=${STAGING_INCDIR}/kodi \
                   -DCMAKE_MODULE_PATH='${STAGING_DIR_HOST}${libdir}/kodi;${STAGING_DIR_HOST}${datadir}/kodi/cmake' \
                   -DCMAKE_PREFIX_PATH=${STAGING_DIR_HOST}${prefix} \
-                  -DKODI_INCLUDE_DIR=${STAGING_INCDIR}/kodi \
                 "
 
 do_compile_prepend() {
-        sed -i -e 's:I/usr/include:I${STAGING_INCDIR}:g' \
-               -e 's:-pipe:${HOST_CC_ARCH} ${TOOLCHAIN_OPTIONS} -pipe:g' \
-                  ${B}/CMakeFiles/kodiplatform.dir/flags.make
-        sed -i -e 's:-pipe:${HOST_CC_ARCH} ${TOOLCHAIN_OPTIONS} -pipe:g'\
-                  ${B}/CMakeFiles/kodiplatform.dir/link.txt
+	sed -i -e 's:I/usr/include:I${STAGING_INCDIR}:g' \
+	       -e 's:-pipe:${HOST_CC_ARCH} ${TOOLCHAIN_OPTIONS} -pipe:g' \
+	          ${B}/CMakeFiles/kodiplatform.dir/flags.make
+	sed -i -e 's:-pipe:${HOST_CC_ARCH} ${TOOLCHAIN_OPTIONS} -pipe:g'\
+	          ${B}/CMakeFiles/kodiplatform.dir/link.txt
 }
 
 do_install_append() {
-        sed -i -e '/CXX/d' \
+	sed -i -e '/CXX/d' \
                -e '/CC/d' \
                -e 's:${STAGING_LIBDIR}:${libdir}:g' \
                -e 's:${STAGING_DIR_HOST}:/:g' \
@@ -57,3 +55,9 @@ PACKAGES =+ "libkodiplatform"
 FILES_libkodiplatform = "${libdir}/lib*.so.*"
 
 FILES_${PN}-dev += "${libdir}/*platform"
+
+do_qa_staging() {
+}
+
+do_rm_work() {
+}

--- a/meta-openpli/recipes-mediacenter/kodi-addons/p8platform_git.bb
+++ b/meta-openpli/recipes-mediacenter/kodi-addons/p8platform_git.bb
@@ -1,22 +1,24 @@
 SUMMARY = "Platform support library used by libCEC and binary add-ons for Kodi"
 HOMEPAGE = "http://libcec.pulse-eight.com/"
 
-PACKAGE_ARCH = "${MACHINE_ARCH}"
+PACKAGE_ARCH = "${MACHINE}"
 
 LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://src/os.h;md5=752555fa94e82005d45fd201fee5bd33"
 
-SRC_URI = "git://github.com/Pulse-Eight/platform.git"
-SRCREV = "a7cd0d5780ed80a4e70480d1650749f29e8a1fb2"
+PE = "1"
+PV = "2.1.0"
 
-# real version is 2.1.1 but
-# we keep this to avoid PE
-PV = "2.2.0+gitr${SRCPV}"
+SRC_URI = "git://github.com/Pulse-Eight/platform.git"
+SRCREV = "a822e196cb57d8545dccca6cc22fda0f83c34321"
 
 S = "${WORKDIR}/git"
 
 inherit cmake pkgconfig
 
-EXTRA_OECMAKE = "-DCMAKE_INSTALL_LIBDIR=${libdir} -DCMAKE_INSTALL_LIBDIR_NOARCH=${libdir}"
+EXTRA_OECMAKE += "-DCMAKE_INSTALL_LIBDIR=${libdir} -DCMAKE_INSTALL_LIBDIR_NOARCH=${libdir}"
 
 FILES_${PN}-dev += "${libdir}/p8-platform"
+
+do_rm_work() {
+}


### PR DESCRIPTION
The kodi-addons folder need more work.
For the moment fix the build reverting d274941 and 902f769

Signed-off-by: Andrea Adami <andrea.adami@gmail.com>