### PR TITLE
V2 for musl

### DIFF
--- a/meta-openpli/recipes-connectivity/samba/wsdd/wsdd.c
+++ b/meta-openpli/recipes-connectivity/samba/wsdd/wsdd.c
@@ -49,7 +49,12 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
+
+#ifdef __GLIBC__
 #include <sys/poll.h>
+#else
+#include <poll.h>
+#endif
 
 #include <time.h>
 #include <pthread.h>

--- a/meta-openpli/recipes-extended/ofgwrite/files/0001-ofgwrite-fix-build-with-musl.patch
+++ b/meta-openpli/recipes-extended/ofgwrite/files/0001-ofgwrite-fix-build-with-musl.patch
@@ -1,0 +1,96 @@
+From 99a8478d4b660c0d61f1a9af36481e7c1891a649 Mon Sep 17 00:00:00 2001
+From: Andrea Adami <andrea.adami@gmail.com>
+Date: Tue, 15 Jun 2021 02:05:39 +0200
+Subject: [PATCH 1/1] ofgwrite: fix build with musl
+
+-fix: u_long and u_short
+
+ lib/libfec.c:628:5: error: unknown type name 'u_long'
+  628 |     u_long magic ;
+
+- fix missing rpmatch(line)
+
+- define WTMP_FILE
+
+Signed-off-by: Andrea Adami <andrea.adami@gmail.com>
+---
+ busybox/libbb/messages.c | 4 ++++
+ include/common.h         | 9 +++++++++
+ lib/common.h             | 9 +++++++++
+ lib/libfec.c             | 5 +++++
+ 4 files changed, 27 insertions(+)
+
+diff --git a/busybox/libbb/messages.c b/busybox/libbb/messages.c
+index c1b7ba2..5875a29 100644
+--- a/busybox/libbb/messages.c
++++ b/busybox/libbb/messages.c
+@@ -19,6 +19,10 @@
+ 
+ #define BANNER "BusyBox v" BB_VER " (" BB_EXTRA_VERSION ")"
+ 
++#ifndef __GLIBC__
++#define WTMP_FILE "/var/log/wtmp"
++#endif
++
+ const char bb_banner[] ALIGN1 = BANNER;
+ 
+ 
+diff --git a/include/common.h b/include/common.h
+index 0e9f8cf..29b9585 100644
+--- a/include/common.h
++++ b/include/common.h
+@@ -102,6 +102,15 @@ extern "C" {
+ 	my_fprintf(stderr, "%s: warning!: " fmt "\n", PROGRAM_NAME, ##__VA_ARGS__); \
+ } while(0)
+ 
++/* musl libc compat */
++#ifndef HAVE_RPMATCH
++#define rpmatch(line) \
++	( (line == NULL)? -1 : \
++	  (*line == 'y' || *line == 'Y')? 1 : \
++	  (*line == 'n' || *line == 'N')? 0 : \
++	  -1 )
++#endif
++
+ /**
+  * prompt the user for confirmation
+  */
+diff --git a/lib/common.h b/lib/common.h
+index 0e9f8cf..29b9585 100644
+--- a/lib/common.h
++++ b/lib/common.h
+@@ -102,6 +102,15 @@ extern "C" {
+ 	my_fprintf(stderr, "%s: warning!: " fmt "\n", PROGRAM_NAME, ##__VA_ARGS__); \
+ } while(0)
+ 
++/* musl libc compat */
++#ifndef HAVE_RPMATCH
++#define rpmatch(line) \
++	( (line == NULL)? -1 : \
++	  (*line == 'y' || *line == 'Y')? 1 : \
++	  (*line == 'n' || *line == 'N')? 0 : \
++	  -1 )
++#endif
++
+ /**
+  * prompt the user for confirmation
+  */
+diff --git a/lib/libfec.c b/lib/libfec.c
+index 060eb32..efb368e 100644
+--- a/lib/libfec.c
++++ b/lib/libfec.c
+@@ -46,6 +46,11 @@
+ #include <stdlib.h>
+ #include <string.h>
+ 
++/* for musl u_long and u_short */
++#ifndef __GLIBC__
++#include <sys/types.h>
++#endif
++
+ /*
+  * stuff used for testing purposes only
+  */
+-- 
+2.17.1
+

--- a/meta-openpli/recipes-extended/ofgwrite/files/fix_glibc_major.patch
+++ b/meta-openpli/recipes-extended/ofgwrite/files/fix_glibc_major.patch
@@ -4,9 +4,9 @@
  #include <sys/ioctl.h>
  #include <sys/stat.h>
  #include <sys/types.h>
-+#ifdef __GLIBC__
++//#ifdef __GLIBC__
 +#include <sys/sysmacros.h>
-+#endif
++//#endif
  #include <libubi.h>
  #include "libubi_int.h"
  #include "common.h"
@@ -16,9 +16,9 @@
  #include <fcntl.h>
  #include <dirent.h>
  #include <sys/types.h>
-+#ifdef __GLIBC__
++//#ifdef __GLIBC__
 +#include <sys/sysmacros.h>
-+#endif
++//#endif
  #include <sys/stat.h>
  #include <sys/ioctl.h>
  #include <inttypes.h>
@@ -28,9 +28,9 @@
  #include <stdlib.h>
  #include <errno.h>
  #include <sys/types.h>
-+#ifdef __GLIBC__
++//#ifdef __GLIBC__
 +#include <sys/sysmacros.h>
-+#endif
++//#endif
  #include <sys/stat.h>
  #include <sys/ioctl.h>
  #include <mtd/mtd-user.h>

--- a/meta-openpli/recipes-extended/ofgwrite/ofgwrite.bb
+++ b/meta-openpli/recipes-extended/ofgwrite/ofgwrite.bb
@@ -10,8 +10,9 @@ inherit gitpkgv
 PV = "4.x+git${SRCPV}"
 PKGV = "4.x+git${GITPKGV}"
 
-SRC_URI = "git://github.com/oe-alliance/ofgwrite.git \
-	file://fix_glibc_major.patch"
+SRC_URI = "git://github.com/oe-alliance/ofgwrite.git"
+SRC_URI_append = " file://fix_glibc_major.patch"
+SRC_URI_append_libc-musl = " file://0001-ofgwrite-fix-build-with-musl.patch"
 
 S = "${WORKDIR}/git"
 EXTRA_OEMAKE=""

--- a/meta-openpli/recipes-multimedia/dvd+rw-tools/files/fix-glibc2.28_major.patch
+++ b/meta-openpli/recipes-multimedia/dvd+rw-tools/files/fix-glibc2.28_major.patch
@@ -4,9 +4,9 @@
  #include <string.h>
  #include <fcntl.h>
  #include <sys/types.h>
-+#ifdef __GLIBC__
++//#ifdef __GLIBC__
 +#include <sys/sysmacros.h>
-+#endif
++//#endif
  #include <sys/stat.h>
  #include <assert.h>
  #include "mp.h"

--- a/meta-openpli/recipes-multimedia/tuxtxt/files/0001-libtuxtxt-fix-build-with-musl.patch
+++ b/meta-openpli/recipes-multimedia/tuxtxt/files/0001-libtuxtxt-fix-build-with-musl.patch
@@ -1,0 +1,36 @@
+From cc14b371c38cec4c35530f95078713e1e368c6c7 Mon Sep 17 00:00:00 2001
+From: Andrea Adami <andrea.adami@gmail.com>
+Date: Mon, 14 Jun 2021 23:49:35 +0200
+Subject: [PATCH 1/1] libtuxtxt: fix build with musl
+
+fix
+libtuxtxt.c:47:46: error:
+ 'PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP'
+ undeclared here (not in a function);
+  did you mean 'PTHREAD_MUTEX_INITIALIZER'?
+
+Signed-off-by: Andrea Adami <andrea.adami@gmail.com>
+---
+ libtuxtxt.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/libtuxtxt.c b/libtuxtxt.c
+index 476c7db..d7870dc 100644
+--- a/libtuxtxt.c
++++ b/libtuxtxt.c
+@@ -44,7 +44,12 @@
+  ******************************************************************************/
+ 
+ static int tuxtxt_initialized=0;
++
++#ifdef __GLIBC__
+ static pthread_mutex_t tuxtxt_control_lock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
++#else
++static pthread_mutex_t tuxtxt_control_lock = {{PTHREAD_MUTEX_RECURSIVE}};
++#endif
+ static pthread_mutex_t tuxtxt_key_queue_lock = PTHREAD_MUTEX_INITIALIZER;
+ 
+ int tuxtxt_init()
+-- 
+2.17.1
+

--- a/meta-openpli/recipes-multimedia/tuxtxt/files/0001-tuxtxt-enigma2-fix-build-with-musl.patch
+++ b/meta-openpli/recipes-multimedia/tuxtxt/files/0001-tuxtxt-enigma2-fix-build-with-musl.patch
@@ -1,0 +1,32 @@
+From f3a16f097d5483734b562c0f997bfd616cb69f5e Mon Sep 17 00:00:00 2001
+From: Andrea Adami <andrea.adami@gmail.com>
+Date: Tue, 15 Jun 2021 00:17:39 +0200
+Subject: [PATCH 1/1] tuxtxt-enigma2: fix build with musl
+
+fix
+ | ../git/tuxtxt/tuxtxt.c:215:15: error: storage size of 's' isn't known
+ |   215 |   struct stat s;
+ |       |               ^
+
+Signed-off-by: Andrea Adami <andrea.adami@gmail.com>
+---
+ tuxtxt.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/tuxtxt.h b/tuxtxt.h
+index 7f40b09..500f0fa 100644
+--- a/tuxtxt.h
++++ b/tuxtxt.h
+@@ -40,6 +40,9 @@
+ #include <string.h>
+ #include <unistd.h>
+ #include <sys/types.h>
++#ifndef __GLIBC__
++#include <sys/stat.h>
++#endif
+ #include <sys/time.h>
+ #include <ctype.h>
+ 
+-- 
+2.17.1
+

--- a/meta-openpli/recipes-multimedia/tuxtxt/libtuxtxt.bb
+++ b/meta-openpli/recipes-multimedia/tuxtxt/libtuxtxt.bb
@@ -7,6 +7,7 @@ inherit gitpkgv
 
 GITHUB_URI ?= "git://github.com"
 SRC_URI = "${GITHUB_URI}/OpenPLi/tuxtxt.git"
+SRC_URI_append_libc-musl = " file://0001-libtuxtxt-fix-build-with-musl.patch"
 
 S = "${WORKDIR}/git/libtuxtxt"
 

--- a/meta-openpli/recipes-multimedia/tuxtxt/tuxtxt-enigma2.bb
+++ b/meta-openpli/recipes-multimedia/tuxtxt/tuxtxt-enigma2.bb
@@ -8,6 +8,7 @@ inherit gitpkgv
 
 GITHUB_URI ?= "git://github.com"
 SRC_URI = "${GITHUB_URI}/OpenPLi/tuxtxt.git"
+SRC_URI_append_libc-musl = " file://0001-tuxtxt-enigma2-fix-build-with-musl.patch"
 
 S = "${WORKDIR}/git/tuxtxt"
 

--- a/meta-openpli/recipes-openpli/enigma2/enigma2.bb
+++ b/meta-openpli/recipes-openpli/enigma2/enigma2.bb
@@ -24,18 +24,20 @@ RDEPENDS_${PN} = " \
 	alsa-conf \
 	enigma2-fonts \
 	ethtool \
-	glibc-gconv-iso8859-15 \
 	${PYTHON_RDEPS} \
 	"
+
+RDEPENDS_${PN}_append_libc-glibc = " glibc-gconv-iso8859-15"
 
 RRECOMMENDS_${PN} = " \
 	enigma2-plugin-skins-pli-hd \
 	hotplug-e2-helper \
-	glibc-gconv-utf-16 \
 	python-sendfile \
 	ofgwrite \
 	virtual/enigma2-mediaservice \
 	"
+
+RRECOMMENDS_${PN}_append_libc-glibc = " glibc-gconv-utf-16"
 
 PYTHON_RDEPS = " \
 	python-codecs \

--- a/meta-openpli/recipes-openpli/enigma2/enigma2.bb
+++ b/meta-openpli/recipes-openpli/enigma2/enigma2.bb
@@ -113,6 +113,7 @@ PKGV = "2.7+git${GITPKGV}"
 ENIGMA2_BRANCH ?= "develop"
 GITHUB_URI ?= "git://github.com"
 SRC_URI = "${GITHUB_URI}/OpenPLi/${BPN}.git;branch=${ENIGMA2_BRANCH}"
+SRC_URI_append_libc-musl = " file://0001-enigma2-fix-build-with-musl.patch"
 
 LDFLAGS_prepend = " -lxml2 "
 

--- a/meta-openpli/recipes-openpli/enigma2/enigma2/0001-enigma2-fix-build-with-musl.patch
+++ b/meta-openpli/recipes-openpli/enigma2/enigma2/0001-enigma2-fix-build-with-musl.patch
@@ -1,0 +1,270 @@
+From 7b264116e251e5932e636008df873325152e3926 Mon Sep 17 00:00:00 2001
+From: Andrea Adami <andrea.adami@gmail.com>
+Date: Tue, 15 Jun 2021 09:59:32 +0200
+Subject: [PATCH 1/1] enigma2: fix build with musl
+
+fixes:
+ lib/base/thread.cpp:59:5: error: 'struct sched_param' has no member named '__sched_priority';
+ lib/base/e2avahi.cpp:154:37: error: missing sentinel in function call [-Werror=format=]
+ lib/dvb/epgcache.cpp:400:2: error: 'PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP' was not declared in this scope;
+ lib/dvb/epgtransponderdatareader.cpp:10:65: error: 'PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP' was not declared in this scope;
+ lib/gdi/gpixmap.cpp:9:2: error: #error "no BYTE_ORDER defined!"
+ lib/gdi/font.cpp:35:31: error: 'PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP' was not declared in this scope;
+ lib/gdi/pixmapcache.h:11:9: error: 'uint' does not name a type; did you mean 'rint'?
+ lib/gdi/pixmapcache.cpp:134:30: error: 'MaximumSize' was not declared in this scope
+ lib/gdi/font.cpp:35:31: error: 'PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP' was not declared in this scope;
+ lib/gdi/pixmapcache.h:11:9: error: 'uint' does not name a type; did you mean 'rint'?
+ lib/gdi/pixmapcache.cpp:8:1: error: 'uint' does not name a type; did y
+ lib/gdi/pixmapcache.cpp:134:30: error: 'MaximumSize' was not declared
+
+ Plugins/Extensions/SocketMMI/src/socket_mmi.cpp:1:
+ ...../usr/include/sys/poll.h:1:2: error: #warning redirecting incorrect
+  include <sys/poll.h> to <poll.h> [-Werror=cpp]
+
+lib/gdi/font.cpp:35:31: error: 'PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP' was not declared in this scope;
+main/bsod.cpp:6:10: fatal error: execinfo.h: No such file or directory
+main/enigma.cpp:357:18: error: variable 'dump_malloc_stats()::mallinfo mi' has initializer but incomplete type
+main/enigma.cpp:357:32: error: invalid use of incomplete type 'struct dump_malloc_stats()::mallinfo'
+
+Signed-off-by: Andrea Adami <andrea.adami@gmail.com>
+---
+ lib/base/e2avahi.cpp                 |  4 ++++
+ lib/base/ebase.h                     |  4 ++++
+ lib/base/eerror.cpp                  | 12 +++++++++++-
+ lib/base/thread.cpp                  |  4 ++++
+ lib/dvb/epgcache.cpp                 |  4 ++++
+ lib/dvb/epgtransponderdatareader.cpp | 14 ++++++++++++--
+ lib/gdi/font.cpp                     |  7 ++++++-
+ lib/gdi/gpixmap.cpp                  |  4 ++++
+ lib/gdi/pixmapcache.h                |  4 ++++
+ main/bsod.cpp                        |  6 ++++++
+ main/enigma.cpp                      |  4 ++++
+ 11 files changed, 63 insertions(+), 4 deletions(-)
+
+diff --git a/lib/base/e2avahi.cpp b/lib/base/e2avahi.cpp
+index 2c53e39de..fd77d7146 100644
+--- a/lib/base/e2avahi.cpp
++++ b/lib/base/e2avahi.cpp
+@@ -151,7 +151,11 @@ static void avahi_service_try_register(AvahiServiceEntry *entry)
+ 			AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC,
+ 			(AvahiPublishFlags)0,
+ 			service_name, entry->service_type,
++#ifdef __GLIBC__
+ 			NULL, NULL, entry->port_num, NULL))
++#else
++			NULL, NULL, entry->port_num, __null))
++#endif
+ 	{
+ 		avahi_entry_group_commit(entry->group);
+ 		eDebug("[Avahi] Registered %s (%s) on %s:%u",
+diff --git a/lib/base/ebase.h b/lib/base/ebase.h
+index 79be15b9f..4a59e6349 100644
+--- a/lib/base/ebase.h
++++ b/lib/base/ebase.h
+@@ -4,7 +4,11 @@
+ #ifndef SWIG
+ #include <vector>
+ #include <map>
++#ifdef __GLIBC__
+ #include <sys/poll.h>
++#else
++#include <poll.h>
++#endif
+ #include <sys/time.h>
+ #include <asm/types.h>
+ #include <time.h>
+diff --git a/lib/base/eerror.cpp b/lib/base/eerror.cpp
+index 224ab8c1b..a02d61672 100644
+--- a/lib/base/eerror.cpp
++++ b/lib/base/eerror.cpp
+@@ -13,7 +13,11 @@
+ #ifdef MEMLEAK_CHECK
+ AllocList *allocList;
+ pthread_mutex_t memLock =
++#ifdef __GLIBC__
+ 	PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
++#else
++	{{PTHREAD_MUTEX_RECURSIVE}};
++#endif
+ 
+ void DumpUnfreed()
+ {
+@@ -79,7 +83,13 @@ void DumpUnfreed()
+ int debugLvl = lvlDebug;
+ static bool debugTime = false;
+ 
+-static pthread_mutex_t DebugLock = PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP;
++static pthread_mutex_t DebugLock = 
++#ifdef __GLIBC__
++    PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP;
++#else
++    PTHREAD_MUTEX_INITIALIZER;
++#endif
++
+ #define RINGBUFFER_SIZE 16384
+ static char ringbuffer[RINGBUFFER_SIZE];
+ static unsigned int ringbuffer_head;
+diff --git a/lib/base/thread.cpp b/lib/base/thread.cpp
+index f64eb4c19..91e91af64 100644
+--- a/lib/base/thread.cpp
++++ b/lib/base/thread.cpp
+@@ -56,7 +56,11 @@ int eThread::runAsync(int prio, int policy)
+ 	if (prio || policy)
+ 	{
+ 		struct sched_param p;
++#ifdef __GLIBC__
+ 		p.__sched_priority=prio;
++#else
++		p.sched_priority=prio;
++#endif
+ 		pthread_attr_setschedpolicy(&attr, policy);
+ 		pthread_attr_setschedparam(&attr, &p);
+ 	}
+diff --git a/lib/dvb/epgcache.cpp b/lib/dvb/epgcache.cpp
+index 378f8a36a..3398def2c 100644
+--- a/lib/dvb/epgcache.cpp
++++ b/lib/dvb/epgcache.cpp
+@@ -397,7 +397,11 @@ void eventData::cacheCorrupt(const char* context)
+ 
+ eEPGCache* eEPGCache::instance;
+ static pthread_mutex_t cache_lock =
++#ifdef __GLIBC__
+ 	PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
++#else
++	{{PTHREAD_MUTEX_RECURSIVE}};
++#endif
+ 
+ DEFINE_REF(eEPGCache)
+ 
+diff --git a/lib/dvb/epgtransponderdatareader.cpp b/lib/dvb/epgtransponderdatareader.cpp
+index e182c6004..5fa652d07 100644
+--- a/lib/dvb/epgtransponderdatareader.cpp
++++ b/lib/dvb/epgtransponderdatareader.cpp
+@@ -7,8 +7,18 @@
+ 
+ 
+ eEPGTransponderDataReader* eEPGTransponderDataReader::instance;
+-pthread_mutex_t eEPGTransponderDataReader::known_channel_lock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
+-pthread_mutex_t eEPGTransponderDataReader::last_channel_update_lock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
++pthread_mutex_t eEPGTransponderDataReader::known_channel_lock = 
++#ifdef __GLIBC__
++	PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
++#else
++	{{PTHREAD_MUTEX_RECURSIVE}};
++#endif
++pthread_mutex_t eEPGTransponderDataReader::last_channel_update_lock = 
++#ifdef __GLIBC__
++	PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
++#else
++	{{PTHREAD_MUTEX_RECURSIVE}};
++#endif
+ 
+ DEFINE_REF(eEPGTransponderDataReader)
+ 
+diff --git a/lib/gdi/font.cpp b/lib/gdi/font.cpp
+index 738b5c46e..837c98437 100644
+--- a/lib/gdi/font.cpp
++++ b/lib/gdi/font.cpp
+@@ -32,7 +32,12 @@
+ 
+ fontRenderClass *fontRenderClass::instance;
+ 
+-static pthread_mutex_t ftlock=PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP;
++static pthread_mutex_t ftlock= 
++#ifdef __GLIBC__
++	PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP;
++#else
++	PTHREAD_MUTEX_INITIALIZER;
++#endif
+ 
+ struct fntColorCacheKey
+ {
+diff --git a/lib/gdi/gpixmap.cpp b/lib/gdi/gpixmap.cpp
+index b33e8b691..825fd56bb 100644
+--- a/lib/gdi/gpixmap.cpp
++++ b/lib/gdi/gpixmap.cpp
+@@ -5,9 +5,13 @@
+ #include <lib/gdi/accel.h>
+ #include <byteswap.h>
+ 
++#ifdef __GLIBC__
+ #ifndef BYTE_ORDER
+ #error "no BYTE_ORDER defined!"
+ #endif
++#else
++#define BYTE_ORDER __BTE_ORDER
++#endif
+ 
+ /* surface acceleration threshold: do not attempt to accelerate surfaces smaller than the threshold (measured in bytes) */
+ #ifndef GFX_SURFACE_ACCELERATION_THRESHOLD
+diff --git a/lib/gdi/pixmapcache.h b/lib/gdi/pixmapcache.h
+index 4f41a3001..cb87d8d2e 100644
+--- a/lib/gdi/pixmapcache.h
++++ b/lib/gdi/pixmapcache.h
+@@ -3,6 +3,10 @@
+ 
+ #include <lib/gdi/gpixmap.h>
+ 
++#ifndef __GLIBC__
++#include <sys/types.h>
++#endif
++
+ #ifndef SWIG
+ 
+ class PixmapCache
+diff --git a/main/bsod.cpp b/main/bsod.cpp
+index cac47793b..100645958 100644
+--- a/main/bsod.cpp
++++ b/main/bsod.cpp
+@@ -3,7 +3,9 @@
+ #include <csignal>
+ #include <fstream>
+ #include <sstream>
++#ifdef __GLIBC__
+ #include <execinfo.h>
++#endif
+ #include <dlfcn.h>
+ #include <lib/base/eenv.h>
+ #include <lib/base/eerror.h>
+@@ -301,6 +303,7 @@ void oops(const mcontext_t &context)
+  * it's not async-signal-safe and so must not be used in signal
+  * handlers.
+  */
++#ifdef __GLIBC__
+ void print_backtrace()
+ {
+ 	void *array[15];
+@@ -320,12 +323,15 @@ void print_backtrace()
+ 		}
+ 	}
+ }
++#endif
+ 
+ void handleFatalSignal(int signum, siginfo_t *si, void *ctx)
+ {
+ 	ucontext_t *uc = (ucontext_t*)ctx;
+ 	oops(uc->uc_mcontext);
++#ifdef __GLIBC__
+ 	print_backtrace();
++#endif
+ 	eLog(lvlFatal, "-------FATAL SIGNAL");
+ 	bsodFatal("enigma2, signal");
+ }
+diff --git a/main/enigma.cpp b/main/enigma.cpp
+index f7cbe89f9..f1ff732e0 100644
+--- a/main/enigma.cpp
++++ b/main/enigma.cpp
+@@ -354,6 +354,10 @@ const char *getBoxType()
+ 
+ void dump_malloc_stats(void)
+ {
++#ifdef __GLIBC__
+ 	struct mallinfo mi = mallinfo();
+ 	eDebug("MALLOC: %d total", mi.uordblks);
++#else
++	eDebug("MALLOC: info not exposed");
++#endif
+ }
+-- 
+2.17.1
+

--- a/meta-openpli/recipes-openpli/images/openpli-image.bb
+++ b/meta-openpli/recipes-openpli/images/openpli-image.bb
@@ -19,7 +19,6 @@ IMAGE_INSTALL = "\
 	e2fsprogs-tune2fs \
 	fakelocale \
 	fuse-exfat \
-	glibc-binary-localedata-en-gb \
 	kernel-params \
 	modutils-loadscript \
 	cifs-utils \
@@ -42,6 +41,8 @@ IMAGE_INSTALL = "\
 	volatile-media \
 	vsftpd \
 "
+
+IMAGE_INSTALL_append_libc-glibc = " glibc-binary-localedata-en-gb"
 
 export IMAGE_BASENAME = "openpli"
 IMAGE_LINGUAS = ""

--- a/meta-openpli/recipes-openpli/streamproxy/files/0001-streamproxy-fix-build-with-musl.patch
+++ b/meta-openpli/recipes-openpli/streamproxy/files/0001-streamproxy-fix-build-with-musl.patch
@@ -1,0 +1,34 @@
+From bb7800494d834f517c0d97768ef3cc1d2521d4eb Mon Sep 17 00:00:00 2001
+From: Andrea Adami <andrea.adami@gmail.com>
+Date: Tue, 15 Jun 2021 01:41:13 +0200
+Subject: [PATCH 1/1] streamproxy: fix build with musl
+
+fix
+ | ../../git/src/webrequest.cpp:15:10: fatal error: sys/unistd.h:
+ No such file or directory
+ |    15 | #include <sys/unistd.h>
+
+Signed-off-by: Andrea Adami <andrea.adami@gmail.com>
+---
+ src/webrequest.cpp | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/webrequest.cpp b/src/webrequest.cpp
+index ce20a45..02e0f24 100644
+--- a/src/webrequest.cpp
++++ b/src/webrequest.cpp
+@@ -12,7 +12,11 @@ using std::string;
+ #include <string.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
++#ifdef __GLIBC__
+ #include <sys/unistd.h>
++#else
++#include <unistd.h>
++#endif
+ #include <string.h>
+ 
+ WebRequest::WebRequest(const ConfigMap &config_map_in, const HeaderMap &headers_in,
+-- 
+2.17.1
+

--- a/meta-openpli/recipes-openpli/streamproxy/streamproxy.bb
+++ b/meta-openpli/recipes-openpli/streamproxy/streamproxy.bb
@@ -11,6 +11,8 @@ PKGV = "2+git${GITPKGV}"
 RDEPENDS_${PN} = "enigma2-plugin-systemplugins-transcodingsetup"
 
 SRC_URI = "git://github.com/eriksl/streamproxy.git;protocol=git"
+SRC_URI_append_libc-musl = " file://0001-streamproxy-fix-build-with-musl.patch"
+
 FILES_${PN} = "${bindir}/streamproxy ${sysconfdir}/init.d/streamproxy.sh ${sysconfdir}/enigma2/streamproxy.conf"
 CONFFILES_${PN} = "${sysconfdir}/enigma2/streamproxy.conf"
 S = "${WORKDIR}/git"


### PR DESCRIPTION
With this patchset I have build-tested openpli-enigma2-image with glibc and musl libc, here the results with the same config for vuduo2 (without opera-browser stuff):

andrea@andrea-ThinkPad-T520:/oe/tc/images/vuduo2-glibc$ ls -ahl
total 323M
drwxr-xr-x 2 andrea andrea 4,0K giu 15 13:28 .
drwxrwxr-x 4 andrea andrea 4,0K giu 15 13:38 ..
-rw-rw-r-- 1 andrea andrea 7,4M giu 15 12:41 modules--3.13.5-r1.7.4-vuduo2-20210615102216.tgz
lrwxrwxrwx 1 andrea andrea   48 giu 15 13:31 modules-vuduo2.tgz -> modules--3.13.5-r1.7.4-vuduo2-20210615102216.tgz
-rwxr-xr-x 1 andrea andrea 6,1M giu 15 13:28 openpli-enigma2-homebuild-vuduo2.initrd_cfe_auto.bin
-rw-r--r-- 1 andrea andrea  23K giu 15 13:28 openpli-enigma2-homebuild-vuduo2.rootfs.manifest
-rw-r--r-- 1 andrea andrea 106M giu 15 13:28 openpli-enigma2-homebuild-vuduo2.rootfs.ubi
-rw-r--r-- 1 andrea andrea 103M giu 15 13:28 openpli-enigma2-homebuild-vuduo2.rootfs.ubifs
-rw-r--r-- 1 andrea andrea 400K giu 15 13:28 openpli-enigma2-homebuild-vuduo2.testdata.json
-rw-r--r-- 1 andrea andrea 3,5M giu 15 13:28 openpli-enigma2-homebuild-vuduo2.vmlinux.gz
-rw-r--r-- 1 andrea andrea  89M giu 15 13:28 openpli-homebuild-vuduo2_usb.zip
-rw-r--r-- 1 andrea andrea  241 giu 15 13:28 ubinize-openpli-enigma2-homebuild-vuduo2.cfg
lrwxrwxrwx 1 andrea andrea   48 giu 15 13:31 vmlinux -> vmlinux--3.13.5-r1.7.4-vuduo2-20210615102216.bin
-rw-r--r-- 1 andrea andrea 8,9M giu 15 12:41 vmlinux--3.13.5-r1.7.4-vuduo2-20210615102216.bin
lrwxrwxrwx 1 andrea andrea   48 giu 15 13:31 vmlinux-vuduo2.bin -> vmlinux--3.13.5-r1.7.4-vuduo2-20210615102216.bin

andrea@andrea-ThinkPad-T520:/oe/tc/images/vuduo2-musl$ ls -ahl
total 315M
drwxr-xr-x 2 andrea andrea 4,0K giu 15 13:37 .
drwxrwxr-x 4 andrea andrea 4,0K giu 15 13:38 ..
-rw-rw-r-- 1 andrea andrea 7,4M giu 13 22:22 modules--3.13.5-r1.7.4-vuduo2-20210613200530.tgz
lrwxrwxrwx 1 andrea andrea   48 giu 15 13:38 modules-vuduo2.tgz -> modules--3.13.5-r1.7.4-vuduo2-20210613200530.tgz
-rwxr-xr-x 1 andrea andrea 6,1M giu 15 13:37 openpli-enigma2-homebuild-vuduo2.initrd_cfe_auto.bin
-rw-r--r-- 1 andrea andrea  22K giu 15 13:37 openpli-enigma2-homebuild-vuduo2.rootfs.manifest
-rw-r--r-- 1 andrea andrea 103M giu 15 13:37 openpli-enigma2-homebuild-vuduo2.rootfs.ubi
-rw-r--r-- 1 andrea andrea 100M giu 15 13:37 openpli-enigma2-homebuild-vuduo2.rootfs.ubifs
-rw-r--r-- 1 andrea andrea 400K giu 15 13:37 openpli-enigma2-homebuild-vuduo2.testdata.json
-rw-r--r-- 1 andrea andrea 3,5M giu 15 13:37 openpli-enigma2-homebuild-vuduo2.vmlinux.gz
-rw-r--r-- 1 andrea andrea  87M giu 15 13:37 openpli-homebuild-vuduo2_usb.zip
-rw-r--r-- 1 andrea andrea  246 giu 15 13:37 ubinize-openpli-enigma2-homebuild-vuduo2.cfg
lrwxrwxrwx 1 andrea andrea   48 giu 15 13:38 vmlinux -> vmlinux--3.13.5-r1.7.4-vuduo2-20210613200530.bin
-rw-r--r-- 1 andrea andrea 8,9M giu 13 22:22 vmlinux--3.13.5-r1.7.4-vuduo2-20210613200530.bin
lrwxrwxrwx 1 andrea andrea   48 giu 15 13:38 vmlinux-vuduo2.bin -> vmlinux--3.13.5-r1.7.4-vuduo2-20210613200530.bin

Now we need to implement these fresh musl patches from master-next: 

https://git.openembedded.org/openembedded-core/commit/meta/recipes-core/musl?id=e2d54f02bcde7a95235a61b9622c584a77c4e9bc

Note that it is still WIP for glibc-precompiled libs and BSP needs to be adapted (meta-vuplus i.e.):

<khem> use gcompat
<khem> it should handle dlopen too
<khem> its easy to use
<khem> add it to IMAGE_INSTALL thats it
<ant_> ok
<khem> it will install a ldso with same name as glibc and in same location
<khem> then you can open the glibc precompiled application and it will invoke this gcompat layer
<khem> problem is that you will not be able to mix and match libraries
<khem> it works for some well known apps so perhaps will work for your usecase too

<ant_> khem, building kodi in the meanwhile
<ant_> libxbmc_base.so: undefined reference to `stdout@GLIBC_2.0'
<ant_> libEGL.so: undefined reference to `ferror@GLIBC_2.0'
<ant_> ...
<ant_> it fails at buildtime
<khem> right, you need to build it using TCLIBC=glibc but then use the binaries into musl builds
<khem> so perhaps create prebuilt tarballs and then another recipe to build/package them which can be used in musl Distro
<ant_> ok, I have both libc on stage

A.A.
