### PR TITLE
kodi_18: add INSANE_SKIP_${PN}_dual += "file-rdeps"

### DIFF
--- a/meta-openpli/recipes-mediacenter/kodi/kodi_18.inc
+++ b/meta-openpli/recipes-mediacenter/kodi/kodi_18.inc
@@ -94,6 +94,8 @@ INSANE_SKIP_${PN}_gbtrio4k += "file-rdeps"
 INSANE_SKIP_${PN}_sf8008 += "file-rdeps"
 INSANE_SKIP_${PN}_sf8008m += "file-rdeps"
 #
+INSANE_SKIP_${PN}_dual += "file-rdeps"
+#
 INSANE_SKIP_${PN}_h7 += "file-rdeps"
 INSANE_SKIP_${PN}_h9 += "file-rdeps"
 INSANE_SKIP_${PN}_h9combo += "file-rdeps"


### PR DESCRIPTION
The newly added meta-qviart duo unfortunately arises the issue:

QA Issue: /usr/lib/kodi/kodi-stb contained in package kodi
requires libmali.so, but no providers found in RDEPENDS_kodi? [file-rdeps]

this fo libmali.so, libEGL.so, libGLESv2.so
(as for other BSP's provided drivers)

Signed-off-by: Andrea Adami <andrea.adami@gmail.com>