### PR TITLE
kodi_18: skip runtime dependency check for ustym4kpro

### DIFF
--- a/meta-openpli/recipes-mediacenter/kodi/kodi_18.inc
+++ b/meta-openpli/recipes-mediacenter/kodi/kodi_18.inc
@@ -42,6 +42,8 @@ INSANE_SKIP_${PN}_sf8008m += "file-rdeps"
 #
 INSANE_SKIP_${PN}_dual += "file-rdeps"
 #
+INSANE_SKIP_${PN}_ustym4kpro += "file-rdeps"
+#
 INSANE_SKIP_${PN}_h7 += "file-rdeps"
 INSANE_SKIP_${PN}_h9 += "file-rdeps"
 INSANE_SKIP_${PN}_h9combo += "file-rdeps"


### PR DESCRIPTION
fix kodi build.
another set of libs that apparently cannot be offered by the shresolver.
This happens when there are missing SONAME and/or not versioned libs.

Must be verified and fixed in the BSP. Nothing we can do in kodi.

Signed-off-by: Andrea Adami <andrea.adami@gmail.com>