### PR TITLE
kodi_18: remove BUILD_OPTIMIZATION (FULL_OPTIMIZATION_armv7a)

### DIFF
--- a/meta-openpli/recipes-mediacenter/kodi/kodi_18.bb
+++ b/meta-openpli/recipes-mediacenter/kodi/kodi_18.bb
@@ -200,9 +200,6 @@ LDFLAGS += "${TOOLCHAIN_OPTIONS}"
 LDFLAGS_append_mipsarch = " -latomic -lpthread"
 LDFLAGS_append_arm = " -lpthread"
 
-FULL_OPTIMIZATION_armv7a = "-fexpensive-optimizations -fomit-frame-pointer -O4 -ffast-math"
-BUILD_OPTIMIZATION = "${FULL_OPTIMIZATION}"
-
 # for python modules
 export HOST_SYS
 export BUILD_SYS


### PR DESCRIPTION
    Use standard DISTRO optimizations.
    Kodi itself is just a container, we must optimize ffmpeg instead.

    I did some tests planning to add
    FULL_OPTIMIZATION_armv7ve =
     "-fexpensive-optimizations -fomit-frame-pointer -O4 -ffast-math"

    These 'optimizations' were adding the following:
    CFLAGS=" -fexpensive-optimizations -fomit-frame-pointer -O4 -ffast-math
     -march=armv7ve -mfpu=neon-vfpv4 -mfloat-abi=hard --sysroot=..."
    kodi-stb is 18566k
    Note how -march -mfpu -mfloat are wrongly repeated here (these are in $CC)

    Removing the line we have the standard:
    CFLAGS=" -Os -pipe -g -feliminate-unused-debug-types -fmacro-prefix-map...."
    kodi-stb is 18574k

    Note that the gcc manual says Os implies almost the same O2 optimizations
    thus -fexpensive-optimizations is included.

Signed-off-by: Andrea Adami <andrea.adami@gmail.com>