### PR TITLE
Add skin SimpleGray

### DIFF
--- a/meta-openpli/conf/distro/reporefs.conf
+++ b/meta-openpli/conf/distro/reporefs.conf
@@ -274,6 +274,7 @@ SRCREV_pn-enigma2-plugin-skins-pd1loi-hd-night ??= "${AUTOREV}"
 SRCREV_pn-enigma2-plugin-skins-pli-hd ??= "${AUTOREV}"
 SRCREV_pn-enigma2-plugin-skins-pli-hd-fullnight ??= "${AUTOREV}"
 SRCREV_pn-enigma2-plugin-skins-simple-gray-hd ??= "${AUTOREV}"
+SRCREV_pn-enigma2-plugin-skins-simple-gray ??= "${AUTOREV}"
 SRCREV_pn-enigma2-skins ??= "${AUTOREV}"
 
 # softcams

--- a/meta-openpli/recipes-openpli/enigma2-skins/enigma2-plugin-skins-simple-gray.bb
+++ b/meta-openpli/recipes-openpli/enigma2-skins/enigma2-plugin-skins-simple-gray.bb
@@ -1,0 +1,24 @@
+DESCRIPTION = "Simple and clean multi resolution skin SimpleGray by Taapat"
+MAINTAINER = "Taapat"
+LICENSE = "GPLv3"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=1ebbd3e34237af26da5dc08a4e440464"
+
+inherit gitpkgv allarch pythonnative
+
+PV = "1.0+git${SRCPV}"
+PKGV = "1.0+git${GITPKGV}"
+
+SRC_URI = "git://github.com/Taapat/skin-SimpleGray.git;protocol=https"
+
+FILES_${PN} = "${prefix}/"
+
+S = "${WORKDIR}/git"
+
+do_compile() {
+	python -O -m compileall ${S}${libdir}/enigma2/python/Components/
+}
+
+do_install() {
+	install -d ${D}${prefix}
+	cp -r ${S}${prefix}/* ${D}${prefix}/
+}


### PR DESCRIPTION
Simple and clean multi resolution skin for OpenPLi or on OpenPLi based enigma2 images.

Skins use automatic scaling, thefore it is available in all, SD, HD and FHD resolutions.
Skins use svg images, so their quality does not change at all resolutions.