### PR TITLE
Remove twisted-web dependencies from plugin youtube rdepends

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-youtube.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-youtube.bb
@@ -19,8 +19,6 @@ RDEPENDS_${PN} = " \
 	python-codecs \
 	python-json \
 	python-netclient \
-	python-pyopenssl \
-	python-zlib \
 	python-twisted-web \
 	"
 


### PR DESCRIPTION
python-twisted-web dependencies in meta-openembedded have been fixed for a long time and are no longer needed