### PR TITLE
ffmpeg: Add libx264 encoder

### DIFF
--- a/meta-openpli/recipes-multimedia/ffmpeg/ffmpeg_4.%.bbappend
+++ b/meta-openpli/recipes-multimedia/ffmpeg/ffmpeg_4.%.bbappend
@@ -108,6 +108,7 @@ EXTRA_FFCONF = " \
 	--enable-encoder=jpeg2000 \
 	--enable-encoder=jpegls \
 	--enable-encoder=ljpeg \
+	--enable-encoder=libx264 \
 	--enable-encoder=mjpeg \
 	--enable-encoder=mpeg1video \
 	--enable-encoder=mpeg2video \


### PR DESCRIPTION
Required to convert avi to ts(duo4k not support avi codec)