### PR TITLE
Enable libxml2 for ffmpeg

### DIFF
--- a/meta-openpli/recipes-multimedia/ffmpeg/ffmpeg_4.%.bbappend
+++ b/meta-openpli/recipes-multimedia/ffmpeg/ffmpeg_4.%.bbappend
@@ -298,6 +298,7 @@ EXTRA_FFCONF = " \
 	\
 	--enable-zlib \
 	--enable-bzlib \
+	--enable-libxml2 \
 	--enable-openssl \
 	--enable-libass \
 	--enable-bsfs \


### PR DESCRIPTION
Enable support for libxml2. It is needed for mpd dash demuxer to work.