### PR TITLE
Fix libvpx fetch

### DIFF
--- a/meta-openpli/recipes-multimedia/webm/libvpx_1.10.0.bb
+++ b/meta-openpli/recipes-multimedia/webm/libvpx_1.10.0.bb
@@ -8,7 +8,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d5b04755015be901744a78cc30d390d4"
 
 SRCREV = "d55cab425d57b7e73894ac62e28ac505b6b4d6f1"
-SRC_URI += "git://chromium.googlesource.com/webm/libvpx;protocol=https \
+SRC_URI = "git://chromium.googlesource.com/webm/libvpx;protocol=https;branch=main \
             file://libvpx-configure-support-blank-prefix.patch \
            "
 


### PR DESCRIPTION
libvpx branch master is changed to main and it calls out fetcher failure: Unable to find revision d55cab425d57b7e73894ac62e28ac505b6b4d6f1 in branch master even from upstream