### PR TITLE
Optimize SSD mount in udev

### DIFF
--- a/meta-openpli/recipes-core/udev/eudev_%.bbappend
+++ b/meta-openpli/recipes-core/udev/eudev_%.bbappend
@@ -2,7 +2,12 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI += " \
 	file://init \
+	file://60-ssd-scheduler.rules \
 	"
+
+do_install_append() {
+	install -m 0644 ${WORKDIR}/60-ssd-scheduler.rules ${D}${sysconfdir}/udev/rules.d/60-ssd-scheduler.rules
+}
 
 DEPENDS += " udev-extraconf"
 RDEPENDS_${PN} += " udev-extraconf"

--- a/meta-openpli/recipes-core/udev/files/60-ssd-scheduler.rules
+++ b/meta-openpli/recipes-core/udev/files/60-ssd-scheduler.rules
@@ -1,0 +1,2 @@
+# set deadline scheduler for non-rotating disks
+ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/rotational}=="0", ATTR{queue/scheduler}="deadline"

--- a/meta-openpli/recipes-core/udev/files/mount.sh
+++ b/meta-openpli/recipes-core/udev/files/mount.sh
@@ -244,6 +244,11 @@ automount() {
 		;;
 	esac
 
+	# Use the noatime mount option for SSD
+	if [ $(grep . /sys/block/$NAME/queue/rotational) == 0 ]; then
+		MOUNT="$MOUNT -o noatime"
+	fi
+
 	# remove the concurrency lock
 	unlock
 

--- a/meta-openpli/recipes-core/udev/files/mount.sh
+++ b/meta-openpli/recipes-core/udev/files/mount.sh
@@ -245,7 +245,7 @@ automount() {
 	esac
 
 	# Use the noatime mount option for SSD
-	if [ $(grep . /sys/block/$NAME/queue/rotational) == 0 ]; then
+	if [ `cat /sys/block/$DEVBASE/queue/rotational` == 0 ]; then
 		MOUNT="$MOUNT -o noatime"
 	fi
 


### PR DESCRIPTION
Set deadline scheduler for non-rotating disks.
Use the noatime mount option for SSD.