### PR TITLE
Remove YouTube.key file from plugin youtube package

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-youtube.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-youtube.bb
@@ -22,10 +22,3 @@ RDEPENDS_${PN} = " \
 	${PYTHON_PN}-pyopenssl \
 	${PYTHON_PN}-twisted-web \
 	"
-
-CONFFILES = "/etc/enigma2/YouTube.key"
-
-do_install_append() {
-	install -d ${D}/etc/enigma2
-	install -m 0644 ${S}/YouTube.key ${D}/etc/enigma2/YouTube.key
-}


### PR DESCRIPTION
Youtube does not allow the use of keys without verification for private data. This file only creates confusion for users who try to use their keys that don't work. Therefore, remove YouTube.key to use the plugin's verified keys.