### PR TITLE
enigma2-plugins: Build python3-icalendar.

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugins.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugins.bb
@@ -74,6 +74,7 @@ S = "${WORKDIR}/git"
 DEPENDS = " \
 	${PYTHON_PN}-pyopenssl \
 	streamripper \
+	${PYTHON_PN}-icalendar \
 	${PYTHON_PN}-dateutil \
 	${PYTHON_PN}-mutagen \
 	${PYTHON_PN}-pyusb \


### PR DESCRIPTION
Needed for LCD4linux.