### PR TITLE
python3-icalendar: Update to version 5.0.7

### DIFF
--- a/meta-openpli/recipes-devtools/python/python3-icalendar_5.0.7.bb
+++ b/meta-openpli/recipes-devtools/python/python3-icalendar_5.0.7.bb
@@ -1,15 +1,16 @@
 SUMMARY = "The icalendar package is a parser/generator of iCalendar files for use with Python."
 HOMEPAGE = "http://icalendar.readthedocs.org"
 SECTION = "devel/python"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE.rst;md5=1b2957cd26c589d0defcb357be630e80"
 
 DEPENDS = "${PYTHON_PN}-pytz ${PYTHON_PN}-dateutil"
-RDEPENDS_${PN} = "${PYTHON_PN}-pytz ${PYTHON_PN}-dateutil"
+RDEPENDS:${PN} = "${PYTHON_PN}-pytz ${PYTHON_PN}-dateutil"
 
-SRC_URI = "https://files.pythonhosted.org/packages/e4/dd/67c363b99c4384c66bcf94c1abf9b749dd4e809a44bd6db575ec8e22be89/icalendar-4.0.6.tar.gz"
-SRC_URI[md5sum] = "d0a6ce988bb9efc34fe765cd9bfe3a8a"
-SRC_URI[sha256sum] = "7e6fe7232622abe32d8f54d0936ffcd5a9087198a4c2f1ec1803a7dd9fdd979f"
+SRC_URI = "https://files.pythonhosted.org/packages/7b/cb/ab742b444f6a25a349f061f1d661060060191e065f0aa815ba1bf989bf5c/icalendar-${PV}.tar.gz"
+
+SRC_URI[md5sum] = "338c8791e989554273705e3004843b0d"
+SRC_URI[sha256sum] = "e306014a64dc4dcf638da0acb2487ee4ada57b871b03a62ed7b513dfc135655c"
 
 S = "${WORKDIR}/icalendar-${PV}"
 


### PR DESCRIPTION
-Use new override syntax.
-Use new BSD-3-Clause license.