### PR TITLE
feed: Restore shairplay

### DIFF
--- a/meta-openpli/recipes-openpli/images/openpli-enigma2-feed.bb
+++ b/meta-openpli/recipes-openpli/images/openpli-enigma2-feed.bb
@@ -143,6 +143,7 @@ OPTIONAL_PACKAGES += " \
 	satpi \
 	screen \
 	sed \
+	shairplay \
 	sshpass \
 	sshfs-fuse \
 	smartmontools \

--- a/meta-openpli/recipes-support/shairport/shairplay/remove-dns-sd-h-header-file-check.patch
+++ b/meta-openpli/recipes-support/shairport/shairplay/remove-dns-sd-h-header-file-check.patch
@@ -1,0 +1,19 @@
+diff --git a/configure.ac b/configure.ac
+index 5a4b8ad..ea00d92 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -17,14 +17,6 @@ AC_PROG_LIBTOOL
+ LT_LIB_M
+ LT_LIB_DLLOAD
+ 
+-# Checks for header files.
+-AC_HEADER_STDC
+-if test yes = "$libltdl_cv_func_dlopen" || test yes = "$libltdl_cv_lib_dl_dlopen"
+-then
+-  AC_CHECK_HEADERS([dns_sd.h], [],
+-                   [AC_MSG_ERROR([Could not find dns_sd.h header, please install libavahi-compat-libdnssd-dev or equivalent.])])
+-fi
+-
+ # Checks for typedefs, structures, and compiler characteristics.
+ 
+ # Checks for library functions.

--- a/meta-openpli/recipes-support/shairport/shairplay_git.bb
+++ b/meta-openpli/recipes-support/shairport/shairplay_git.bb
@@ -7,7 +7,9 @@ PR = "r1"
 
 inherit autotools pkgconfig
 
-SRC_URI = "git://github.com/juhovh/shairplay.git"
+SRC_URI = "git://github.com/juhovh/shairplay.git \
+           file://remove-dns-sd-h-header-file-check.patch \
+"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Apply patch to remove dns_sh.h header file check as I giving up to add libavahi-compat-libdnssd as dependency and it compiles fine without that file.

Partly revert of commit:
https://github.com/juhovh/shairplay/commit/bd065bd0188c1765f06bf00defd30cc3606ce861