### PR TITLE
hrtunerproxy: Revert back to distutils to fix build

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-systemplugins-hrtunerproxy.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-systemplugins-hrtunerproxy.bb
@@ -9,7 +9,9 @@ inherit gitpkgv distutils-openplugins gettext python3-compileall
 PV = "git${SRCPV}"
 PKGV = "${GITPKGVTAG}"
 
-SRC_URI = "git://github.com/OpenViX/HRTunerProxy.git;protocol=https"
+SRC_URI = "git://github.com/OpenViX/HRTunerProxy.git;protocol=https \
+           file://revert-back-to-distutils.patch \
+           "
 
 S = "${WORKDIR}/git"
 

--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-systemplugins-hrtunerproxy/revert-back-to-distutils.patch
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-systemplugins-hrtunerproxy/revert-back-to-distutils.patch
@@ -1,0 +1,29 @@
+diff --git a/setup.py b/setup.py
+index f0fa819..2f64c81 100644
+--- a/setup.py
++++ b/setup.py
+@@ -1,4 +1,4 @@
+-from setuptools import setup
++from distutils.core import setup
+ import setup_translate
+ 
+ pkg = 'SystemPlugins.HRTunerProxy'
+diff --git a/setup_translate.py b/setup_translate.py
+index 842002e..aca91d0 100644
+--- a/setup_translate.py
++++ b/setup_translate.py
+@@ -1,11 +1,11 @@
+ # Language extension for Python scripts. Based on this concept:
+ # http://wiki.maemo.org/Internationalize_a_Python_application
+-from setuptools import Command as cmd
+-from setuptools.command.build import build as _build
++from distutils import cmd
++from distutils.command.build import build as _build
+ import os
+ 
+ 
+-class build_trans(cmd):
++class build_trans(cmd.Command):
+ 	description = 'Compile .po files into .mo files'
+ 
+ 	def initialize_options(self):


### PR DESCRIPTION
Not compatible with Python 3.9/Hardknott.

Revert commits:
https://github.com/OpenViX/HRTunerProxy/commit/dc96717d8ea2236eced993b2fd55b3ec09bb0d8c https://github.com/OpenViX/HRTunerProxy/commit/30d0f9b66c186278d32a52a01a3cb6d63807042c