### PR TITLE
sabnzbd: Add pythn3-sabctools to RDEPENDS

### DIFF
--- a/meta-openpli/recipes-connectivity/sabnzbd/sabnzbd_4.0.3.bb
+++ b/meta-openpli/recipes-connectivity/sabnzbd/sabnzbd_4.0.3.bb
@@ -11,6 +11,7 @@ RDEPENDS_${PN} = "\
     ${PYTHON_PN}-misc ${PYTHON_PN}-multiprocessing ${PYTHON_PN}-sqlite3 ${PYTHON_PN}-shell ${PYTHON_PN}-sabyenc3 ${PYTHON_PN}-configobj \
     ${PYTHON_PN}-cryptography ${PYTHON_PN}-feedparser ${PYTHON_PN}-cheroot ${PYTHON_PN}-cherrypy ${PYTHON_PN}-portend ${PYTHON_PN}-chardet \
     ${PYTHON_PN}-notify2 ${PYTHON_PN}-puremagic ${PYTHON_PN}-guessit ${PYTHON_PN}-sgmllib3k ${PYTHON_PN}-more-itertools ${PYTHON_PN}-modules \
+    ${PYTHON_PN}-sabctools \
     "
 
 RRECOMMENDS_${PN} = "par2cmdline unrar"

--- a/meta-openpli/recipes-devtools/python/python3-sabctools/remove-x64-instructions.patch
+++ b/meta-openpli/recipes-devtools/python/python3-sabctools/remove-x64-instructions.patch
@@ -1,0 +1,73 @@
+diff --git a/setup.py b/setup.py
+index 68ea2a9..52c2009 100644
+--- a/setup.py
++++ b/setup.py
+@@ -185,68 +185,56 @@ class SABCToolsBuild(build_ext):
+             {
+                 "sources": ["src/yencode/encoder_sse2.cc"],
+                 "depends": srcdeps_enc_common + ["encoder_sse_base.h"],
+-                "gcc_x86_flags": ["-msse2"],
+             },
+             {
+                 "sources": ["src/yencode/decoder_sse2.cc"],
+                 "depends": srcdeps_dec_common + ["decoder_sse_base.h"],
+-                "gcc_x86_flags": ["-msse2"],
+             },
+             {
+                 "sources": ["src/yencode/encoder_ssse3.cc"],
+                 "depends": srcdeps_enc_common + ["encoder_sse_base.h"],
+-                "gcc_x86_flags": ["-mssse3"],
+             },
+             {
+                 "sources": ["src/yencode/decoder_ssse3.cc"],
+                 "depends": srcdeps_dec_common + ["decoder_sse_base.h"],
+-                "gcc_x86_flags": ["-mssse3"],
+             },
+             {
+                 "sources": ["src/yencode/crc_folding.cc"],
+                 "depends": srcdeps_crc_common,
+-                "gcc_x86_flags": ["-mssse3", "-msse4.1", "-mpclmul"],
+             },
+             {
+                 "sources": ["src/yencode/crc_folding_256.cc"],
+                 "depends": srcdeps_crc_common,
+-                "gcc_x86_flags": gcc_vpclmulqdq_flags,
+                 "msvc_x86_flags": ["/arch:AVX2"],
+             },
+             {
+                 "sources": ["src/yencode/encoder_avx.cc"],
+                 "depends": srcdeps_enc_common + ["encoder_sse_base.h"],
+-                "gcc_x86_flags": ["-mavx", "-mpopcnt"],
+                 "msvc_x86_flags": ["/arch:AVX"],
+             },
+             {
+                 "sources": ["src/yencode/decoder_avx.cc"],
+                 "depends": srcdeps_dec_common + ["decoder_sse_base.h"],
+-                "gcc_x86_flags": ["-mavx", "-mpopcnt"],
+                 "msvc_x86_flags": ["/arch:AVX"],
+             },
+             {
+                 "sources": ["src/yencode/encoder_avx2.cc"],
+                 "depends": srcdeps_enc_common + ["encoder_avx_base.h"],
+-                "gcc_x86_flags": ["-mavx2", "-mpopcnt", "-mbmi", "-mbmi2", "-mlzcnt"],
+                 "msvc_x86_flags": ["/arch:AVX2"],
+             },
+             {
+                 "sources": ["src/yencode/decoder_avx2.cc"],
+                 "depends": srcdeps_dec_common + ["decoder_avx2_base.h"],
+-                "gcc_x86_flags": ["-mavx2", "-mpopcnt", "-mbmi", "-mbmi2", "-mlzcnt"],
+                 "msvc_x86_flags": ["/arch:AVX2"],
+             },
+             {
+                 "sources": ["src/yencode/encoder_vbmi2.cc"],
+                 "depends": srcdeps_enc_common + ["encoder_avx_base.h"],
+-                "gcc_x86_flags": gcc_vbmi2_flags,
+                 "msvc_x86_flags": ["/arch:AVX512"],
+             },
+             {
+                 "sources": ["src/yencode/decoder_vbmi2.cc"],
+                 "depends": srcdeps_dec_common + ["decoder_avx2_base.h"],
+-                "gcc_x86_flags": gcc_vbmi2_flags,
+                 "msvc_x86_flags": ["/arch:AVX512"],
+             },
+             {

--- a/meta-openpli/recipes-devtools/python/python3-sabctools_8.0.0.bb
+++ b/meta-openpli/recipes-devtools/python/python3-sabctools_8.0.0.bb
@@ -1,0 +1,13 @@
+SUMMARY = "C implementations of functions for use within SABnzbd"
+SECTION = "devel/python"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://LICENSE.md;md5=892f569a555ba9c07a568a7c0c4fa63a"
+
+SRC_URI[md5sum] = "6277dd0d4f6319d22ca34b63fd8a880e"
+SRC_URI[sha256sum] = "86b4691158669e6e00052a8dfc5dcc9650a0a090a0d4f74cfa856b411fae65b9"
+
+SRC_URI:append = " file://remove-x64-instructions.patch"
+
+inherit pypi setuptools3
+
+include python3-package-split.inc


### PR DESCRIPTION
Add recipe python3-sabctools with patch to suppress compile error:

 arm-oe-linux-gnueabi-gcc: error: unrecognized command-line option '-mvpclmulqdq'
 arm-oe-linux-gnueabi-gcc: error: unrecognized command-line option '-mavx512vbmi2'
 arm-oe-linux-gnueabi-gcc: error: unrecognized command-line option '-msse2'
 etc.