### PR TITLE
sabctools: Downgrade to 7.1.2

### DIFF
--- a/meta-openpli/recipes-devtools/python/python3-sabctools_7.1.2.bb
+++ b/meta-openpli/recipes-devtools/python/python3-sabctools_7.1.2.bb
@@ -3,8 +3,8 @@ SECTION = "devel/python"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=892f569a555ba9c07a568a7c0c4fa63a"
 
-SRC_URI[md5sum] = "6277dd0d4f6319d22ca34b63fd8a880e"
-SRC_URI[sha256sum] = "86b4691158669e6e00052a8dfc5dcc9650a0a090a0d4f74cfa856b411fae65b9"
+SRC_URI[md5sum] = "35d6bd261734f53b6658ae3a1d22a93f"
+SRC_URI[sha256sum] = "c038055eec5c966a8c9515f2afdaa9aee24970e5df3a23964d95d7e77b98101f"
 
 SRC_URI:append = " file://remove-x64-instructions.patch"
 


### PR DESCRIPTION
Sabnzbd 4.1.0 and older doesn't work with  sabctools 8.0.0. Awaiting stable 4.2.0 release Sabnzbd which can.