### PR TITLE
enigma2-plugins: Build pydpflib

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugins.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugins.bb
@@ -85,6 +85,7 @@ DEPENDS = " \
 	${PYTHON_PN}-twisted \
 	${PYTHON_PN}-daap \
 	libcddb \
+	pydpflib \
 	dvdbackup \
 	libtirpc \
 	png-util \


### PR DESCRIPTION
Needed for lcd4linux.