### PR TITLE
pydpflibL Switch to dpf-ax repo @atvcaptain

### DIFF
--- a/meta-openpli/recipes-extended/pydpflib/pydpflib.bb
+++ b/meta-openpli/recipes-extended/pydpflib/pydpflib.bb
@@ -1,28 +1,57 @@
-DESCRIPTION = "DPF access extension module"
-MAINTAINER = "https://sourceforge.net/projects/pydpf/"
-LICENSE = "LGPLv2"
-LIC_FILES_CHKSUM = "file://PKG-INFO;md5=6a256fd20875b5cf06888bbcbe1a21aa"
+ESCRIPTION = "Tools for managing memory technology devices."
+LICENSE = "GPLv2+"
+LIC_FILES_CHKSUM = "file://${S}/README;md5=42a667e310028ad2cc31da2ae54d8f16"
 
-SRC_URI = "git://github.com/athoik/pydpflib.git;protocol=https"
+DEPENDS = "libusb-compat libusb1 python3"
 
-DEPENDS = "libusb"
+SRC_URI="git://github.com/atvcaptain/dpf-ax.git;branch=dreamlayers;protocol=https \
+         file://set-python-version-to-39.patch \
+"
 
 S = "${WORKDIR}/git"
 
-inherit gitpkgv setuptools3
+inherit pkgconfig gitpkgv autotools-brokensep python3native
 
-PV = "0.14+git${SRCPV}"
-PKGV = "0.14+git${GITPKGV}"
-PR = "r0"
+SRCREV = "${AUTOREV}"
+PV = "4.0.+git${SRCPV}"
+PKGV = "4.0.+git${GITPKGV}"
 
-do_compile_prepend() {
-    $MAKE -C ${S}/dpf-ax/dpflib all
+INHIBIT_PACKAGE_STRIP = "1"
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+
+EXTRA_OEMAKE = "'CC=${CC}' 'CFLAGS=${CFLAGS} -I${S}include -I${S}src 'BUILDDIR=${S}'"
+
+EXTRA_OECONF = " \
+        BUILD_SYS=${BUILD_SYS} \
+        HOST_SYS=${HOST_SYS} \
+        STAGING_INCDIR=${STAGING_INCDIR} \
+        STAGING_LIBDIR=${STAGING_LIBDIR} \
+        DEVLIB=${S} \
+"
+
+do_configure:prepend() {
+    export BUILD_SYS=${BUILD_SYS}
+    export HOST_SYS=${HOST_SYS}
+    export STAGING_INCDIR=${STAGING_INCDIR}
+    export STAGING_LIBDIR=${STAGING_LIBDIR}
+    export DEVLIB=${S}
 }
 
-do_install:prepend() {
-	cp ${B}/lib.linux-x86_64-3.9/dpflib.cpython*.so ${B}/lib.linux-x86_64-3.9/dpflib.so
+do_compile:prepend() {
+    export BUILD_SYS=${BUILD_SYS}
+    export HOST_SYS=${HOST_SYS}
+    export STAGING_INCDIR=${STAGING_INCDIR}
+    export STAGING_LIBDIR=${STAGING_LIBDIR}
+    export DEVLIB=${S}
 }
 
-do_install:append() {
-	rm ${D}${PYTHON_SITEPACKAGES_DIR}/dpflib.cpython*.so
+do_compile() {
+    make -f ${S}/Makefile default
+}
+
+FILES:${PN} = "${libdir}"
+
+do_install() {
+    install -d ${D}${libdir}/enigma2/python/Plugins/Extensions/LCD4linux
+    install -m 644 ${S}/python/Debug/libdpf.so ${D}${libdir}//enigma2/python/Plugins/Extensions/LCD4linux/dpflib.so
 }

--- a/meta-openpli/recipes-extended/pydpflib/pydpflib/set-python-version-to-39.patch
+++ b/meta-openpli/recipes-extended/pydpflib/pydpflib/set-python-version-to-39.patch
@@ -1,0 +1,13 @@
+diff --git a/python/Makefile b/python/Makefile
+index 31adb6b..eb02794 100644
+--- a/python/Makefile
++++ b/python/Makefile
+@@ -37,7 +37,7 @@ endif
+ 
+ 
+ include $(DEVLIB)/unixdll.mk
+-DLLDEPS = $(CLIENTLIB) -lpython3.8
++DLLDEPS = $(CLIENTLIB) -lpython3.9
+ PYTHONINCLUDES = -I${PYTHON_INCLUDE_DIR}
+ 
+ 


### PR DESCRIPTION
Old repo requires more c-api changes (ob_size field, Py_FindMethod() etc). Well, just use new repo.

Thanks @kueken for pointing to and @atvcaptain.