### PR TITLE
wireguard: fix depends and fix wg-quick

### DIFF
--- a/meta-openpli/recipes-kernel/wireguard/files/wg-quick.patch
+++ b/meta-openpli/recipes-kernel/wireguard/files/wg-quick.patch
@@ -1,0 +1,13 @@
+diff --git a/src/wg-quick/linux.bash b/src/wg-quick/linux.bash
+index 4193ce5..0d85840 100755
+--- a/src/wg-quick/linux.bash
++++ b/src/wg-quick/linux.bash
+@@ -240,7 +240,7 @@ add_default() {
+ 	[[ $proto == -4 ]] && cmd sysctl -q net.ipv4.conf.all.src_valid_mark=1
+ 	if type -p nft >/dev/null; then
+ 		cmd nft -f <(echo -n "$nftcmd")
+-	else
++	elif type -p iptables >/dev/null; then
+ 		echo -n "$restore" | cmd $iptables-restore -n
+ 	fi
+ 	HAVE_SET_FIREWALL=1

--- a/meta-openpli/recipes-kernel/wireguard/wireguard-module_1.0.20210424.bb
+++ b/meta-openpli/recipes-kernel/wireguard/wireguard-module_1.0.20210424.bb
@@ -6,7 +6,7 @@ SRC_URI[sha256sum] = "8839139a53733bd20602e39cfc679a8176747dae8fe9f9c7fce28f8fba
 
 S = "${WORKDIR}/wireguard-linux-compat-${PV}/src"
 
-inherit module kernel-module-split
+inherit module
 
 DEPENDS = "bc-native virtual/kernel libmnl"
 
@@ -21,6 +21,7 @@ EXTRA_OEMAKE_append = " \
 MAKE_TARGETS = "module"
 
 RRECOMMENDS_${PN} = "kernel-module-xt-hashlimit"
+RPROVIDES_${PN} = "${@ 'kernel-module-wireguard' if ("${KERNEL_VERSION}" and bb.utils.vercmp_string("${KERNEL_VERSION}", '5.6') < 0) else '' }"
 MODULE_NAME = "wireguard"
 
 # Kernel module packages MUST begin with 'kernel-module-', otherwise

--- a/meta-openpli/recipes-kernel/wireguard/wireguard-tools_1.0.20210424.bb
+++ b/meta-openpli/recipes-kernel/wireguard/wireguard-tools_1.0.20210424.bb
@@ -1,6 +1,6 @@
 require wireguard.inc
 
-SRC_URI = "https://git.zx2c4.com/wireguard-tools/snapshot/wireguard-tools-${PV}.tar.xz"
+SRC_URI = "https://git.zx2c4.com/wireguard-tools/snapshot/wireguard-tools-${PV}.tar.xz file://wg-quick.patch;striplevel=2"
 SRC_URI[md5sum] = "53a0f06dbb298bbae7532fd10bcc3af1"
 SRC_URI[sha256sum] = "b288b0c43871d919629d7e77846ef0b47f8eeaa9ebc9cedeee8233fc6cc376ad"
 
@@ -8,14 +8,8 @@ S = "${WORKDIR}/wireguard-tools-${PV}/src"
 
 inherit bash-completion systemd pkgconfig
 
-# Get the kernel version for this image, we need it to build conditionally on kernel version
-export KERNEL_VERSION = "${@oe.utils.read_file('${PKGDATA_DIR}/kernel-depmod/kernel-abiversion')}"
-
-DEPENDS = "libmnl ${@ 'wireguard-module' if ("${KERNEL_VERSION}" and bb.utils.vercmp_string("${KERNEL_VERSION}", '5.6') < 0) else "" }"
-
-RDEPENDS_${PN} = "kernel-module-wireguard bash"
-
-PACKAGE_ARCH = "${MACHINE_ARCH}"
+DEPENDS = "libmnl"
+RDEPENDS_${PN} = "bash, iproute2-ip, kernel-module-wireguard, openresolv"
 
 do_install () {
     oe_runmake DESTDIR="${D}" PREFIX="${prefix}" SYSCONFDIR="${sysconfdir}" \


### PR DESCRIPTION
This commit fixes lot of report issues with wireguard.

Issue 1: /usr/bin/wg-quick: line 32: resolvconf: command not found Fixed by adding an RDEPEND to openresolv

Issue 2: AllowedIps = 0.0.0.0/0 fails with ip: invalid argument '51820' to 'table' Fixed by adding an RDEPEND to iproute2-ip

Issue 3: /usr/bin/wg-quick: line 32: ip6tables-restore: command not found Fixed by adding iptables existance check in wg-quick

Issue 4: - nothing provides wireguard-module needed by wireguard-tools Fixed by depending only on kernel-module-wireguard. Now wireguard-module RPROVIDES kernel-module-wireguard for kernels < 5.6