### PR TITLE
enigma2-plugins: Add python/Components dir to FILES

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugins.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugins.bb
@@ -58,6 +58,8 @@ FILES:enigma2-plugin-extensions-babelzapper += "${sysconfdir}/babelzapper"
 FILES:enigma2-plugin-extensions-netcaster += "${sysconfdir}/NETcaster.conf"
 CONFFILES:enigma2-plugin-extensions-netcaster += "${sysconfdir}/NETcaster.conf"
 
+FILES:enigma2-plugin-extensions-lcd4linux += "${libdir}/enigma2/python/Components/*"
+
 FILES:${PN}-meta = "${datadir}/meta"
 PACKAGES += "${PN}-meta ${PN}-build-dependencies"
 


### PR DESCRIPTION
To fix warning:

WARNING: enigma2-plugins-gitAUTOINC+988db20811-r0 do_package: QA Issue: enigma2-plugins: Files/directories were installed but not shipped in any package: /usr/lib/enigma2/python/Components/Renderer/PixmapLcd4linux.pyc