### PR TITLE
zerotier: Fix build

### DIFF
--- a/meta-openpli/recipes-connectivity/zerotier/zerotier.bb
+++ b/meta-openpli/recipes-connectivity/zerotier/zerotier.bb
@@ -23,7 +23,7 @@ TARGET_CFLAGS += "-fpic"
 RDEPENDS:${PN} = "kernel-module-tun"
 
 do_compile:prepend:mipsel() {
-    export LDLIBS+=-latomic
+    export LDLIBS=-latomic
 }
 
 do_install:append() {


### PR DESCRIPTION
No need for additional assigment.

Fix for:

openpli-oe-core/build/tmp/work/mips32el-oe-linux/zerotier/1.0-r0/temp/run.do_compile.49443: 151: export: LDLIBS+: bad variable name