### PR TITLE
ffmpeg: Refresh add-av_stream_get_first_dts-for-chromium patch

### DIFF
--- a/meta-openpli/recipes-multimedia/ffmpeg/ffmpeg/0013-add-av_stream_get_first_dts-for-chromium.patch
+++ b/meta-openpli/recipes-multimedia/ffmpeg/ffmpeg/0013-add-av_stream_get_first_dts-for-chromium.patch
@@ -5,13 +5,15 @@ Subject: [PATCH] Add av_stream_get_first_dts for Chromium
 
 [foutrelis: adjust for new FFStream struct replacing AVStreamInternal]
 
+Rebased against ffmpeg 5.0.1
+
 diff --git a/libavformat/avformat.h b/libavformat/avformat.h
-index 1916aa2..e668284 100644
+index 6ce367e..cba3f5e 100644
 --- a/libavformat/avformat.h
 +++ b/libavformat/avformat.h
-@@ -1019,6 +1019,10 @@ attribute_deprecated
+@@ -1115,6 +1115,10 @@ struct AVCodecParserContext *av_stream_get_parser(const AVStream *s);
+  */
  int64_t    av_stream_get_end_pts(const AVStream *st);
- #endif
  
 +// Chromium: We use the internal field first_dts vvv
 +int64_t    av_stream_get_first_dts(const AVStream *st);
@@ -21,10 +23,10 @@ index 1916aa2..e668284 100644
  
  /**
 diff --git a/libavformat/utils.c b/libavformat/utils.c
-index cf4d68b..d3e7488 100644
+index cee86ae..b8bafee 100644
 --- a/libavformat/utils.c
 +++ b/libavformat/utils.c
-@@ -99,6 +99,13 @@ static int append_packet_chunked(AVIOContext *s, AVPacket *pkt, int size)
+@@ -194,6 +194,13 @@ static int append_packet_chunked(AVIOContext *s, AVPacket *pkt, int size)
      return pkt->size > orig_size ? pkt->size - orig_size : ret;
  }
  


### PR DESCRIPTION
Fix:
Applying patch 0013-add-av_stream_get_first_dts-for-chromium.patch patching file libavformat/avformat.h
Hunk #1 succeeded at 1115 with fuzz 2 (offset 96 lines). patching file libavformat/utils.c
Hunk #1 succeeded at 194 (offset 95 lines).