### PR TITLE
Switch exteplayer3 repo to oe-mirrors

### DIFF
--- a/meta-openpli/recipes-multimedia/exteplayer3/exteplayer3_git.bb
+++ b/meta-openpli/recipes-multimedia/exteplayer3/exteplayer3_git.bb
@@ -9,10 +9,10 @@ RDEPENDS_${PN} = "ffmpeg libbluray"
 
 inherit gitpkgv
 
-PV = "68+gitr${SRCPV}"
-PKGV = "68+gitr${GITPKGV}"
+PV = "69+gitr${SRCPV}"
+PKGV = "69+gitr${GITPKGV}"
 
-SRC_URI = "git://github.com/technic/exteplayer3.git;protocol=https;branch=master"
+SRC_URI = "git://github.com/oe-mirrors/exteplayer3.git;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
It looks like technic is no longer actively supporting the exteplayer3 repo.

This fixes the playback of youtube links.
I made a pull request a few days ago to fix it, but there is no activity.
After that I saw that it was already fixed on oe-mirrors and thefore I thought that using their repo would be better.
I hope they don't break compatibility with ffmpeg 4 at some point, but there is always the possibility of pinning the exteplayer3 version.