### PR TITLE
oscam-whitelist: Inherit gitpkgv

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-softcams/enigma2-plugin-softcams-oscam-whitelist.bb
+++ b/meta-openpli/recipes-openpli/enigma2-softcams/enigma2-plugin-softcams-oscam-whitelist.bb
@@ -12,7 +12,7 @@ S = "${WORKDIR}/git"
 
 DEPENDS = "enigma2-plugin-softcams-oscam"
 
-inherit allarch
+inherit allarch gitpkgv
 
 do_install () {
 	install -d ${D}${sysconfdir}/enigma2/


### PR DESCRIPTION
Fix ${GITPKGV} in ipk file name.

Before:
enigma2-plugin-softcams-oscam-whitelist_2.0+git${GITPKGV}0+2afe8ba139-r0_all

After:
enigma2-plugin-softcams-oscam-whitelist_2.0+git8+2afe8ba0+2afe8ba139-r0_all