### PR TITLE
enigma-info: Drop obsolete gbtrio4kpro runtime fix

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2/enigma-info.bb
+++ b/meta-openpli/recipes-openpli/enigma2/enigma-info.bb
@@ -618,15 +618,6 @@ elif [ "$MACHINE" = "ustym4kpro" ]; then
 		updateinfo "machinebuild" "ustym4ktwin"
 	fi
 
-# runtime fixes for the Gigablue Trio 4K PRO
-elif [ "$MACHINE" = "gbtrio4k" ]; then
-	if [ ! -f $WIFI1 ] || ( [ -f $WIFI1 ] && [ $(head -n 1 $WIFI1) != "0608" ] ); then
-		updateinfo "displaymodel" "UHD TRIO 4K PRO"
-		updateinfo "model" "gbtrio4kpro"
-		updateinfo "machinebuild" "gbtrio4kpro"
-	fi
-fi
-
 # re-add the checksum
 MD5SUM=`md5sum $TMPFILE | cut -d ' ' -f 1`
 echo "checksum=$MD5SUM" >> $TMPFILE


### PR DESCRIPTION
https://github.com/OpenPLi-meta/meta-gigablue/commit/73c044096112008a50f5eccdc890318839f76171