### PR TITLE
Downgrade hiko Uclan Driver

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2/enigma2.bb
+++ b/meta-openpli/recipes-openpli/enigma2/enigma2.bb
@@ -142,6 +142,7 @@ EXTRA_OECONF = "\
 	${@get_crashaddr(d)} \
 	${@bb.utils.contains("MACHINE_FEATURES", "textlcd", "--with-textlcd" , "", d)} \
 	${@bb.utils.contains("MACHINE_FEATURES", "7segment", "--with-7segment" , "", d)} \
+	${@bb.utils.contains("MACHINE_FEATURES", "hifblayer", "--with-hifblayer" , "", d)} \
 	BUILD_SYS=${BUILD_SYS} \
 	HOST_SYS=${HOST_SYS} \
 	STAGING_INCDIR=${STAGING_INCDIR} \


### PR DESCRIPTION
SRCDATE = "20240306" -> SRCDATE = "20230804"
Tuner avl26x1
add hifblayer

For Information
The more recent version includes the same firmware from Avalink. It is packed into the dvb.ko and is also visibly marked there.
Obviously, however, another driver Dev has used wrong values here.
This is also visible in the dvb.ko.
These values are correct within the older driver from the date, so the old version should definitely work better.
Firmware Avalink ->Version: 1.8.28209

0x38 = 56        16APSK 9/10 is correct 
0x38 = 55        16APSK 9/10 is wrong