### PR TITLE
Downgrade Uclan Ustym4kpro hiko Driver

### DIFF
--- a/meta-uclan/recipes-drivers/uclan-dvb-modules-ustym4kpro.bb
+++ b/meta-uclan/recipes-drivers/uclan-dvb-modules-ustym4kpro.bb
@@ -1,7 +1,7 @@
 KV = "4.4.35"
-SRCDATE = "20240306"
+SRCDATE = "20230804"
 
 require uclan-dvb-modules-hisi.inc
 
-SRC_URI[md5sum] = "2cdf26f3dae95b460f3b14c84b8bea93"
-SRC_URI[sha256sum] = "19365d9e3d68ccbd1556fc63a607d454e8f0d83302ce1b6e18fda95cad01af1e"
+SRC_URI[md5sum] = "f0b68baa9fc0f7296efd99b58fff3cd7"
+SRC_URI[sha256sum] = "8a5b52280934dd307b9c097468128894a85470a08e5ecd1cf916c30262af0e82"


### PR DESCRIPTION
SRCDATE = "20240306" -> SRCDATE = "20230804"
Tuner avl26x1

For Information
The more recent version includes the same firmware from Avalink. It is packed into the dvb.ko and is also visibly marked there. Obviously, however, another driver Dev has used wrong values here. This is also visible in the dvb.ko.
These values are correct within the older driver from the date, so the old version should definitely work better. Firmware Avalink ->Version: 1.8.28209

0x38 = 56 16APSK 9/10 is correct
0x38 = 55 16APSK 9/10 is wrong