### PR TITLE
liquid-dsp - disable SIMD when NEON is not in TUNE_FEATURES

### DIFF
--- a/meta-openpli/recipes-multimedia/liquid-dsp/liquid-dsp.bb
+++ b/meta-openpli/recipes-multimedia/liquid-dsp/liquid-dsp.bb
@@ -16,6 +16,8 @@ SRC_URI = " \
 
 S = "${WORKDIR}/git"
 
+EXTRA_OECONF:append = "${@bb.utils.contains('TUNE_FEATURES', 'neon', '', ' --enable-simdoverride', d)}"
+
 inherit autotools-brokensep
 
 do_install() {


### PR DESCRIPTION
liquid-dsp assumes that NEON is available on all ARMv7 targets and enables BUILD_NEON even when the selected tune only uses VFP. This causes compilation to fail with "target specific option mismatch".

Pass --enable-simdoverride for targets without NEON in TUNE_FEATURES so that the portable implementation is used.