### PR TITLE
[octagon-blindscan] Fix blindscan plugin not installed

### DIFF
--- a/meta-octagon/conf/machine/include/octagon-hisi-3716mv430.inc
+++ b/meta-octagon/conf/machine/include/octagon-hisi-3716mv430.inc
@@ -11,7 +11,7 @@ MACHINE_ESSENTIAL_EXTRA_RDEPENDS = "\
     octagon-hihalt-${MACHINE} \
     octagon-reader-${MACHINE} \
     octagon-libreader-${SOC_FAMILY} \
-    ${@bb.utils.contains("MACHINE_FEATURES", "blindscan", "octagon-blindscan-${SOC_FAMILY}" , "", d)} \    
+    ${@bb.utils.contains("MACHINE_FEATURES", "blindscan-dvbs", "octagon-blindscan-${SOC_FAMILY}" , "", d)} \
     octagon-partitions-${MACHINE} \
     octagon-buildimage \
     gptfdisk \

--- a/meta-octagon/conf/machine/include/octagon-hisi-3798mv300.inc
+++ b/meta-octagon/conf/machine/include/octagon-hisi-3798mv300.inc
@@ -11,7 +11,7 @@ MACHINE_ESSENTIAL_EXTRA_RDEPENDS = "\
     octagon-hihalt-${MACHINE} \
     octagon-reader-${MACHINE} \
     octagon-libreader-${SOC_FAMILY} \
-    ${@bb.utils.contains("MACHINE_FEATURES", "blindscan", "octagon-blindscan-${SOC_FAMILY}" , "", d)} \    
+    ${@bb.utils.contains("MACHINE_FEATURES", "blindscan-dvbs", "octagon-blindscan-${SOC_FAMILY}" , "", d)} \
     octagon-partitions-${MACHINE} \
     octagon-buildimage \
     e2fsprogs-resize2fs \

--- a/meta-octagon/conf/machine/include/octagon-hisi.inc
+++ b/meta-octagon/conf/machine/include/octagon-hisi.inc
@@ -11,7 +11,7 @@ MACHINE_ESSENTIAL_EXTRA_RDEPENDS = "\
     octagon-hihalt-${MACHINE} \
     octagon-reader-${MACHINE} \
     octagon-libreader-${SOC_FAMILY} \
-    ${@bb.utils.contains("MACHINE_FEATURES", "blindscan", "octagon-blindscan-${SOC_FAMILY}" , "", d)} \    
+    ${@bb.utils.contains("MACHINE_FEATURES", "blindscan-dvbs", "octagon-blindscan-${SOC_FAMILY}" , "", d)} \
     octagon-partitions-${MACHINE} \
     octagon-buildimage \
     e2fsprogs-resize2fs \


### PR DESCRIPTION
See:
https://github.com/OpenPLi-meta/meta-octagon/commit/78c0c80a361f1217adfe42f9a47dfdeb3398f13e

https://forums.openpli.org/topic/102219-openpli-scarthgap-sf8008/page-7#entry1756929