### PR TITLE
[openpli] add GT IPTV Player Pro v1.0.0

### DIFF
--- a/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-gtiptvplayerpro.bb
+++ b/meta-openpli/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-gtiptvplayerpro.bb
@@ -1,0 +1,53 @@
+SUMMARY = "Standalone IPTV browser and player for Enigma2"
+DESCRIPTION = "GT IPTV Player Pro provides Xtream Codes, M3U and Stalker/MAC portal browsing and playback."
+HOMEPAGE = "https://github.com/VicTuS59/GT-IPTV-Player-Pro"
+MAINTAINER = "VicTuS59"
+LICENSE = "GPL-2.0-or-later"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+PRIORITY = "optional"
+
+inherit allarch python3-compileall
+
+SRC_URI = "git://github.com/VicTuS59/GT-IPTV-Player-Pro.git;protocol=https;branch=main"
+SRCREV = "8ce3454e293247263879f34b22df3144a8a0ecb3"
+
+PV = "1.0.0"
+PR = "r0"
+
+S = "${WORKDIR}/git"
+
+RDEPENDS:${PN} = "\
+    python3-core \
+    python3-crypt \
+    python3-datetime \
+    python3-difflib \
+    python3-html \
+    python3-io \
+    python3-json \
+    python3-netclient \
+    python3-stringold \
+    python3-threading \
+"
+
+PLUGINPATH = "${libdir}/enigma2/python/Plugins/Extensions/GTIPTVPlayerPro"
+
+FILES:${PN} = "${PLUGINPATH}"
+
+do_patch[noexec] = "1"
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+
+do_install() {
+    install -d ${D}${PLUGINPATH}
+    cp -r --no-preserve=ownership ${S}/GTIPTVPlayerPro/. ${D}${PLUGINPATH}/
+    chmod -R a+rX ${D}${PLUGINPATH}
+}
+
+pkg_postrm:${PN}() {
+#!/bin/sh
+plugin_dir="${PLUGINPATH}"
+if [ ! -L "$plugin_dir" ] && [ -d "$plugin_dir" ]; then
+    rm -rf "$plugin_dir"
+fi
+exit 0
+}

--- a/meta-openpli/recipes-openpli/images/openpli-enigma2-feed.bb
+++ b/meta-openpli/recipes-openpli/images/openpli-enigma2-feed.bb
@@ -203,6 +203,7 @@ OPTIONAL_ENIGMA2_PACKAGES = " \
 	enigma2-plugin-extensions-foreca-one \
 	enigma2-plugin-extensions-freechannels \
 	enigma2-plugin-extensions-fritzcall \
+	enigma2-plugin-extensions-gtiptvplayerpro \
 	enigma2-plugin-extensions-hdmitest \
 	enigma2-plugin-extensions-historyzapselector \
 	enigma2-plugin-extensions-infobarweather \


### PR DESCRIPTION
## Summary

* add a source-built BitBake recipe for GT IPTV Player Pro v1.0.0
* add `enigma2-plugin-extensions-gtiptvplayerpro` to the optional OpenPLi Enigma2 feed packages
* pin the recipe to the stable `v1.0.0` source commit for reproducible builds

## Plugin

GT IPTV Player Pro is a standalone, account-oriented IPTV browser and player for Enigma2. It supports user-supplied Xtream Codes/M3U accounts and Stalker/MAC portals, with dedicated Live TV, Movies and Series screens.

The repository does not bundle channel lists, provider accounts, credentials or copyrighted media. The plugin does not contain a self-update mechanism; feed/package-manager updates remain authoritative.

Source: https://github.com/VicTuS59/GT-IPTV-Player-Pro

Release: https://github.com/VicTuS59/GT-IPTV-Player-Pro/releases/tag/v1.0.0

License: GPL-2.0-or-later

## Packaging

* package architecture: `all`
* installs Python source under `Plugins/Extensions/GTIPTVPlayerPro`
* uses OpenPLi's `python3-compileall` class
* declares the required split Python runtime packages
* removes residual plugin runtime/bytecode files on uninstall without deleting user playlist data

## Validation

* `v1.0.0` resolves to commit `8ce3454e293247263879f34b22df3144a8a0ecb3`
* the source license checksum was verified
* source installation and Python bytecode compilation were reproduced from the tagged checkout
* Python 3.9 grammar compatibility and Python 3.13/3.14 removed-API compatibility were checked
* manual installation, operation and uninstall testing completed on OpenPLi Enigma2 receivers
