### PR TITLE
[meson] fix python install path

### DIFF
--- a/meta-openpli/recipes-devtools/meson/meson.inc
+++ b/meta-openpli/recipes-devtools/meson/meson.inc
@@ -11,6 +11,7 @@ SRC_URI = "https://github.com/mesonbuild/meson/releases/download/${PV}/meson-${P
            file://0001-gtkdoc-fix-issues-that-arise-when-cross-compiling.patch \
            file://0001-python-module-do-not-manipulate-the-environment-when.patch \
            file://disable-rpath-handling.patch \
+           file://0001-modules-python.py-do-not-substitute-python-s-install.patch \
            file://0001-Make-CPU-family-warnings-fatal.patch \
            file://0002-Support-building-allarch-recipes-again.patch \
            file://0001-is_debianlike-always-return-False.patch \

--- a/meta-openpli/recipes-devtools/meson/meson/0001-modules-python.py-do-not-substitute-python-s-install.patch
+++ b/meta-openpli/recipes-devtools/meson/meson/0001-modules-python.py-do-not-substitute-python-s-install.patch
@@ -1,0 +1,28 @@
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Thu, 18 Apr 2019 17:36:11 +0200
+Subject: [PATCH] modules/python.py: do not substitute python's install prefix
+ with meson's
+
+Ported to Meson 0.59.2.
+
+Upstream-Status: Pending
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+Signed-off-by: ims <ims21@users.sourceforge.net>
+---
+ mesonbuild/modules/python.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/mesonbuild/modules/python.py
++++ b/mesonbuild/modules/python.py
+@@ -251 +251 @@
+-install_paths = sysconfig.get_paths(scheme='posix_prefix', vars={'base': '', 'platbase': '', 'installed_base': ''})
++install_paths = sysconfig.get_paths(scheme='posix_prefix')
+@@ -332,7 +332,7 @@
+     def _get_path(self, key: str) -> None:
+         user_dir = str(Path.home())
+         sys_paths = self.info['sys_paths']
+-        rel_path = self.info['install_paths'][key][1:]
++        rel_path = self.info['install_paths'][key]
+         if not any(p.endswith(rel_path) for p in sys_paths if not p.startswith(user_dir)):
+             # On Debian derivatives sysconfig install path is broken and is not
+             # included in the locations python actually lookup.

--- a/meta-openpli/recipes-devtools/python/python3-pycairo_%.bbappend
+++ b/meta-openpli/recipes-devtools/python/python3-pycairo_%.bbappend
@@ -1,8 +1,1 @@
 include ${PYTHON_PN}-package-split.inc
-
-# hack, workaround for an odd meson install issue, installing
-# the package into ./image/usr/usr instead of ./image/usr
-do_install_append() {
-    cp -r ${WORKDIR}/image/usr/usr/* ${WORKDIR}/image/usr
-    rm -rf ${WORKDIR}/image/usr/usr
-}


### PR DESCRIPTION
Fix wrong Meson 0.59.2 Python install path which creates /usr/usr.

The original OE-core patch does not apply cleanly to Meson 0.59.2, so it was ported.

Tested with python3-pycairo:
- /usr/usr is no longer created
- files are installed to /usr/lib/python3.9/site-packages
- do_package succeeds
- python3-pycairo package is created

Removes the temporary pycairo do_install_append() workaround.